### PR TITLE
Fix a few more bugs in the way static options are used

### DIFF
--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/AtomicStepInstruction.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/AtomicStepInstruction.kt
@@ -84,7 +84,10 @@ open class AtomicStepInstruction(parent: XProcInstruction, instructionType: QNam
 
         for (output in decl.getOutputs()) {
             val wo = withOutput()
-            wo.port = output.port
+            if (!output.portDefined) {
+                output._port = "!result"
+            }
+            wo._port = output.port
             wo.primary = output.primary
             wo.sequence = output.sequence
             wo.contentTypes = output.contentTypes

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/CompoundStepDeclaration.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/CompoundStepDeclaration.kt
@@ -204,7 +204,8 @@ abstract class CompoundStepDeclaration(parent: XProcInstruction?, stepConfig: St
         for (option in children.filterIsInstance<OptionInstruction>()) {
             option.elaborateInstructions()
             if (option.static) {
-                _staticOptions[option.name] = builder.staticOptionsManager.get(option)
+                _staticOptions[option.name] = StaticOptionDetails(option)
+                stepConfig.addStaticBinding(option.name, option.select!!.staticValue!!)
             }
         }
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/OptionInstruction.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/OptionInstruction.kt
@@ -112,6 +112,7 @@ open class OptionInstruction(parent: XProcInstruction, name: QName, stepConfig: 
                 throw XProcError.xsShadowStaticOption(name).exception()
             }
             select!!.computeStaticValue(stepConfig)
+            stepConfig.addStaticBinding(name, select!!.staticValue!!)
         }
 
         super.elaborateInstructions()

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/OutputInstruction.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/OutputInstruction.kt
@@ -13,6 +13,12 @@ class OutputInstruction(parent: XProcInstruction): PortBindingContainer(parent, 
         this._sequence = sequence
     }
 
+    init {
+        // Output ports don't have to have a name. Make sure they get the
+        // "right" unusable name if none is specified.
+        _port = "!result"
+    }
+
     private var _serialization: XProcExpression? = null
     var serialization: XProcExpression
         get() = _serialization!!

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/PortBindingContainer.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/PortBindingContainer.kt
@@ -1,8 +1,6 @@
 package com.xmlcalabash.datamodel
 
-import com.thaiopensource.resolver.Input
 import com.xmlcalabash.exceptions.XProcError
-import com.xmlcalabash.namespace.Ns
 import net.sf.saxon.s9api.QName
 
 open class PortBindingContainer(parent: XProcInstruction, stepConfig: StepConfiguration, instructionType: QName): BindingContainer(parent, stepConfig, instructionType) {
@@ -25,11 +23,6 @@ open class PortBindingContainer(parent: XProcInstruction, stepConfig: StepConfig
         set(value) {
             checkOpen()
             val pname = stepConfig.parseNCName(value)
-            for (pdecl in parent!!.children.filterIsInstance<PortBindingContainer>().filter { port == pname }) {
-                if (pdecl !== this) {
-                    println("DUPLICATE PORT: $port")
-                }
-            }
             _port = pname
         }
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/parsers/xpl/elements/ElementNode.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/parsers/xpl/elements/ElementNode.kt
@@ -32,11 +32,7 @@ open class ElementNode(parent: AnyNode?, stepConfig: StepConfiguration, node: Xd
         }
     }
 
-    internal open fun resolveUseWhen(context: UseWhenContext) {
-        if (useWhen == false) {
-            return
-        }
-
+    internal fun computeUseWhenOnThisElement(context: UseWhenContext) {
         if (useWhen == null) {
             context.useWhen.add(this)
             val resolved = context.resolveUseWhen(stepConfig, conditional!!)
@@ -55,6 +51,14 @@ open class ElementNode(parent: AnyNode?, stepConfig: StepConfiguration, node: Xd
                 }
             }
         }
+    }
+
+    internal open fun resolveUseWhen(context: UseWhenContext) {
+        if (useWhen == false) {
+            return
+        }
+
+        computeUseWhenOnThisElement(context)
 
         if (useWhen == true) {
             var inline = false
@@ -62,21 +66,6 @@ open class ElementNode(parent: AnyNode?, stepConfig: StepConfiguration, node: Xd
             while (!inline && tnode != null) {
                 inline = tnode.node.nodeName == NsP.inline
                 tnode = tnode.parent
-            }
-
-            if (!inline && node.nodeName == NsP.option) {
-                val isStatic =  stepConfig.parseBoolean(attributes[Ns.static] ?: "false")
-                if (isStatic) {
-                    val name = stepConfig.parseQName(attributes[Ns.name]!!)
-                    if (!context.builder.staticOptionsManager.useWhenOptions.contains(name)) {
-                        val select = if (Ns.select in attributes) {
-                            attributes[Ns.select]!!
-                        } else {
-                            "()"
-                        }
-                        context.builder.staticOptionsManager.useWhenValue(name, context.resolveExpression(stepConfig, select)!!)
-                    }
-                }
             }
 
             for (child in children.filterIsInstance<ElementNode>()) {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/parsers/xpl/elements/OptionNode.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/parsers/xpl/elements/OptionNode.kt
@@ -24,7 +24,7 @@ class OptionNode(parent: AnyNode, node: XdmNode, val name: QName, val select: St
             return
         }
 
-        super.resolveUseWhen(context)
+        computeUseWhenOnThisElement(context)
 
         if (context.staticOptions[this] == null) {
             if (useWhen == true) {
@@ -42,6 +42,7 @@ class OptionNode(parent: AnyNode, node: XdmNode, val name: QName, val select: St
 
                 context.staticOptions[this] = value
             } else {
+                useWhen = null // try again next time
                 context.staticOptions[this] = null
             }
         }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/parsers/xpl/elements/UseWhenContext.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/parsers/xpl/elements/UseWhenContext.kt
@@ -88,14 +88,19 @@ class UseWhenContext internal constructor(val builder: PipelineBuilder) {
         for ((prefix, uri) in stepConfig.inscopeNamespaces) {
             compiler.declareNamespace(prefix, uri.toString())
         }
-        for ((name, value) in builder.staticOptionsManager.useWhenOptions) {
-            compiler.declareVariable(name)
+        for ((option, value) in staticOptions) {
+            if (value != null) {
+                compiler.declareVariable(option.name)
+            }
         }
 
         val selector = compiler.compile(expr).load()
-        for ((name, value) in builder.staticOptionsManager.useWhenOptions) {
-            selector.setVariable(name, value)
+        for ((option, value) in staticOptions) {
+            if (value != null) {
+                selector.setVariable(option.name, value)
+            }
         }
+
         return selector
     }
 


### PR DESCRIPTION
My previous PR didn't address some cases where static options and [p:]use-when interact.

I'm still not persuaded that I've got it exactly right. And I think static option handling is still a bit messy. But progress.

Also fixed a bug where an anonymous output wasn't supported on a user-defined step.