### PR TITLE
Reworked how ‘empty’ steps are resolved

### DIFF
--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/PortBindingContainer.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/PortBindingContainer.kt
@@ -145,11 +145,11 @@ open class PortBindingContainer(parent: XProcInstruction, stepConfig: Instructio
                 }
                 sawEmpty = true
             } else {
-                newChildren.add(child as ConnectionInstruction)
                 if (sawEmpty) {
                     throw XProcError.xsEmptyNotAllowed().exception()
                 }
             }
+            newChildren.add(child as ConnectionInstruction)
         }
 
         _children.clear()

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/CompoundStepHead.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/CompoundStepHead.kt
@@ -19,7 +19,7 @@ import kotlin.collections.component2
 import kotlin.collections.iterator
 
 class CompoundStepHead(config: XProcStepConfiguration, step: HeadModel): AbstractStep(config, step) {
-    override val params = RuntimeStepParameters(NsCx.foot, "!head",
+    override val params = RuntimeStepParameters(NsCx.head, "!head",
         step.location, step.inputs, step.outputs, step.options)
     val defaultInputs = step.defaultInputs
     val openPorts = mutableSetOf<String>()


### PR DESCRIPTION
There was a bug when an manufactured cx:select step was bound to empty. I’ve fixed that by moving the code that resolves empty into the graph builder. It’s a bit dodgy around p:run, but p:run is weird.