### PR TITLE
Support '?*' in a quantified expression as a context reference

### DIFF
--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/parsers/xpath31/XPathExpressionParser.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/parsers/xpath31/XPathExpressionParser.kt
@@ -214,7 +214,7 @@ class XPathExpressionParser(val stepConfig: XProcStepConfiguration) {
             }
 
             val xmlResult = XdmDestination()
-            transformer!!.applyTemplates(builder.result, xmlResult)
+            transformer.applyTemplates(builder.result, xmlResult)
             return xmlResult.xdmNode.toString()
         }
 
@@ -277,7 +277,7 @@ class XPathExpressionParser(val stepConfig: XProcStepConfiguration) {
     private class Nonterminal(val name: String, parent: Tree): Tree() {
         override val squash: Boolean
             get() {
-                return (name != "VarRef" && name != "ArgumentList" && name != "ParamList"
+                return (name != "VarRef" && name != "ArgumentList" && name != "ParamList" && name != "UnaryLookup"
                         && children.size == 1 && children.first() is Nonterminal)
                         || name == "QName" || name == "EQName"
             }

--- a/xmlcalabash/src/main/resources/com/xmlcalabash/xpath.xsl
+++ b/xmlcalabash/src/main/resources/com/xmlcalabash/xpath.xsl
@@ -11,6 +11,9 @@
 
 <xsl:template match="/">
   <xsl:variable name="context" as="xs:boolean*">
+    <xsl:if test="nt:XPath/nt:QuantifiedExpr/nt:UnaryLookup">
+      <xsl:sequence select="true()"/>
+    </xsl:if>
     <xsl:apply-templates select="//nt:AxisStep"/>
     <xsl:apply-templates select="//nt:ContextItemExpr"/>
   </xsl:variable>


### PR DESCRIPTION
Fix #9 

It fixes this problem in this context, but it's very ad hoc. Something more systematic is needed here.