### PR TITLE
Warn for (some) ports that accept no documents

### DIFF
--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/MediaType.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/MediaType.kt
@@ -402,6 +402,9 @@ class MediaType private constructor(val mediaType: String, val mediaSubtype: Str
 
     override fun toString(): String {
         val sb = StringBuilder()
+        if (!inclusive) {
+            sb.append("-")
+        }
         sb.append(toStringWithoutParameters())
 
         for (param in parameters) {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/PortBindingContainer.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/PortBindingContainer.kt
@@ -2,6 +2,7 @@ package com.xmlcalabash.datamodel
 
 import com.xmlcalabash.exceptions.XProcError
 import net.sf.saxon.s9api.QName
+import org.apache.logging.log4j.kotlin.logger
 
 open class PortBindingContainer(parent: XProcInstruction, stepConfig: InstructionConfiguration, instructionType: QName): BindingContainer(parent, stepConfig, instructionType) {
     companion object {
@@ -119,6 +120,19 @@ open class PortBindingContainer(parent: XProcInstruction, stepConfig: Instructio
 
         pipe?.let { promotePipe(it) }
         pipe = null
+
+        if (contentTypes.isNotEmpty()) {
+            var acceptsSomething = false
+            for (ctype in contentTypes) {
+                acceptsSomething = acceptsSomething || ctype.inclusive
+                if (ctype.mediaType == "*" && ctype.mediaSubtype == "*" && !ctype.inclusive) {
+                    acceptsSomething = false
+                }
+            }
+            if (!acceptsSomething) {
+                logger.debug { "Content type constraints on port '${port}' excludes all documents" }
+            }
+        }
 
         var sawEmpty = false
         var welded = children.filterIsInstance<EmptyInstruction>().isNotEmpty()


### PR DESCRIPTION
Fix #32 

In the end, I punted a bit. Solving the general problem "does this accept any content types" is a bit complex. This PR just adds a warning if there are no inclusive content types or if -*/* is among the exclusive content types.