### PR TITLE
Support --init:className for registering Saxon extension functions

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -168,7 +168,6 @@ tasks.register("stage-release") {
   dependsOn("jar")
 
   doLast {
-    println("Staging release...")
     mkdir(layout.buildDirectory.dir("stage"))
     mkdir(layout.buildDirectory.dir("stage/lib"))
     copy {

--- a/app/src/main/kotlin/com/xmlcalabash/app/CommandLine.kt
+++ b/app/src/main/kotlin/com/xmlcalabash/app/CommandLine.kt
@@ -49,6 +49,7 @@ class CommandLine private constructor(val args: Array<out String>) {
     private var _outputs = mutableMapOf<String, OutputFilename>()
     private var _options = mutableMapOf<String,List<String>>()
     private var _namespaces = mutableMapOf<String, NamespaceUri>()
+    private var _initializers = mutableListOf<String>()
     private var _pipeline: File? = null
     private var _step: String? = null
 
@@ -125,6 +126,10 @@ class CommandLine private constructor(val args: Array<out String>) {
     val namespaces: Map<String, NamespaceUri>
         get() = _namespaces
 
+    /** Function initializers (--init initializers for Saxon) */
+    val initializers: List<String>
+        get() = _initializers
+
     /** The pipeline or library document containing the pipeline to run. */
     val pipeline: File?
         get() = _pipeline
@@ -140,6 +145,7 @@ class CommandLine private constructor(val args: Array<out String>) {
         ArgumentDescription("--input", listOf("-i"), ArgumentType.STRING) { it -> parseInput(it) },
         ArgumentDescription("--output", listOf("-o"), ArgumentType.STRING) { it -> parseOutput(it) },
         ArgumentDescription("--namespace", listOf("-ns"), ArgumentType.STRING) { it -> parseNamespace(it) },
+        ArgumentDescription("--init", listOf(), ArgumentType.STRING) { it -> _initializers.add(it) },
         ArgumentDescription("--configuration", listOf("-c", "--config"), ArgumentType.EXISTING_FILE) { it -> _config = File(it) },
         ArgumentDescription("--step", listOf(), ArgumentType.STRING) { it -> _step = it },
         ArgumentDescription("--graph", listOf(), ArgumentType.FILE) { it -> _pipelineGraph = it },

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/DefaultErrorExplanation.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/DefaultErrorExplanation.kt
@@ -47,7 +47,7 @@ class DefaultErrorExplanation(): ErrorExplanation {
             System.err.println("   in ${error.inputLocation}")
         }
         if (error.throwable != null && error.throwable?.message != null) {
-            System.err.println("   cause: ${error.throwable!!.message}")
+            System.err.println("   cause: ${error.throwable!!.toString()}")
         }
     }
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/XProcError.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/XProcError.kt
@@ -354,6 +354,7 @@ class XProcError private constructor(val code: QName, val variant: Int, val loca
         fun xiDocumentNotInCache(href: URI) = internal(38, href)
         fun xiNoPipelineInLibrary(href: String) = internal(Pair(39, 1), href)
         fun xiNoPipelineInLibrary(name: String, href: String) = internal(Pair(39, 2), name, href)
+        fun xiInitializerError(message: String) = internal(Pair(40, 1), message)
 
         fun xiCliInvalidValue(option: String, value: String) = internal(200, option, value)
         fun xiCliValueRequired(option: String) = internal(202, option)

--- a/xmlcalabash/src/main/resources/com/xmlcalabash/explain-errors.txt
+++ b/xmlcalabash/src/main/resources/com/xmlcalabash/explain-errors.txt
@@ -1363,6 +1363,9 @@ No steps in library (“$1”).
 cxerr:XI0039/2
 No step named “$1” in library (“$2”).
 
+cxerr:XI0040/1
+Initializer failed: $1
+
 cxerr:XI0200
 Invalid command line option: $1=$2.
 


### PR DESCRIPTION
This is analagous to the `-init:` option on Saxon itself.

TODO: add them to the XML Calabash configuration file, perhaps add them to pipelines?