### PR TITLE
Removed the dead API that supported access to in-scope bindings

### DIFF
--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/api/XProcStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/api/XProcStep.kt
@@ -12,7 +12,6 @@ interface XProcStep {
     fun extensionAttributes(attributes: Map<QName, String>)
 
     fun option(name: QName, binding: LazyValue)
-    fun inScopeBinding(name: QName, binding: LazyValue)
     fun input(port: String, doc: XProcDocument)
     fun run()
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/ExpressionEvaluator.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/ExpressionEvaluator.kt
@@ -22,13 +22,6 @@ class ExpressionEvaluator(val processor: Processor, val select: String) {
         variableBindings.putAll(bindings)
     }
 
-    fun setExpressionBindings(bindings: Map<QName, LazyValue>) {
-        variableBindings.clear()
-        for ((name, binding) in bindings) {
-            variableBindings[name] = binding.value;
-        }
-    }
-
     fun setContext(item: XdmItem) {
         contextItem = item
     }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/AbstractAtomicStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/AbstractAtomicStep.kt
@@ -70,10 +70,6 @@ abstract class AbstractAtomicStep(): XProcStep {
         _options[name] = binding
     }
 
-    override fun inScopeBinding(name: QName, binding: LazyValue) {
-        // you have to override this one if you want them
-    }
-
     override fun run() {
         stepConfig.environment.messageReporter.progress { "Running ${this} (${stepParams.stepName}/${nodeId})" }
         logger.debug { "Running ${this} (${stepParams.stepName}/${nodeId})" }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/FilterStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/FilterStep.kt
@@ -11,14 +11,9 @@ import net.sf.saxon.s9api.XdmItem
 
 class FilterStep(): AbstractAtomicStep() {
     lateinit var document: XProcDocument
-    val inScopeBindings = mutableMapOf<QName, LazyValue>()
 
     override fun input(port: String, doc: XProcDocument) {
         document = doc
-    }
-
-    override fun inScopeBinding(name: QName, binding: LazyValue) {
-        inScopeBindings[name] = binding
     }
 
     override fun run() {
@@ -27,7 +22,6 @@ class FilterStep(): AbstractAtomicStep() {
         val evaluator = ExpressionEvaluator(stepConfig.processor, stringBinding(Ns.select)!!)
         evaluator.setNamespaces(stepConfig.inscopeNamespaces)
         // FIXME: should only evaluate the bindings that are actually referenced...
-        evaluator.setExpressionBindings(inScopeBindings)
         evaluator.setContext(document.value as XdmItem)
         val value = evaluator.evaluate()
         for (doc in S9Api.makeDocuments(stepConfig, value)) {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/HttpRequestStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/HttpRequestStep.kt
@@ -18,7 +18,6 @@ import kotlin.math.floor
 
 open class HttpRequestStep(): AbstractAtomicStep() {
     val documents = mutableListOf<XProcDocument>()
-    val inScopeBindings = mutableMapOf<QName, LazyValue>()
 
     var href: URI = URI("https://xmlcalabash.com/not/used")
     var method = "GET"
@@ -50,10 +49,6 @@ open class HttpRequestStep(): AbstractAtomicStep() {
 
     override fun input(port: String, doc: XProcDocument) {
         documents.add(doc)
-    }
-
-    override fun inScopeBinding(name: QName, binding: LazyValue) {
-        inScopeBindings[name] = binding
     }
 
     override fun run() {
@@ -180,7 +175,6 @@ open class HttpRequestStep(): AbstractAtomicStep() {
         if (assert != "") {
             val evaluator = ExpressionEvaluator(stepConfig.processor, assert)
             evaluator.setNamespaces(stepConfig.inscopeNamespaces)
-            evaluator.setExpressionBindings(inScopeBindings)
             evaluator.setContext(response.report!!)
             val result = evaluator.evaluate()
             if (!result.underlyingValue.effectiveBooleanValue()) {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/internal/NullStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/internal/NullStep.kt
@@ -33,10 +33,6 @@ class NullStep(): XProcStep {
         throw RuntimeException("Configuration error: option called on null step")
     }
 
-    override fun inScopeBinding(name: QName, binding: LazyValue) {
-        throw RuntimeException("Configuration error: inScopeBinding called on null step")
-    }
-
     override fun run() {
         throw RuntimeException("Configuration error: run called on null step")
     }


### PR DESCRIPTION
There was a time when I thought that `p:filter` (and `assert` on `p:http-request`) could access any in-scope variable. I was mistaken. This PR pulls out the dead API that supported that.