### PR TITLE
Fixed issues related to the runtime cache

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,6 +26,7 @@ val antennahouseRelease by configurations.dependencyScope("antennahouseRelease")
 val fopRelease by configurations.dependencyScope("fopRelease")
 val uniqueidRelease by configurations.dependencyScope("uniqueidRelease")
 val metadataextractorRelease by configurations.dependencyScope("metadataextractorRelease")
+val cacheRelease by configurations.dependencyScope("cacheRelease")
 
 dependencies {
   xmlcalabashRelease(project(mapOf("path" to ":xmlcalabash",
@@ -46,6 +47,8 @@ dependencies {
                                 "configuration" to "releaseArtifacts")))
   metadataextractorRelease(project(mapOf("path" to ":ext:metadata-extractor",
                                          "configuration" to "releaseArtifacts")))
+  cacheRelease(project(mapOf("path" to ":ext:cache",
+                             "configuration" to "releaseArtifacts")))
 
   implementation(project(":xmlcalabash"))
   implementation(project(":ixml-coffeepress"))
@@ -56,6 +59,7 @@ dependencies {
   implementation(project(":paged-media:fop"))
   implementation(project(":ext:unique-id"))
   implementation(project(":ext:metadata-extractor"))
+  implementation(project(":ext:cache"))
 }
 
 val xmlcalabashJar = configurations.resolvable("xmlcalabashJar") {
@@ -84,6 +88,9 @@ val uniqueidJar = configurations.resolvable("uniqueidJar") {
 }
 val metadataextractorJar = configurations.resolvable("metadataextractorJar") {
   extendsFrom(metadataextractorRelease)
+}
+val cacheJar = configurations.resolvable("cacheJar") {
+  extendsFrom(cacheRelease)
 }
 
 application {
@@ -149,6 +156,7 @@ tasks.register("stage-release") {
   inputs.files(fopJar)
   inputs.files(uniqueidJar)
   inputs.files(metadataextractorJar)
+  inputs.files(cacheJar)
   dependsOn("jar")
 
   doLast {

--- a/documentation/src/reference/extension-steps/cx-cache-add.xml
+++ b/documentation/src/reference/extension-steps/cx-cache-add.xml
@@ -1,0 +1,65 @@
+<refentry xmlns:p="http://www.w3.org/ns/xproc"
+          xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
+          xmlns:xi="http://www.w3.org/2001/XInclude"
+          xmlns:xlink="http://www.w3.org/1999/xlink"
+          xmlns="http://docbook.org/ns/docbook"
+          xml:id="cx-cache-add">
+<?db filename="cx-cache-add"?>
+   <refnamediv>
+      <refname>cx:cache-add</refname>
+      <refpurpose>A step for adding documents to the runtime cache</refpurpose>
+   </refnamediv>
+   <refsynopsisdiv>
+     <xi:include href="../../../../ext/cache/src/main/resources/com/xmlcalabash/ext/cache.xpl"
+                 xpointer="xpath(/*/*[@type='cx:cache-add'])"/>
+   </refsynopsisdiv>
+   <refsection>
+      <title>Description</title>
+
+<para>XML Calabash maintains a cache of documents. If a step attempts to load a
+URI, and that URI is present in the cache, the cached value will always be
+returned. Some steps use the cache implicitly (for example, the validate steps
+update it to hold schema documents).</para>
+
+<para>A pipeline can add a document to the cache explicitly with <tag>cx:cache-add</tag>.
+If the <option>href</option> option is provided, it is used as the URI for
+caching, otherwise the <port>source</port> document URI is used.
+<error code="I0030">It is a
+<glossterm>dynamic error</glossterm> if the <port>source</port> document does not have
+a base URI and the <option>href</option> option is not provided.</error>
+</para>
+
+<para>Irrespective of the cache URI, the step simply copies it’s <port>source</port>
+document to the <port>result</port> port. (It does not change the document’s base URI,
+even if an <option>href</option> option is provided to the <tag>cx:cache-add</tag> step.</para>
+
+<para><error code="I0037">It is a <glossterm>dynamic error</glossterm> if the
+<option>fail-if-in-cache</option> option is <literal>true</literal> and the
+cache already contains a document with the URI being cached.</error></para>
+
+<refsection>
+<title>Options</title>
+
+<para>There are two  options.</para>
+
+<variablelist>
+<varlistentry><term><option>href</option></term>
+<listitem>
+<para>The URI to cache. Defaults to the <port>source</port> document URI.</para>
+</listitem>
+</varlistentry>
+<varlistentry><term><option>fail-if-in-cache</option></term>
+<listitem>
+<para>Determines whether the URI must not already exist in the cache.</para>
+</listitem>
+</varlistentry>
+</variablelist>
+</refsection>
+
+<refsection>
+<title>Document properties</title>
+
+<para>No properties are changed.</para>
+</refsection>
+</refsection>
+</refentry>

--- a/documentation/src/reference/extension-steps/cx-cache-delete.xml
+++ b/documentation/src/reference/extension-steps/cx-cache-delete.xml
@@ -1,0 +1,65 @@
+<refentry xmlns:p="http://www.w3.org/ns/xproc"
+          xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
+          xmlns:xi="http://www.w3.org/2001/XInclude"
+          xmlns:xlink="http://www.w3.org/1999/xlink"
+          xmlns="http://docbook.org/ns/docbook"
+          xml:id="cx-cache-delete">
+<?db filename="cx-cache-delete"?>
+   <refnamediv>
+      <refname>cx:cache-delete</refname>
+      <refpurpose>A step for deleting documents from the runtime cache</refpurpose>
+   </refnamediv>
+   <refsynopsisdiv>
+     <xi:include href="../../../../ext/cache/src/main/resources/com/xmlcalabash/ext/cache.xpl"
+                 xpointer="xpath(/*/*[@type='cx:cache-delete'])"/>
+   </refsynopsisdiv>
+   <refsection>
+      <title>Description</title>
+
+<para>XML Calabash maintains a cache of documents. If a step attempts to load a
+URI, and that URI is present in the cache, the cached value will always be
+returned. Some steps use the cache implicitly (for example, the validate steps
+update it to hold schema documents).</para>
+
+<para>A pipeline can remove a document from the cache explicitly with <tag>cx:cache-delete</tag>.
+If the <option>href</option> option is provided, it is used as the URI for
+caching, otherwise the <port>source</port> document URI is used.
+<error code="I0030">It is a
+<glossterm>dynamic error</glossterm> if the <port>source</port> document does not have
+a base URI and the <option>href</option> option is not provided.</error>
+</para>
+
+<para>Irrespective of the cache URI, the step simply copies it’s <port>source</port>
+document to the <port>result</port> port. (It does not change the document’s base URI,
+even if an <option>href</option> option is provided to the <tag>cx:cache-add</tag> step.</para>
+
+<para><error code="I0038">It is a <glossterm>dynamic error</glossterm> if the
+<option>fail-if-not-in-cache</option> option is <literal>true</literal> and the
+cache does not contains a document with the URI being cached.</error></para>
+
+<refsection>
+<title>Options</title>
+
+<para>There are two  options.</para>
+
+<variablelist>
+<varlistentry><term><option>href</option></term>
+<listitem>
+<para>The URI to cache. Defaults to the <port>source</port> document URI.</para>
+</listitem>
+</varlistentry>
+<varlistentry><term><option>fail-if-not-in-cache</option></term>
+<listitem>
+<para>Determines whether the URI must already exist in the cache.</para>
+</listitem>
+</varlistentry>
+</variablelist>
+</refsection>
+
+<refsection>
+<title>Document properties</title>
+
+<para>No properties are changed.</para>
+</refsection>
+</refsection>
+</refentry>

--- a/documentation/src/reference/extension-steps/reference.xml
+++ b/documentation/src/reference/extension-steps/reference.xml
@@ -6,6 +6,8 @@
   <title>Extension steps</title>
 </info>
 
+<xi:include href="cx-cache-add.xml"/>
+<xi:include href="cx-cache-delete.xml"/>
 <xi:include href="cx-metadata-extractor.xml"/>
 <xi:include href="cx-unique-id.xml"/>
 

--- a/documentation/src/xsl/common.xsl
+++ b/documentation/src/xsl/common.xsl
@@ -58,6 +58,32 @@
   </span>
 </xsl:template>
 
+<xsl:template match="db:error">
+  <span class="pipeline-error">
+    <xsl:apply-templates/>
+  </span>
+</xsl:template>
+
+<xsl:template match="db:error/db:glossterm">
+  <span class="glossterm">
+    <xsl:next-match/>
+    <xsl:text> (</xsl:text>
+    <code>
+      <xsl:choose>
+        <xsl:when test="starts-with(../@code, 'I')">
+          <xsl:text>cxerr:X</xsl:text>
+          <xsl:value-of select="../@code"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:text>err:X</xsl:text>
+          <xsl:value-of select="../@code"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </code>
+    <xsl:text>)</xsl:text>
+  </span>
+</xsl:template>
+
 <xsl:template match="processing-instruction('version')">
   <xsl:variable name="ver"
                 select="if (normalize-space(.) = '')

--- a/documentation/src/xsl/ref-custom.xsl
+++ b/documentation/src/xsl/ref-custom.xsl
@@ -72,12 +72,6 @@
   </header>
 </xsl:template>
 
-<xsl:template match="db:error">
-  <span class="error">
-    <xsl:apply-templates/>
-  </span>
-</xsl:template>
-
 <xsl:template match="db:impl">
   <span class="impl">
     <xsl:apply-templates/>

--- a/ext/cache/README.org
+++ b/ext/cache/README.org
@@ -1,0 +1,23 @@
+:PROPERTIES:
+:ID:       F538A400-37DE-402C-B482-91B8A9AD7994
+:END:
+#+title: Caching steps
+#+date: 2024-05-23
+#+author: Norman Tovey-Walsh
+
+The ~cx:cache-add~ step adds a document to the runtime cache;
+~cx:cache-delete~ removes a step from the cache.
+
+#+BEGIN_SRC xml
+<p:declare-step type="cx:cache-add">
+  <p:option name="href" as="xs:anyURI?" select="()"/>
+  <p:input port="source"/>
+  <p:output port="result"/>
+</p:declare-step>
+
+<p:declare-step type="cx:cache-delete">
+  <p:option name="href" as="xs:anyURI?" select="()"/>
+  <p:input port="source"/>
+  <p:output port="result"/>
+</p:declare-step>
+#+END_SRC

--- a/ext/cache/build.gradle.kts
+++ b/ext/cache/build.gradle.kts
@@ -1,0 +1,16 @@
+import com.xmlcalabash.build.XmlCalabashBuildExtension
+
+plugins {
+  id("buildlogic.kotlin-library-conventions")
+  id("com.xmlcalabash.build.xmlcalabash-build")
+}
+
+dependencies {
+  implementation(project(":xmlcalabash"))
+}
+
+val xmlbuild = the<XmlCalabashBuildExtension>()
+
+tasks.jar {
+  archiveFileName.set(xmlbuild.jarArchiveFilename())
+}

--- a/ext/cache/src/main/kotlin/com/xmlcalabash/ext/cache/CacheDeleteStep.kt
+++ b/ext/cache/src/main/kotlin/com/xmlcalabash/ext/cache/CacheDeleteStep.kt
@@ -1,0 +1,49 @@
+package com.xmlcalabash.ext.cache
+
+import com.xmlcalabash.documents.DocumentProperties
+import com.xmlcalabash.documents.XProcDocument
+import com.xmlcalabash.exceptions.XProcError
+import com.xmlcalabash.namespace.Ns
+import com.xmlcalabash.steps.AbstractAtomicStep
+import net.sf.saxon.om.NamespaceUri
+import net.sf.saxon.s9api.QName
+
+class CacheDeleteStep(): AbstractAtomicStep() {
+    companion object {
+        val failIfNotInCache = QName(NamespaceUri.NULL, "fail-if-not-in-cache")
+    }
+    private lateinit var document: XProcDocument
+
+    override fun input(port: String, doc: XProcDocument) {
+        document = doc
+    }
+
+    override fun run() {
+        super.run()
+
+        val failIfNotCached = booleanBinding(failIfNotInCache)!!
+        val href = uriBinding(Ns.href)
+
+        if (href == null && document.baseURI == null) {
+            throw XProcError.xiBaseUriRequiredToCache().exception()
+        }
+
+        if (href != null) {
+            if (failIfNotCached && stepConfig.documentManager.getCached(href) == null) {
+                throw XProcError.xiDocumentNotInCache(href).exception()
+            }
+            val props = DocumentProperties(document.properties)
+            props.set(Ns.baseUri, href)
+            stepConfig.documentManager.uncache(document.with(props))
+        } else {
+            if (failIfNotCached && stepConfig.documentManager.getCached(document.baseURI!!) == null) {
+                throw XProcError.xiDocumentNotInCache(document.baseURI!!).exception()
+            }
+            stepConfig.documentManager.uncache(document)
+        }
+
+        receiver.output("result", document)
+    }
+
+    override fun toString(): String = "cx:cache-delete"
+}

--- a/ext/cache/src/main/kotlin/com/xmlcalabash/ext/cache/DocumentResolverProvider.kt
+++ b/ext/cache/src/main/kotlin/com/xmlcalabash/ext/cache/DocumentResolverProvider.kt
@@ -1,0 +1,49 @@
+package com.xmlcalabash.ext.cache
+
+import com.xmlcalabash.datamodel.MediaType
+import com.xmlcalabash.documents.XProcDocument
+import com.xmlcalabash.io.DocumentLoader
+import com.xmlcalabash.io.DocumentManager
+import com.xmlcalabash.spi.DocumentResolver
+import com.xmlcalabash.spi.DocumentResolverProvider
+import com.xmlcalabash.config.XProcStepConfiguration
+import java.io.IOException
+import java.net.URI
+
+class DocumentResolverProvider:  DocumentResolverProvider, DocumentResolver {
+    companion object {
+        val MAGIC_URI = URI("https://xmlcalabash.com/ext/library/cache.xpl")
+        var library: XProcDocument? = null
+    }
+
+    override fun create(): DocumentResolver {
+        return this
+    }
+
+    override fun configure(manager: DocumentManager) {
+        manager.registerPrefix(MAGIC_URI.toString(), this)
+    }
+
+    override fun resolve(context: XProcStepConfiguration, uri: URI, current: XProcDocument?): XProcDocument? {
+        if (current != null) {
+            return current // WAT?
+        }
+
+        if (uri != MAGIC_URI) {
+            return null // WAT?
+        }
+
+        synchronized(Companion) {
+            if (library != null) {
+                return library
+            }
+
+            val loader = DocumentLoader(context, MAGIC_URI)
+            val stream = com.xmlcalabash.ext.cache.DocumentResolverProvider::class.java.getResourceAsStream("/com/xmlcalabash/ext/cache.xpl")
+                ?: throw IOException("Failed to find unique-id.xpl as a resource")
+            library = loader.load(MAGIC_URI, stream, MediaType.XML)
+            stream.close()
+            return library
+        }
+    }
+}

--- a/ext/cache/src/main/kotlin/com/xmlcalabash/ext/cache/StepProvider.kt
+++ b/ext/cache/src/main/kotlin/com/xmlcalabash/ext/cache/StepProvider.kt
@@ -1,0 +1,37 @@
+package com.xmlcalabash.ext.cache
+
+import com.xmlcalabash.api.XProcStep
+import com.xmlcalabash.exceptions.XProcError
+import com.xmlcalabash.namespace.NsCx
+import com.xmlcalabash.runtime.parameters.StepParameters
+import com.xmlcalabash.spi.AtomicStepManager
+import com.xmlcalabash.spi.AtomicStepProvider
+import net.sf.saxon.s9api.QName
+
+class StepProvider: AtomicStepProvider, AtomicStepManager {
+    companion object {
+        private val CACHE_ADD = QName(NsCx.namespace, "cx:cache-add")
+        private val CACHE_DELETE = QName(NsCx.namespace, "cx:cache-delete")
+    }
+
+    override fun create(): AtomicStepManager {
+        return this
+    }
+
+    override fun createStep(params: StepParameters): () -> XProcStep {
+        if (params.stepType == CACHE_ADD) {
+            return { -> CacheAddStep() }
+        } else if (params.stepType == CACHE_DELETE) {
+            return { -> CacheDeleteStep() }
+        }
+        throw XProcError.xiImpossible("Attempted to create ${params.stepType} step").exception()
+    }
+
+    override fun stepAvailable(stepType: QName): Boolean {
+        return stepType == CACHE_ADD || stepType == CACHE_DELETE
+    }
+
+    override fun stepTypes(): Set<QName> {
+        return setOf(CACHE_ADD, CACHE_DELETE)
+    }
+}

--- a/ext/cache/src/main/resources/META-INF/services/com.xmlcalabash.spi.AtomicStepProvider
+++ b/ext/cache/src/main/resources/META-INF/services/com.xmlcalabash.spi.AtomicStepProvider
@@ -1,0 +1,1 @@
+com.xmlcalabash.ext.cache.StepProvider

--- a/ext/cache/src/main/resources/META-INF/services/com.xmlcalabash.spi.DocumentResolverProvider
+++ b/ext/cache/src/main/resources/META-INF/services/com.xmlcalabash.spi.DocumentResolverProvider
@@ -1,0 +1,1 @@
+com.xmlcalabash.ext.cache.DocumentResolverProvider

--- a/ext/cache/src/main/resources/com/xmlcalabash/ext/cache.xpl
+++ b/ext/cache/src/main/resources/com/xmlcalabash/ext/cache.xpl
@@ -1,0 +1,20 @@
+<p:library xmlns:p="http://www.w3.org/ns/xproc"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:cx="http://xmlcalabash.com/ns/extensions"
+           version="3.0">
+
+  <p:declare-step type="cx:cache-add">
+    <p:option name="href" as="xs:anyURI?" select="()"/>
+    <p:option name="fail-if-in-cache" as="xs:boolean" select="false()"/>
+    <p:input port="source"/>
+    <p:output port="result"/>
+  </p:declare-step>
+
+  <p:declare-step type="cx:cache-delete">
+    <p:option name="href" as="xs:anyURI?" select="()"/>
+    <p:option name="fail-if-not-in-cache" as="xs:boolean" select="false()"/>
+    <p:input port="source"/>
+    <p:output port="result"/>
+  </p:declare-step>
+
+</p:library>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,6 +10,6 @@ include("xmlcalabash", "app", "test-driver",
         "ixml-coffeepress", "send-mail",
         "paged-media:weasyprint", "paged-media:prince",
         "paged-media:antenna-house", "paged-media:fop",
-        "ext:unique-id", "ext:metadata-extractor",
+        "ext:unique-id", "ext:metadata-extractor", "ext:cache",
         "template:kotlin", "template:java",
     )

--- a/test-driver/build.gradle.kts
+++ b/test-driver/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
   implementation(project(":paged-media:fop"))
   implementation(project(":ext:unique-id"))
   implementation(project(":ext:metadata-extractor"))
+  implementation(project(":ext:cache"))
   implementation(files("lib"))
   // WTF? Why is this necessary?
   implementation(files("build/classes/kotlin/main"))

--- a/tests/extra-suite/test-suite/tests/cache-001.xml
+++ b/tests/extra-suite/test-suite/tests/cache-001.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+  <t:info>
+    <t:title>cache-001</t:title>
+    <t:revision-history>
+      <t:revision>
+        <t:date>2024-11-29</t:date>
+        <t:author>
+          <t:name>Norm Tovey-Walsh</t:name>
+        </t:author>
+        <t:description xmlns="http://www.w3.org/1999/xhtml">
+          <p>Created test.</p>
+        </t:description>
+      </t:revision>
+    </t:revision-history>
+  </t:info>
+  <t:description xmlns="http://www.w3.org/1999/xhtml">
+    <p>Tests that the document isn’t in the cache (if we didn’t add it).</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0"
+                    xmlns:err="http://www.w3.org/ns/xproc-error"
+                    xmlns:cx="http://xmlcalabash.com/ns/extensions"
+                    xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      <p:import href="https://xmlcalabash.com/ext/library/cache.xpl"/>
+
+      <p:try>
+        <p:xinclude>
+          <p:with-input>
+            <doc xmlns:xi="http://www.w3.org/2001/XInclude">
+              <xi:include href="https://xmlcalabash.com/does/not/exist.xml"/>
+            </doc>
+          </p:with-input>
+        </p:xinclude>
+        <p:catch code="err:XC0029">
+          <p:identity>
+            <p:with-input>
+              <correct/>
+            </p:with-input>
+          </p:identity>
+        </p:catch>
+      </p:try>
+    </p:declare-step>
+  </t:pipeline>
+  <t:schematron>
+    <s:schema queryBinding="xslt2"
+              xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:pattern>
+        <s:rule context="/">
+          <s:assert test="correct">The document root is not correct.</s:assert>
+        </s:rule>
+      </s:pattern>
+    </s:schema>
+  </t:schematron>
+</t:test>

--- a/tests/extra-suite/test-suite/tests/cache-002.xml
+++ b/tests/extra-suite/test-suite/tests/cache-002.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+  <t:info>
+    <t:title>cache-002</t:title>
+    <t:revision-history>
+      <t:revision>
+        <t:date>2024-11-29</t:date>
+        <t:author>
+          <t:name>Norm Tovey-Walsh</t:name>
+        </t:author>
+        <t:description xmlns="http://www.w3.org/1999/xhtml">
+          <p>Created test.</p>
+        </t:description>
+      </t:revision>
+    </t:revision-history>
+  </t:info>
+  <t:description xmlns="http://www.w3.org/1999/xhtml">
+    <p>Tests that the document can be added to the cache.</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0"
+                    xmlns:err="http://www.w3.org/ns/xproc-error"
+                    xmlns:cx="http://xmlcalabash.com/ns/extensions"
+                    xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      <p:import href="https://xmlcalabash.com/ext/library/cache.xpl"/>
+
+      <cx:cache-add name="cache-add"
+                    href="https://xmlcalabash.com/does/not/exist.xml">
+        <p:with-input>
+          <does-so/>
+        </p:with-input>
+      </cx:cache-add>
+
+      <p:try>
+        <p:xinclude depends="cache-add">
+          <p:with-input>
+            <doc xmlns:xi="http://www.w3.org/2001/XInclude">
+              <xi:include href="https://xmlcalabash.com/does/not/exist.xml"/>
+            </doc>
+          </p:with-input>
+        </p:xinclude>
+        <p:catch code="err:XC0029">
+          <p:identity>
+            <p:with-input>
+              <fail/>
+            </p:with-input>
+          </p:identity>
+        </p:catch>
+      </p:try>
+    </p:declare-step>
+  </t:pipeline>
+  <t:schematron>
+    <s:schema queryBinding="xslt2"
+              xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:pattern>
+        <s:rule context="/">
+          <s:assert test="doc">The document root is not doc.</s:assert>
+          <s:assert test="doc/does-so">The document doesn’t contain does-so.</s:assert>
+        </s:rule>
+      </s:pattern>
+    </s:schema>
+  </t:schematron>
+</t:test>

--- a/tests/extra-suite/test-suite/tests/cache-003.xml
+++ b/tests/extra-suite/test-suite/tests/cache-003.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+  <t:info>
+    <t:title>cache-003</t:title>
+    <t:revision-history>
+      <t:revision>
+        <t:date>2024-11-29</t:date>
+        <t:author>
+          <t:name>Norm Tovey-Walsh</t:name>
+        </t:author>
+        <t:description xmlns="http://www.w3.org/1999/xhtml">
+          <p>Created test.</p>
+        </t:description>
+      </t:revision>
+    </t:revision-history>
+  </t:info>
+  <t:description xmlns="http://www.w3.org/1999/xhtml">
+    <p>Tests that the document can be replaced in the cache.</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0"
+                    xmlns:err="http://www.w3.org/ns/xproc-error"
+                    xmlns:cx="http://xmlcalabash.com/ns/extensions"
+                    xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      <p:import href="https://xmlcalabash.com/ext/library/cache.xpl"/>
+
+      <cx:cache-add name="cache-pre-add"
+                    href="https://xmlcalabash.com/does/not/exist.xml">
+        <p:with-input>
+          <this-is-replaced/>
+        </p:with-input>
+      </cx:cache-add>
+
+      <cx:cache-add name="cache-add"
+                    href="https://xmlcalabash.com/does/not/exist.xml">
+        <p:with-input>
+          <does-so/>
+        </p:with-input>
+      </cx:cache-add>
+
+      <p:try>
+        <p:xinclude depends="cache-add">
+          <p:with-input>
+            <doc xmlns:xi="http://www.w3.org/2001/XInclude">
+              <xi:include href="https://xmlcalabash.com/does/not/exist.xml"/>
+            </doc>
+          </p:with-input>
+        </p:xinclude>
+        <p:catch code="err:XC0029">
+          <p:identity>
+            <p:with-input>
+              <fail/>
+            </p:with-input>
+          </p:identity>
+        </p:catch>
+      </p:try>
+    </p:declare-step>
+  </t:pipeline>
+  <t:schematron>
+    <s:schema queryBinding="xslt2"
+              xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:pattern>
+        <s:rule context="/">
+          <s:assert test="doc">The document root is not doc.</s:assert>
+          <s:assert test="doc/does-so">The document doesn’t contain does-so.</s:assert>
+        </s:rule>
+      </s:pattern>
+    </s:schema>
+  </t:schematron>
+</t:test>

--- a/tests/extra-suite/test-suite/tests/cache-004.xml
+++ b/tests/extra-suite/test-suite/tests/cache-004.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:cxerr="https://xmlcalabash.com/ns/error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0"
+        expected="fail" code="cxerr:XI0037">
+  <t:info>
+    <t:title>cache-004</t:title>
+    <t:revision-history>
+      <t:revision>
+        <t:date>2024-11-29</t:date>
+        <t:author>
+          <t:name>Norm Tovey-Walsh</t:name>
+        </t:author>
+        <t:description xmlns="http://www.w3.org/1999/xhtml">
+          <p>Created test.</p>
+        </t:description>
+      </t:revision>
+    </t:revision-history>
+  </t:info>
+  <t:description xmlns="http://www.w3.org/1999/xhtml">
+    <p>Tests that document replacement can raise an error.</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0"
+                    xmlns:err="http://www.w3.org/ns/xproc-error"
+                    xmlns:cx="http://xmlcalabash.com/ns/extensions"
+                    xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      <p:import href="https://xmlcalabash.com/ext/library/cache.xpl"/>
+
+      <cx:cache-add name="cache-pre-add"
+                    href="https://xmlcalabash.com/does/not/exist.xml">
+        <p:with-input>
+          <this-is-replaced/>
+        </p:with-input>
+      </cx:cache-add>
+
+      <cx:cache-add name="cache-add" p:depends="cache-pre-add"
+                    fail-if-in-cache="true"
+                    href="https://xmlcalabash.com/does/not/exist.xml">
+        <p:with-input>
+          <does-so/>
+        </p:with-input>
+      </cx:cache-add>
+
+      <p:try>
+        <p:xinclude depends="cache-add">
+          <p:with-input>
+            <doc xmlns:xi="http://www.w3.org/2001/XInclude">
+              <xi:include href="https://xmlcalabash.com/does/not/exist.xml"/>
+            </doc>
+          </p:with-input>
+        </p:xinclude>
+        <p:catch code="err:XC0029">
+          <p:identity>
+            <p:with-input>
+              <fail/>
+            </p:with-input>
+          </p:identity>
+        </p:catch>
+      </p:try>
+    </p:declare-step>
+  </t:pipeline>
+</t:test>

--- a/tests/extra-suite/test-suite/tests/cache-005.xml
+++ b/tests/extra-suite/test-suite/tests/cache-005.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+  <t:info>
+    <t:title>cache-005</t:title>
+    <t:revision-history>
+      <t:revision>
+        <t:date>2024-11-29</t:date>
+        <t:author>
+          <t:name>Norm Tovey-Walsh</t:name>
+        </t:author>
+        <t:description xmlns="http://www.w3.org/1999/xhtml">
+          <p>Created test.</p>
+        </t:description>
+      </t:revision>
+    </t:revision-history>
+  </t:info>
+  <t:description xmlns="http://www.w3.org/1999/xhtml">
+    <p>Tests that the document can be removed from the cache.</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0"
+                    xmlns:err="http://www.w3.org/ns/xproc-error"
+                    xmlns:cx="http://xmlcalabash.com/ns/extensions"
+                    xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      <p:import href="https://xmlcalabash.com/ext/library/cache.xpl"/>
+
+      <cx:cache-add name="cache-add"
+                    href="https://xmlcalabash.com/does/not/exist.xml">
+        <p:with-input>
+          <does-so/>
+        </p:with-input>
+      </cx:cache-add>
+
+      <cx:cache-delete name="cache-delete" p:depends="cache-add"
+                       fail-if-not-in-cache="true"
+                       href="https://xmlcalabash.com/does/not/exist.xml">
+        <p:with-input>
+          <irrelevant/>
+        </p:with-input>
+      </cx:cache-delete>
+
+      <p:try>
+        <p:xinclude depends="cache-delete">
+          <p:with-input>
+            <doc xmlns:xi="http://www.w3.org/2001/XInclude">
+              <xi:include href="https://xmlcalabash.com/does/not/exist.xml"/>
+            </doc>
+          </p:with-input>
+        </p:xinclude>
+        <p:catch code="err:XC0029">
+          <p:identity>
+            <p:with-input>
+              <correct/>
+            </p:with-input>
+          </p:identity>
+        </p:catch>
+      </p:try>
+    </p:declare-step>
+  </t:pipeline>
+  <t:schematron>
+    <s:schema queryBinding="xslt2"
+              xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:pattern>
+        <s:rule context="/">
+          <s:assert test="correct">The document root is not correct.</s:assert>
+        </s:rule>
+      </s:pattern>
+    </s:schema>
+  </t:schematron>
+</t:test>

--- a/tests/extra-suite/test-suite/tests/cache-006.xml
+++ b/tests/extra-suite/test-suite/tests/cache-006.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:cxerr="https://xmlcalabash.com/ns/error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0"
+        expected="fail" code="cxerr:XI0038">
+  <t:info>
+    <t:title>cache-005</t:title>
+    <t:revision-history>
+      <t:revision>
+        <t:date>2024-11-29</t:date>
+        <t:author>
+          <t:name>Norm Tovey-Walsh</t:name>
+        </t:author>
+        <t:description xmlns="http://www.w3.org/1999/xhtml">
+          <p>Created test.</p>
+        </t:description>
+      </t:revision>
+    </t:revision-history>
+  </t:info>
+  <t:description xmlns="http://www.w3.org/1999/xhtml">
+    <p>Tests that the document can be removed from the cache.</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0"
+                    xmlns:err="http://www.w3.org/ns/xproc-error"
+                    xmlns:cx="http://xmlcalabash.com/ns/extensions"
+                    xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      <p:import href="https://xmlcalabash.com/ext/library/cache.xpl"/>
+
+      <cx:cache-delete name="cache-delete"
+                       fail-if-not-in-cache="true"
+                       href="https://xmlcalabash.com/does/not/exist.xml">
+        <p:with-input>
+          <irrelevant/>
+        </p:with-input>
+      </cx:cache-delete>
+
+      <p:try>
+        <p:xinclude depends="cache-delete">
+          <p:with-input>
+            <doc xmlns:xi="http://www.w3.org/2001/XInclude">
+              <xi:include href="https://xmlcalabash.com/does/not/exist.xml"/>
+            </doc>
+          </p:with-input>
+        </p:xinclude>
+        <p:catch code="err:XC0029">
+          <p:identity>
+            <p:with-input>
+              <correct/>
+            </p:with-input>
+          </p:identity>
+        </p:catch>
+      </p:try>
+    </p:declare-step>
+  </t:pipeline>
+  <t:schematron>
+    <s:schema queryBinding="xslt2"
+              xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:pattern>
+        <s:rule context="/">
+          <s:assert test="correct">The document root is not correct.</s:assert>
+        </s:rule>
+      </s:pattern>
+    </s:schema>
+  </t:schematron>
+</t:test>

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/XProcError.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/XProcError.kt
@@ -301,6 +301,7 @@ class XProcError private constructor(val code: QName, val variant: Int, val loca
         fun xcXmlSchemaInvalidSchema(uri: URI) = step(Pair(152, 2), uri)
         fun xcNotRelaxNG(message: String) = step(Pair(153,1), message)
         fun xcNotRelaxNG(uri: URI, message: String) = step(Pair(153,2), uri, message)
+        fun xcNotNvdl(message: String) = step(154, message)
         fun xcNotSchemaValidRelaxNG(message: String) = step(Pair(155,1), message)
         fun xcNotSchemaValidRelaxNG(uri: URI, message: String) = step(Pair(155,2), uri, message)
         fun xcNotSchemaValidXmlSchema(message: String) = step(Pair(156, 1), message)
@@ -344,6 +345,8 @@ class XProcError private constructor(val code: QName, val variant: Int, val loca
         fun xiUnwritableOutputFile(filename: String) = internal(33, filename)
         fun xiNoRunnableSteps() = internal(35)
         fun xiNotASpecialType(type: String) = internal(36, type)
+        fun xiDocumentInCache(href: URI) = internal(37, href)
+        fun xiDocumentNotInCache(href: URI) = internal(38, href)
 
         fun xiCliInvalidValue(option: String, value: String) = internal(200, option, value)
         fun xiCliValueRequired(option: String) = internal(202, option)

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/XIncludeStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/XIncludeStep.kt
@@ -1,5 +1,7 @@
 package com.xmlcalabash.steps
 
+import com.nwalsh.sinclude.DefaultDocumentResolver
+import com.nwalsh.sinclude.DocumentResolver
 import com.nwalsh.sinclude.XInclude
 import com.xmlcalabash.documents.XProcDocument
 import com.xmlcalabash.exceptions.XProcError
@@ -17,7 +19,8 @@ open class XIncludeStep(): AbstractAtomicStep() {
     override fun run() {
         super.run()
 
-        val xincluder = XInclude()
+        val defaultResolver = DefaultDocumentResolver()
+        val xincluder = XInclude(XiResolver(defaultResolver))
         xincluder.trimText = booleanBinding(NsCx.trim) ?: false
         xincluder.fixupXmlBase = booleanBinding(Ns.fixupXmlBase) ?: false
         xincluder.fixupXmlLang = booleanBinding(Ns.fixupXmlLang) ?: false
@@ -31,4 +34,34 @@ open class XIncludeStep(): AbstractAtomicStep() {
     }
 
     override fun toString(): String = "p:xinclude"
+
+    inner class XiResolver(val defaultResolver: DocumentResolver): DocumentResolver {
+        override fun resolveXml(base: XdmNode, uri: String, accept: String?, acceptLanguage: String?): XdmNode? {
+            val href = base.baseURI.resolve(uri)
+            val cached = stepConfig.documentManager.getCached(href)
+            if (cached == null) {
+                return defaultResolver.resolveXml(base, uri, accept, acceptLanguage)
+            }
+
+            if (cached.value is XdmNode) {
+                return cached.value as XdmNode
+            }
+
+            throw XProcError.xcXIncludeError("Cached document is not XML: ${href}").exception()
+        }
+
+        override fun resolveText(base: XdmNode, uri: String, encoding: String?, accept: String?, acceptLanguage: String?): XdmNode? {
+            val href = base.baseURI.resolve(uri)
+            val cached = stepConfig.documentManager.getCached(href)
+            if (cached == null) {
+                return defaultResolver.resolveText(base, uri, encoding, accept, acceptLanguage)
+            }
+
+            if (cached.value is XdmNode) {
+                return cached.value as XdmNode
+            }
+
+            throw XProcError.xcXIncludeError("Cached document is not a node: ${href}").exception()
+        }
+    }
 }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/validation/ValidateWithNVDL.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/validation/ValidateWithNVDL.kt
@@ -61,7 +61,11 @@ open class ValidateWithNVDL(): AbstractAtomicStep() {
 
         try {
             driver.loadSchema(nvdl)
+        } catch (ex: Exception) {
+            throw XProcError.xcNotNvdl(ex.message ?: "").exception(ex)
+        }
 
+        try {
             if (!driver.validate(doc)) {
                 if (assertValid) {
                     throw XProcError.xcNotSchemaValidNVDL().exception()

--- a/xmlcalabash/src/main/resources/com/xmlcalabash/pipeline2dot.xsl
+++ b/xmlcalabash/src/main/resources/com/xmlcalabash/pipeline2dot.xsl
@@ -318,11 +318,19 @@
                 from="cluster_{generate-id($from_step)}_foot" output="{generate-id($from_port)}_foot"/>
     </xsl:when>
     <xsl:otherwise>
-<!--
+
+    <!--
+      <xsl:message select="'FROM-STEP:', $from_step"/>
+      <xsl:message select="'FROM-PORT:', $from_port"/>
+      <xsl:message select="'TO-STEP:', $to_step"/>
+      <xsl:message select="'TO-STEP:', $to_port"/>
       <xsl:message>cluster_{generate-id($from_step)} . {generate-id($from_port)} → cluster_{generate-id($to_step)} . {generate-id($to_port)}</xsl:message>
--->
-      <dot:edge x="5" to="cluster_{generate-id($to_step)}" input="{generate-id($to_port)}"
-                from="cluster_{generate-id($from_step)}" output="{generate-id($from_port)}"/>
+    -->
+
+      <xsl:for-each select="$from_port">
+        <dot:edge x="5" to="cluster_{generate-id($to_step)}" input="{generate-id($to_port)}"
+                  from="cluster_{generate-id($from_step)}" output="{generate-id(.)}"/>
+      </xsl:for-each>
     </xsl:otherwise>
   </xsl:choose>
 </xsl:template>


### PR DESCRIPTION
1. Make sure the `DocumentManager` uses the cache; this fixes a failing NVDL test
2. Generate slightly more precise errors in the NVDL step, fixing another failing test
3. Added `cx:cache-add` and `cx:cache-delete` steps for pipeline cache control