### PR TITLE
Rewrote the API for getting inputs to atomic steps

### DIFF
--- a/ext/cache/src/main/kotlin/com/xmlcalabash/ext/cache/CacheAddStep.kt
+++ b/ext/cache/src/main/kotlin/com/xmlcalabash/ext/cache/CacheAddStep.kt
@@ -12,14 +12,11 @@ class CacheAddStep(): AbstractAtomicStep() {
     companion object {
         val failIfInCache = QName(NamespaceUri.NULL, "fail-if-in-cache")
     }
-    private lateinit var document: XProcDocument
-
-    override fun input(port: String, doc: XProcDocument) {
-        document = doc
-    }
 
     override fun run() {
         super.run()
+
+        val document = queues["source"]!!.first()
 
         val failIfCached = booleanBinding(failIfInCache)!!
         val href = uriBinding(Ns.href)

--- a/ext/cache/src/main/kotlin/com/xmlcalabash/ext/cache/CacheDeleteStep.kt
+++ b/ext/cache/src/main/kotlin/com/xmlcalabash/ext/cache/CacheDeleteStep.kt
@@ -12,15 +12,11 @@ class CacheDeleteStep(): AbstractAtomicStep() {
     companion object {
         val failIfNotInCache = QName(NamespaceUri.NULL, "fail-if-not-in-cache")
     }
-    private lateinit var document: XProcDocument
-
-    override fun input(port: String, doc: XProcDocument) {
-        document = doc
-    }
 
     override fun run() {
         super.run()
 
+        val document = queues["source"]!!.first()
         val failIfNotCached = booleanBinding(failIfNotInCache)!!
         val href = uriBinding(Ns.href)
 

--- a/ext/metadata-extractor/src/main/kotlin/com/xmlcalabash/ext/metadataextractor/MetadataExtractor.kt
+++ b/ext/metadata-extractor/src/main/kotlin/com/xmlcalabash/ext/metadataextractor/MetadataExtractor.kt
@@ -4,26 +4,19 @@ import com.xmlcalabash.documents.XProcDocument
 import com.xmlcalabash.namespace.Ns
 import com.xmlcalabash.steps.AbstractAtomicStep
 import net.sf.saxon.s9api.QName
-import net.sf.saxon.s9api.XdmValue
 
 class MetadataExtractor(): AbstractAtomicStep() {
     companion object {
         private val _assertMetadata = QName("assert-metadata")
     }
 
-    lateinit var document: XProcDocument
-    lateinit var properties: Map<QName, XdmValue>
-    var assertMetadata = false
-
-    override fun input(port: String, doc: XProcDocument) {
-        document = doc
-    }
-
     override fun run() {
         super.run()
 
-        properties = qnameMapBinding(Ns.properties)
-        assertMetadata = booleanBinding(_assertMetadata) ?: false
+        val document = queues["source"]!!.first()
+
+        val properties = qnameMapBinding(Ns.properties)
+        val assertMetadata = booleanBinding(_assertMetadata) ?: false
 
         val impl = MetadataExtractorImpl(stepConfig, document, properties)
 

--- a/ext/metadata-extractor/src/test/kotlin/SmokeTestMetadataExtractor.kt
+++ b/ext/metadata-extractor/src/test/kotlin/SmokeTestMetadataExtractor.kt
@@ -2,7 +2,6 @@ import com.xmlcalabash.config.XmlCalabash
 import com.xmlcalabash.documents.XProcDocument
 import com.xmlcalabash.util.BufferingReceiver
 import com.xmlcalabash.util.DefaultXmlCalabashConfiguration
-import net.sf.saxon.s9api.Processor
 import net.sf.saxon.s9api.QName
 import net.sf.saxon.s9api.XdmNode
 import org.junit.jupiter.api.Assertions
@@ -12,7 +11,7 @@ import java.io.File
 import java.net.URI
 import kotlin.collections.first
 
-class SmokeTest {
+class SmokeTestMetadataExtractor {
     private fun runPipeline(pipeline: URI, href: String? = null): XProcDocument {
         val config = DefaultXmlCalabashConfiguration()
         val calabash = XmlCalabash.newInstance(config)

--- a/ext/unique-id/src/main/kotlin/com/xmlcalabash/ext/uniqueid/UniqueIdStep.kt
+++ b/ext/unique-id/src/main/kotlin/com/xmlcalabash/ext/uniqueid/UniqueIdStep.kt
@@ -28,8 +28,6 @@ class UniqueIdStep(): AbstractAtomicStep(), ProcessMatchingNodes {
         private val _type = QName("type")
     }
 
-    private lateinit var document: XProcDocument
-
     var matchPattern = "/*"
     val parameters = mutableMapOf<QName, XdmValue>()
     var flavor = "uuid"
@@ -41,13 +39,10 @@ class UniqueIdStep(): AbstractAtomicStep(), ProcessMatchingNodes {
     val matcher: ProcessMatch
         get() = _matcher ?: throw RuntimeException("Configuration error...")
 
-    override fun input(port: String, doc: XProcDocument) {
-        document = doc
-    }
-
     override fun run() {
         super.run()
 
+        val document = queues["source"]!!.first()
         matchPattern = stringBinding(Ns.match)!!
         parameters.putAll(qnameMapBinding(Ns.parameters))
         flavor = stringBinding(_flavor) ?: "uuid"

--- a/ext/unique-id/src/test/kotlin/SmokeTestUniqueId.kt
+++ b/ext/unique-id/src/test/kotlin/SmokeTestUniqueId.kt
@@ -1,6 +1,4 @@
 import com.xmlcalabash.config.XmlCalabash
-import com.xmlcalabash.parsers.xpl.XplParser
-import com.xmlcalabash.runtime.XProcRuntime
 import com.xmlcalabash.util.BufferingReceiver
 import com.xmlcalabash.util.DefaultXmlCalabashConfiguration
 import org.junit.jupiter.api.Assertions.fail
@@ -8,7 +6,7 @@ import org.junit.jupiter.api.Test
 import java.io.File
 import kotlin.collections.first
 
-class SmokeTest {
+class SmokeTestUniqueId {
     @Test
     fun testUniqueId() {
         val config = DefaultXmlCalabashConfiguration()

--- a/ixml-coffeepress/src/main/kotlin/com/xmlcalabash/ext/coffeepress/CoffeePress.kt
+++ b/ixml-coffeepress/src/main/kotlin/com/xmlcalabash/ext/coffeepress/CoffeePress.kt
@@ -12,28 +12,18 @@ import org.nineml.coffeefilter.InvisibleXml
 import java.lang.IllegalArgumentException
 
 class CoffeePress(): AbstractAtomicStep() {
-    val grammar = mutableListOf<XProcDocument>()
-    lateinit var source: XProcDocument
-    lateinit var parameters: Map<QName, XdmValue>
-    var failOnError = true
-
-    override fun input(port: String, doc: XProcDocument) {
-        if (port == "source") {
-            source = doc
-        } else {
-            grammar.add(doc)
-        }
-    }
-
     override fun run() {
         super.run()
+
+        val source = queues["source"]!!.first()
+        val grammar = queues["grammar"]!!
 
         if (stepParams.stepType == NsP.ixml) {
             logger.info { "The step type p:ixml is deprecated, use p:invisible-xml instead" }
         }
 
-        failOnError = booleanBinding(Ns.failOnError) ?: true
-        parameters = qnameMapBinding(Ns.parameters)
+        val failOnError = booleanBinding(Ns.failOnError) != false
+        val parameters = qnameMapBinding(Ns.parameters)
 
         val invisibleXml = InvisibleXml()
         val parser = if (grammar.isNotEmpty()) {

--- a/ixml-coffeepress/src/test/kotlin/com/xmlcalabash/ixml/SmokeTestInvisibleXml.kt
+++ b/ixml-coffeepress/src/test/kotlin/com/xmlcalabash/ixml/SmokeTestInvisibleXml.kt
@@ -5,7 +5,7 @@ import com.xmlcalabash.util.BufferingReceiver
 import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Test
 
-class SmokeTest {
+class SmokeTestInvisibleXml {
     @Test
     fun testCoffeePress() {
         val calabash = XmlCalabash.newInstance()

--- a/paged-media/fop/src/test/kotlin/com/xmlcalabash/pagedmedia/SmokeTestFop.kt
+++ b/paged-media/fop/src/test/kotlin/com/xmlcalabash/pagedmedia/SmokeTestFop.kt
@@ -1,4 +1,4 @@
-package com.xmlcalabash.pagemedia
+package com.xmlcalabash.pagedmedia
 
 import com.xmlcalabash.config.XmlCalabash
 import com.xmlcalabash.datamodel.MediaType
@@ -9,19 +9,17 @@ import com.xmlcalabash.util.BufferingReceiver
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
 import java.io.File
 import java.io.FileOutputStream
 import java.net.URI
 
-class WeasySmokeTest {
+class SmokeTestFop {
     companion object {
         const val WRITE_OUTPUT = false
     }
 
     @Test
-    @EnabledIfEnvironmentVariable(named = "XMLCALABASH_TEST_WEASY", matches = "true")
-    fun testGenericCssFormatter() {
+    fun testGenericXslFormatter() {
         val managers = mutableListOf<PagedMediaManager>()
         for (provider in PagedMediaServiceProvider.providers()) {
             managers.add(provider.create())
@@ -29,21 +27,20 @@ class WeasySmokeTest {
         Assertions.assertTrue(managers.isNotEmpty())
         var xslManager: PagedMediaManager? = null
         for (manager in managers) {
-            if (manager.formatterAvailable(URI("https://xmlcalabash.com/paged-media/css-formatter"))) {
+            if (manager.formatterAvailable(URI("https://xmlcalabash.com/paged-media/xsl-formatter"))) {
                 xslManager = manager
                 break
             }
         }
 
         Assertions.assertNotNull(xslManager)
-        Assertions.assertTrue(xslManager!!.formatterAvailable(URI("https://xmlcalabash.com/paged-media/css-formatter/weasyprint")))
-        Assertions.assertTrue(xslManager.formatterAvailable(URI("https://xmlcalabash.com/paged-media/css-formatter")))
-        Assertions.assertFalse(xslManager.formatterAvailable(URI("https://xmlcalabash.com/paged-media/xsl-formatter")))
+        Assertions.assertTrue(xslManager!!.formatterAvailable(URI("https://xmlcalabash.com/paged-media/xsl-formatter/fop")))
+        Assertions.assertTrue(xslManager.formatterAvailable(URI("https://xmlcalabash.com/paged-media/xsl-formatter")))
+        Assertions.assertFalse(xslManager.formatterAvailable(URI("https://xmlcalabash.com/paged-media/css-formatter")))
     }
 
     @Test
-    @EnabledIfEnvironmentVariable(named = "XMLCALABASH_TEST_WEASY", matches = "true")
-    fun testWeasyprintCssFormatter() {
+    fun testFopXslFormatter() {
         val managers = mutableListOf<PagedMediaManager>()
         for (provider in PagedMediaServiceProvider.providers()) {
             managers.add(provider.create())
@@ -51,20 +48,19 @@ class WeasySmokeTest {
         Assertions.assertTrue(managers.isNotEmpty())
         var xslManager: PagedMediaManager? = null
         for (manager in managers) {
-            if (manager.formatterAvailable(URI("https://xmlcalabash.com/paged-media/css-formatter/weasyprint"))) {
+            if (manager.formatterAvailable(URI("https://xmlcalabash.com/paged-media/xsl-formatter/fop"))) {
                 xslManager = manager
                 break
             }
         }
 
         Assertions.assertNotNull(xslManager)
-        Assertions.assertTrue(xslManager!!.formatterAvailable(URI("https://xmlcalabash.com/paged-media/css-formatter/weasyprint")))
-        Assertions.assertTrue(xslManager.formatterAvailable(URI("https://xmlcalabash.com/paged-media/css-formatter")))
-        Assertions.assertFalse(xslManager.formatterAvailable(URI("https://xmlcalabash.com/paged-media/xsl-formatter")))
+        Assertions.assertTrue(xslManager!!.formatterAvailable(URI("https://xmlcalabash.com/paged-media/xsl-formatter/fop")))
+        Assertions.assertTrue(xslManager.formatterAvailable(URI("https://xmlcalabash.com/paged-media/xsl-formatter")))
+        Assertions.assertFalse(xslManager.formatterAvailable(URI("https://xmlcalabash.com/paged-media/css-formatter")))
     }
 
     @Test
-    @EnabledIfEnvironmentVariable(named = "XMLCALABASH_TEST_WEASY", matches = "true")
     fun testFormatter() {
         val calabash = XmlCalabash.newInstance()
         val parser = calabash.newXProcParser()
@@ -77,7 +73,6 @@ class WeasySmokeTest {
         try {
             exec.run()
         } catch (ex: Exception) {
-            ex.printStackTrace()
             fail()
         }
 
@@ -85,7 +80,7 @@ class WeasySmokeTest {
         Assertions.assertEquals(MediaType.PDF, result.contentType)
 
         if (WRITE_OUTPUT) {
-            val out = FileOutputStream(File("/tmp/out.pdf"))
+            val out = FileOutputStream(File("/tmp/envelope.pdf"))
             out.write((result as XProcBinaryDocument).binaryValue)
             out.close()
         }

--- a/paged-media/prince/src/test/kotlin/com/xmlcalabash/pagedmedia/SmokeTestPrince.kt
+++ b/paged-media/prince/src/test/kotlin/com/xmlcalabash/pagedmedia/SmokeTestPrince.kt
@@ -9,17 +9,19 @@ import com.xmlcalabash.util.BufferingReceiver
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
 import java.io.File
 import java.io.FileOutputStream
 import java.net.URI
 
-class FopSmokeTest {
+class SmokeTestPrince {
     companion object {
         const val WRITE_OUTPUT = false
     }
 
     @Test
-    fun testGenericXslFormatter() {
+    @EnabledIfEnvironmentVariable(named = "XMLCALABASH_TEST_PRINCE", matches = "true")
+    fun testGenericCssFormatter() {
         val managers = mutableListOf<PagedMediaManager>()
         for (provider in PagedMediaServiceProvider.providers()) {
             managers.add(provider.create())
@@ -27,20 +29,21 @@ class FopSmokeTest {
         Assertions.assertTrue(managers.isNotEmpty())
         var xslManager: PagedMediaManager? = null
         for (manager in managers) {
-            if (manager.formatterAvailable(URI("https://xmlcalabash.com/paged-media/xsl-formatter"))) {
+            if (manager.formatterAvailable(URI("https://xmlcalabash.com/paged-media/css-formatter"))) {
                 xslManager = manager
                 break
             }
         }
 
         Assertions.assertNotNull(xslManager)
-        Assertions.assertTrue(xslManager!!.formatterAvailable(URI("https://xmlcalabash.com/paged-media/xsl-formatter/fop")))
-        Assertions.assertTrue(xslManager.formatterAvailable(URI("https://xmlcalabash.com/paged-media/xsl-formatter")))
-        Assertions.assertFalse(xslManager.formatterAvailable(URI("https://xmlcalabash.com/paged-media/css-formatter")))
+        Assertions.assertTrue(xslManager!!.formatterAvailable(URI("https://xmlcalabash.com/paged-media/css-formatter/prince")))
+        Assertions.assertTrue(xslManager.formatterAvailable(URI("https://xmlcalabash.com/paged-media/css-formatter")))
+        Assertions.assertFalse(xslManager.formatterAvailable(URI("https://xmlcalabash.com/paged-media/xsl-formatter")))
     }
 
     @Test
-    fun testFopXslFormatter() {
+    @EnabledIfEnvironmentVariable(named = "XMLCALABASH_TEST_PRINCE", matches = "true")
+    fun testPrinceCssFormatter() {
         val managers = mutableListOf<PagedMediaManager>()
         for (provider in PagedMediaServiceProvider.providers()) {
             managers.add(provider.create())
@@ -48,19 +51,20 @@ class FopSmokeTest {
         Assertions.assertTrue(managers.isNotEmpty())
         var xslManager: PagedMediaManager? = null
         for (manager in managers) {
-            if (manager.formatterAvailable(URI("https://xmlcalabash.com/paged-media/xsl-formatter/fop"))) {
+            if (manager.formatterAvailable(URI("https://xmlcalabash.com/paged-media/css-formatter/prince"))) {
                 xslManager = manager
                 break
             }
         }
 
         Assertions.assertNotNull(xslManager)
-        Assertions.assertTrue(xslManager!!.formatterAvailable(URI("https://xmlcalabash.com/paged-media/xsl-formatter/fop")))
-        Assertions.assertTrue(xslManager.formatterAvailable(URI("https://xmlcalabash.com/paged-media/xsl-formatter")))
-        Assertions.assertFalse(xslManager.formatterAvailable(URI("https://xmlcalabash.com/paged-media/css-formatter")))
+        Assertions.assertTrue(xslManager!!.formatterAvailable(URI("https://xmlcalabash.com/paged-media/css-formatter/prince")))
+        Assertions.assertTrue(xslManager.formatterAvailable(URI("https://xmlcalabash.com/paged-media/css-formatter")))
+        Assertions.assertFalse(xslManager.formatterAvailable(URI("https://xmlcalabash.com/paged-media/xsl-formatter")))
     }
 
     @Test
+    @EnabledIfEnvironmentVariable(named = "XMLCALABASH_TEST_PRINCE", matches = "true")
     fun testFormatter() {
         val calabash = XmlCalabash.newInstance()
         val parser = calabash.newXProcParser()
@@ -80,7 +84,7 @@ class FopSmokeTest {
         Assertions.assertEquals(MediaType.PDF, result.contentType)
 
         if (WRITE_OUTPUT) {
-            val out = FileOutputStream(File("/tmp/envelope.pdf"))
+            val out = FileOutputStream(File("/tmp/out.pdf"))
             out.write((result as XProcBinaryDocument).binaryValue)
             out.close()
         }

--- a/paged-media/weasyprint/src/test/kotlin/com/xmlcalabash/pagemedia/SmokeTestWeasyPrint.kt
+++ b/paged-media/weasyprint/src/test/kotlin/com/xmlcalabash/pagemedia/SmokeTestWeasyPrint.kt
@@ -1,4 +1,4 @@
-package com.xmlcalabash.pagedmedia
+package com.xmlcalabash.pagemedia
 
 import com.xmlcalabash.config.XmlCalabash
 import com.xmlcalabash.datamodel.MediaType
@@ -14,13 +14,13 @@ import java.io.File
 import java.io.FileOutputStream
 import java.net.URI
 
-class PrinceSmokeTest {
+class SmokeTestWeasyPrint {
     companion object {
         const val WRITE_OUTPUT = false
     }
 
     @Test
-    @EnabledIfEnvironmentVariable(named = "XMLCALABASH_TEST_PRINCE", matches = "true")
+    @EnabledIfEnvironmentVariable(named = "XMLCALABASH_TEST_WEASY", matches = "true")
     fun testGenericCssFormatter() {
         val managers = mutableListOf<PagedMediaManager>()
         for (provider in PagedMediaServiceProvider.providers()) {
@@ -36,14 +36,14 @@ class PrinceSmokeTest {
         }
 
         Assertions.assertNotNull(xslManager)
-        Assertions.assertTrue(xslManager!!.formatterAvailable(URI("https://xmlcalabash.com/paged-media/css-formatter/prince")))
+        Assertions.assertTrue(xslManager!!.formatterAvailable(URI("https://xmlcalabash.com/paged-media/css-formatter/weasyprint")))
         Assertions.assertTrue(xslManager.formatterAvailable(URI("https://xmlcalabash.com/paged-media/css-formatter")))
         Assertions.assertFalse(xslManager.formatterAvailable(URI("https://xmlcalabash.com/paged-media/xsl-formatter")))
     }
 
     @Test
-    @EnabledIfEnvironmentVariable(named = "XMLCALABASH_TEST_PRINCE", matches = "true")
-    fun testPrinceCssFormatter() {
+    @EnabledIfEnvironmentVariable(named = "XMLCALABASH_TEST_WEASY", matches = "true")
+    fun testWeasyprintCssFormatter() {
         val managers = mutableListOf<PagedMediaManager>()
         for (provider in PagedMediaServiceProvider.providers()) {
             managers.add(provider.create())
@@ -51,20 +51,20 @@ class PrinceSmokeTest {
         Assertions.assertTrue(managers.isNotEmpty())
         var xslManager: PagedMediaManager? = null
         for (manager in managers) {
-            if (manager.formatterAvailable(URI("https://xmlcalabash.com/paged-media/css-formatter/prince"))) {
+            if (manager.formatterAvailable(URI("https://xmlcalabash.com/paged-media/css-formatter/weasyprint"))) {
                 xslManager = manager
                 break
             }
         }
 
         Assertions.assertNotNull(xslManager)
-        Assertions.assertTrue(xslManager!!.formatterAvailable(URI("https://xmlcalabash.com/paged-media/css-formatter/prince")))
+        Assertions.assertTrue(xslManager!!.formatterAvailable(URI("https://xmlcalabash.com/paged-media/css-formatter/weasyprint")))
         Assertions.assertTrue(xslManager.formatterAvailable(URI("https://xmlcalabash.com/paged-media/css-formatter")))
         Assertions.assertFalse(xslManager.formatterAvailable(URI("https://xmlcalabash.com/paged-media/xsl-formatter")))
     }
 
     @Test
-    @EnabledIfEnvironmentVariable(named = "XMLCALABASH_TEST_PRINCE", matches = "true")
+    @EnabledIfEnvironmentVariable(named = "XMLCALABASH_TEST_WEASY", matches = "true")
     fun testFormatter() {
         val calabash = XmlCalabash.newInstance()
         val parser = calabash.newXProcParser()
@@ -77,6 +77,7 @@ class PrinceSmokeTest {
         try {
             exec.run()
         } catch (ex: Exception) {
+            ex.printStackTrace()
             fail()
         }
 

--- a/send-mail/src/main/kotlin/com/xmlcalabash/ext/sendmail/SendMail.kt
+++ b/send-mail/src/main/kotlin/com/xmlcalabash/ext/sendmail/SendMail.kt
@@ -58,13 +58,10 @@ class SendMail(): AbstractAtomicStep() {
         sendmail = stepConfig.saxonConfig.xmlCalabash.xmlCalabashConfig.sendmail
     }
 
-    override fun input(port: String, doc: XProcDocument) {
-        sources.add(doc)
-    }
-
     override fun run() {
         super.run()
 
+        sources.addAll(queues["source"]!!)
         val parameters = qnameMapBinding(Ns.parameters)
         serialization = qnameMapBinding(Ns.serialization)
         auth = qnameMapBinding(Ns.serialization)

--- a/send-mail/src/test/kotlin/com/xmlcalabash/sendmail/SmokeTestSendMail.kt
+++ b/send-mail/src/test/kotlin/com/xmlcalabash/sendmail/SmokeTestSendMail.kt
@@ -13,7 +13,7 @@ import java.net.URL
 // These tests require the Sendria server to be standing up.
 // They also require single-threaded execution.
 
-class SmokeTest {
+class SmokeTestSendMail {
     companion object {
         private val url = URL("http://localhost:1080/api/messages/")
     }

--- a/template/java/src/main/java/com/xmlcalabash/ext/templatejava/TemplateJava.java
+++ b/template/java/src/main/java/com/xmlcalabash/ext/templatejava/TemplateJava.java
@@ -1,6 +1,5 @@
 package com.xmlcalabash.ext.templatejava;
 
-
 import com.xmlcalabash.datamodel.MediaType;
 import com.xmlcalabash.documents.XProcBinaryDocument;
 import com.xmlcalabash.documents.XProcDocument;
@@ -13,41 +12,40 @@ import net.sf.saxon.s9api.XdmNode;
 import org.jetbrains.annotations.NotNull;
 
 public class TemplateJava extends AbstractAtomicStep {
-    private int binary = 0;
-    private int byteCount = 0;
-    private int markup = 0;
-    private int json = 0;
-    private int text = 0;
-    private int lineCount = 0;
-    private int unknown = 0;
-
-    @Override
-    public void input(@NotNull String port, @NotNull XProcDocument doc) {
-        if (doc instanceof XProcBinaryDocument) {
-            binary++;
-            byteCount += ((XProcBinaryDocument) doc).getBinaryValue().length;
-        } else {
-            MediaType ct = doc.getContentType();
-            if (ct == null) {
-                unknown++;
-            } else {
-                if (ct.xmlContentType() || ct.htmlContentType()) {
-                    markup++;
-                } else if (ct.textContentType()) {
-                    text++;
-                    lineCount += ((XdmNode) doc.getValue()).getStringValue().split("\\n").length;
-                } else if (ct.jsonContentType()) {
-                    json++;
-                } else {
-                    unknown++;
-                }
-            }
-        }
-    }
-
     @Override
     public void run() {
         super.run();
+
+        int binary = 0;
+        int byteCount = 0;
+        int markup = 0;
+        int json = 0;
+        int text = 0;
+        int lineCount = 0;
+        int unknown = 0;
+
+        for (XProcDocument doc : getQueues().get("source")) {
+            if (doc instanceof XProcBinaryDocument) {
+                binary++;
+                byteCount += ((XProcBinaryDocument) doc).getBinaryValue().length;
+            } else {
+                MediaType ct = doc.getContentType();
+                if (ct == null) {
+                    unknown++;
+                } else {
+                    if (ct.xmlContentType() || ct.htmlContentType()) {
+                        markup++;
+                    } else if (ct.textContentType()) {
+                        text++;
+                        lineCount += ((XdmNode) doc.getValue()).getStringValue().split("\\n").length;
+                    } else if (ct.jsonContentType()) {
+                        json++;
+                    } else {
+                        unknown++;
+                    }
+                }
+            }
+        }
 
         XProcStepConfiguration stepConfig = getStepConfig();
         SaxonTreeBuilder builder = new SaxonTreeBuilder(stepConfig);
@@ -84,14 +82,7 @@ public class TemplateJava extends AbstractAtomicStep {
     }
 
     @Override
-    public void reset() {
-        super.reset();
-        binary = 0;
-        byteCount = 0;
-        markup = 0;
-        json = 0;
-        text = 0;
-        lineCount = 0;
-        unknown = 0;
+    public String toString() {
+        return "cx:template-java";
     }
 }

--- a/template/kotlin/src/main/kotlin/com/xmlcalabash/ext/templatekotlin/TemplateKotlin.kt
+++ b/template/kotlin/src/main/kotlin/com/xmlcalabash/ext/templatekotlin/TemplateKotlin.kt
@@ -8,41 +8,44 @@ import com.xmlcalabash.util.SaxonTreeBuilder
 import com.xmlcalabash.util.XAttributeMap
 import net.sf.saxon.s9api.QName
 import net.sf.saxon.s9api.XdmNode
+import kotlin.collections.plusAssign
+import kotlin.inc
 
 class TemplateKotlin(): AbstractAtomicStep() {
-    private var binary = 0
-    private var byteCount = 0
-    private var markup = 0
-    private var json = 0
-    private var text = 0
-    private var lineCount = 0
-    private var unknown = 0
+    override fun run() {
+        super.run()
 
-    override fun input(port: String, doc: XProcDocument) {
-        if (doc is XProcBinaryDocument) {
-            binary++
-            byteCount += doc.binaryValue.size
-        } else {
-            val ct = doc.contentType
-            if (ct == null) {
-                unknown++
+        var binary = 0
+        var byteCount = 0
+        var markup = 0
+        var json = 0
+        var text = 0
+        var lineCount = 0
+        var unknown = 0
+
+        for (doc in queues["source"]!!) {
+            if (doc is XProcBinaryDocument) {
+                binary++
+                byteCount += doc.binaryValue.size
             } else {
-                if (ct.xmlContentType() || ct.htmlContentType()) {
-                    markup++
-                } else if (ct.textContentType()) {
-                    text++
-                    lineCount += (doc.value as XdmNode).stringValue.split("\n").size
-                } else if (ct.jsonContentType()) {
-                    json++
-                } else {
+                val ct = doc.contentType
+                if (ct == null) {
                     unknown++
+                } else {
+                    if (ct.xmlContentType() || ct.htmlContentType()) {
+                        markup++
+                    } else if (ct.textContentType()) {
+                        text++
+                        lineCount += (doc.value as XdmNode).stringValue.split("\n").size
+                    } else if (ct.jsonContentType()) {
+                        json++
+                    } else {
+                        unknown++
+                    }
                 }
             }
         }
-    }
 
-    override fun run() {
-        super.run()
 
         val builder = SaxonTreeBuilder(stepConfig)
         builder.startDocument(stepConfig.baseUri)
@@ -75,17 +78,6 @@ class TemplateKotlin(): AbstractAtomicStep() {
         builder.addEndElement()
         builder.endDocument()
         receiver.output("result", ofXml(builder.result, stepConfig))
-    }
-
-    override fun reset() {
-        super.reset()
-        binary = 0
-        byteCount = 0
-        markup = 0
-        json = 0
-        text = 0
-        lineCount = 0
-        unknown = 0
     }
 
     override fun toString(): String = "cx:template-kotlin"

--- a/template/kotlin/src/test/kotlin/SmokeTestTemplate.kt
+++ b/template/kotlin/src/test/kotlin/SmokeTestTemplate.kt
@@ -3,7 +3,7 @@ import com.xmlcalabash.util.BufferingReceiver
 import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Test
 
-class SmokeTest {
+class SmokeTestTemplate {
     @Test
     fun testTemplate() {
         val calabash = XmlCalabash.newInstance()

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/XProcPipeline.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/XProcPipeline.kt
@@ -108,6 +108,7 @@ class XProcPipeline internal constructor(pipeline: CompoundStepModel, val config
         override fun input(port: String, doc: XProcDocument) {
             receiver.output(port, doc)
         }
+
         override fun close(port: String) {
             // nop
         }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/AbstractStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/AbstractStep.kt
@@ -13,6 +13,7 @@ import com.xmlcalabash.runtime.model.StepModel
 import com.xmlcalabash.runtime.parameters.DocumentStepParameters
 import com.xmlcalabash.runtime.parameters.InlineStepParameters
 import com.xmlcalabash.runtime.parameters.RuntimeStepParameters
+import com.xmlcalabash.steps.AbstractAtomicStep
 import com.xmlcalabash.steps.internal.DocumentStep
 import com.xmlcalabash.steps.internal.InlineStep
 import com.xmlcalabash.util.BufferingReceiver
@@ -145,8 +146,10 @@ abstract class AbstractStep(val stepConfig: XProcStepConfiguration, step: StepMo
         when (binding) {
             is InlineInstruction -> {
                 val inlineReceiver = BufferingReceiver()
+                val source = RuntimePort("source", false, true, emptyList())
+                val result = RuntimePort("result", false, false, emptyList())
                 val inlineStepParams = InlineStepParameters("!inline", binding.stepConfig.location,
-                    emptyMap(), emptyMap(), emptyMap(), binding.valueTemplateFilter, binding.contentType, binding.encoding)
+                    mapOf("source" to source), mapOf("result" to result), emptyMap(), binding.valueTemplateFilter, binding.contentType, binding.encoding)
                 val inlineStep = InlineStep(inlineStepParams)
                 inlineStep.setup(binding.stepConfig, inlineReceiver, inlineStepParams)
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/AtomicStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/AtomicStep.kt
@@ -79,7 +79,6 @@ open class AtomicStep(config: XProcStepConfiguration, atomic: AtomicBuiltinStepM
         val targetPort = rpair.second
 
         stepConfig.environment.traceListener.sendDocument(Pair(id,port), Pair(targetStep.id, targetPort), document)
-
         targetStep.input(targetPort, document)
     }
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/AbstractTextStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/AbstractTextStep.kt
@@ -12,17 +12,11 @@ import java.net.URI
 import java.nio.charset.StandardCharsets
 
 abstract class AbstractTextStep(): AbstractAtomicStep() {
-    lateinit var source: XProcDocument
-
-    override fun input(port: String, doc: XProcDocument) {
-        source = doc
-    }
-
-    fun text(doc: XProcDocument = source): String {
+    fun text(doc: XProcDocument): String {
         return S9Api.textContent(doc)
     }
 
-    fun textLines(doc: XProcDocument = source): List<String> {
+    fun textLines(doc: XProcDocument): List<String> {
         var text = text(doc)
 
         text = text.replace("\r\n", "\n")

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/AddAttributeStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/AddAttributeStep.kt
@@ -22,12 +22,9 @@ class AddAttributeStep(): AbstractAtomicStep(), ProcessMatchingNodes {
     val matcher: ProcessMatch
         get() = _matcher ?: throw RuntimeException("Configuration error...")
 
-    override fun input(port: String, doc: XProcDocument) {
-        document = doc
-    }
-
     override fun run() {
         super.run()
+        document = queues["source"]!!.first()
 
         attName = qnameBinding(Ns.attributeName)!!
         forbidNamespaceAttribute(attName)

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/AddXmlBaseStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/AddXmlBaseStep.kt
@@ -24,12 +24,9 @@ class AddXmlBaseStep(): AbstractAtomicStep(), ProcessMatchingNodes {
     val matcher: ProcessMatch
         get() = _matcher ?: throw RuntimeException("Configuration error...")
 
-    override fun input(port: String, doc: XProcDocument) {
-        document = doc
-    }
-
     override fun run() {
         super.run()
+        document = queues["source"]!!.first()
 
         all = booleanBinding(Ns.all) ?: false
         relative = booleanBinding(Ns.relative) ?: true

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/ArchiveManifestStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/ArchiveManifestStep.kt
@@ -36,12 +36,9 @@ open class ArchiveManifestStep(): AbstractArchiveStep() {
     private lateinit var relativeTo: URI
     private lateinit var parameters: Map<QName, XdmValue>
 
-    override fun input(port: String, doc: XProcDocument) {
-        archives.add(doc)
-    }
-
     override fun run() {
         super.run()
+        archives.addAll(queues["source"]!!)
 
         val archive = archives.first()
         val format = qnameBinding(Ns.format) ?: Ns.zip

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/ArchiveStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/ArchiveStep.kt
@@ -39,21 +39,14 @@ open class ArchiveStep(): AbstractArchiveStep() {
     private var origArchiveFiles = mutableListOf<Path>()
     private var archiveFile: Path? = null
 
-    override fun input(port: String, doc: XProcDocument) {
-        when (port) {
-            "source" -> archiveMembers.add(doc)
-            "manifest" -> {
-                if (manifest != null) {
-                    throw stepConfig.exception(XProcError.xcMultipleManifests())
-                }
-                manifest = doc
-            }
-            "archive" -> archives.add(doc)
-        }
-    }
-
     override fun run() {
         super.run()
+        archiveMembers.addAll(queues["source"]!!)
+        archives.addAll(queues["archive"]!!)
+        if (queues["manifest"]!!.size > 1) {
+            throw stepConfig.exception(XProcError.xcMultipleManifests())
+        }
+        manifest = queues["manifest"]!!.firstOrNull()
 
         val format = qnameBinding(Ns.format) ?: Ns.zip
         val relativeTo = relativeTo()

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/CastContentTypeStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/CastContentTypeStep.kt
@@ -22,12 +22,9 @@ open class CastContentTypeStep(): AbstractAtomicStep() {
     var contentType = MediaType.ANY
     var parameters = mapOf<QName,XdmValue>()
 
-    override fun input(port: String, doc: XProcDocument) {
-        document = doc
-    }
-
     override fun run() {
         super.run()
+        document = queues["source"]!!.first()
 
         docContentType = document.contentType ?: MediaType.OCTET_STREAM
         contentType = mediaTypeBinding(Ns.contentType)

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/CompareStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/CompareStep.kt
@@ -19,15 +19,10 @@ open class CompareStep(): AbstractAtomicStep() {
     var failIfNotEqual = false
     var differences = mutableListOf<String>()
 
-    override fun input(port: String, doc: XProcDocument) {
-        when (port) {
-            "source" -> source = doc
-            "alternate" -> alternate = doc
-        }
-    }
-
     override fun run() {
         super.run()
+        source = queues["source"]!!.first()
+        alternate = queues["alternate"]!!.first()
 
         val method = qnameBinding(Ns.method) ?: Ns.deepEqual
         failIfNotEqual = booleanBinding(Ns.failIfNotEqual) ?: false

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/CompressStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/CompressStep.kt
@@ -25,19 +25,14 @@ import java.io.FileOutputStream
 import java.net.URI
 
 open class CompressStep(): AbstractAtomicStep() {
-    var document: XProcDocument? = null
-
-    override fun input(port: String, doc: XProcDocument) {
-        document = doc
-    }
-
     override fun run() {
         super.run()
+        val document = queues["source"]!!.first()
 
         val parameters = qnameMapBinding(Ns.parameters)
         val serialization = qnameMapBinding(Ns.serialization)
 
-        val doc = document!!
+        val doc = document
         val format = qnameBinding(Ns.format) ?: Ns.gzip
 
         val bytes = if (doc.value.underlyingValue is HexBinaryValue) {
@@ -70,12 +65,6 @@ open class CompressStep(): AbstractAtomicStep() {
         properties[Ns.contentType] = "application/${format.localName}"
 
         receiver.output("result", XProcDocument.ofBinary(baos.toByteArray(), stepConfig, properties))
-    }
-
-    private fun storeXml(href: URI, serialization: Map<QName,XdmValue>) {
-        val outputFile = FileOutputStream(href.path)
-        val serializer = XProcSerializer(stepConfig)
-        serializer.write(document!!, outputFile)
     }
 
     override fun toString(): String = "p:store"

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/CountStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/CountStep.kt
@@ -10,15 +10,10 @@ import kotlin.math.max
 import kotlin.math.min
 
 class CountStep(): AbstractAtomicStep() {
-    private var count = 0
-
-    override fun input(port: String, doc: XProcDocument) {
-        count++
-    }
-
     override fun run() {
         super.run()
 
+        val count = queues["source"]!!.size
         val limit = max(integerBinding(Ns.limit) ?: 0, 0)
         val reportedCount = if (limit == 0) {
             count
@@ -34,5 +29,5 @@ class CountStep(): AbstractAtomicStep() {
         receiver.output("result", XProcDocument.ofXml(xdm, stepConfig))
     }
 
-    override fun toString(): String = "p:count (${count})"
+    override fun toString(): String = "p:count"
 }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/CssFormatterStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/CssFormatterStep.kt
@@ -28,16 +28,10 @@ open class CssFormatterStep(): AbstractAtomicStep() {
         extensionAttributes.putAll(attributes)
     }
 
-    override fun input(port: String, doc: XProcDocument) {
-        if (port == "source") {
-            document = doc
-        } else {
-            stylesheets.add(doc)
-        }
-    }
-
     override fun run() {
         super.run()
+        document = queues["source"]!!.first()
+        stylesheets.addAll(queues["stylesheet"]!!)
 
         val contentType = mediaTypeBinding(Ns.contentType, MediaType.PDF)
         val parameters = qnameMapBinding(Ns.parameters)

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/DeleteStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/DeleteStep.kt
@@ -15,19 +15,15 @@ import net.sf.saxon.s9api.XdmNode
 import net.sf.saxon.s9api.XdmValue
 
 class DeleteStep(): AbstractAtomicStep(), ProcessMatchingNodes {
-    lateinit var document: XProcDocument
     var pattern = ""
     var _matcher: ProcessMatch? = null
     val matcher: ProcessMatch
         get() = _matcher ?: throw RuntimeException("Configuration error...")
 
-    override fun input(port: String, doc: XProcDocument) {
-        document = doc
-    }
-
     override fun run() {
         super.run()
 
+        val document = queues["source"]!!.first()
         pattern = stringBinding(Ns.match)!!
         _matcher = ProcessMatch(stepConfig, this, valueBinding(Ns.match).context.inscopeNamespaces)
         matcher.process(document.value as XdmNode, pattern)

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/ErrorStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/ErrorStep.kt
@@ -15,15 +15,10 @@ import net.sf.saxon.s9api.QName
 import net.sf.saxon.value.QNameValue
 
 class ErrorStep(): AbstractAtomicStep() {
-    private var document: XProcDocument? = null
-
-    override fun input(port: String, doc: XProcDocument) {
-        document = doc
-    }
-
     override fun run() {
         super.run()
 
+        val document = queues["source"]!!.firstOrNull()
         val value = options[Ns.code]!!.value.underlyingValue
         val code = when (value) {
             is QName -> value
@@ -70,12 +65,12 @@ class ErrorStep(): AbstractAtomicStep() {
         val builder = SaxonTreeBuilder(stepConfig)
         builder.startDocument(stepConfig.baseUri)
         if (document != null) {
-            builder.addSubtree(document!!.value)
+            builder.addSubtree(document.value)
         }
         builder.endDocument()
 
         val location = if (document != null) {
-            Location(document!!)
+            Location(document)
         } else {
             Location.NULL
         }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/FilterStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/FilterStep.kt
@@ -1,23 +1,15 @@
 package com.xmlcalabash.steps
 
-import com.xmlcalabash.datamodel.XProcExpression
-import com.xmlcalabash.documents.XProcDocument
 import com.xmlcalabash.namespace.Ns
 import com.xmlcalabash.runtime.ExpressionEvaluator
-import com.xmlcalabash.runtime.LazyValue
 import com.xmlcalabash.util.S9Api
-import net.sf.saxon.s9api.QName
 import net.sf.saxon.s9api.XdmItem
 
 class FilterStep(): AbstractAtomicStep() {
-    lateinit var document: XProcDocument
-
-    override fun input(port: String, doc: XProcDocument) {
-        document = doc
-    }
-
     override fun run() {
         super.run()
+
+        val document = queues["source"]!!.first()
 
         val evaluator = ExpressionEvaluator(stepConfig.processor, stringBinding(Ns.select)!!)
         evaluator.setNamespaces(stepConfig.inscopeNamespaces)

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/HashStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/HashStep.kt
@@ -1,16 +1,13 @@
 package com.xmlcalabash.steps
 
-import com.xmlcalabash.documents.XProcDocument
 import com.xmlcalabash.exceptions.XProcError
 import com.xmlcalabash.exceptions.XProcException
 import com.xmlcalabash.namespace.Ns
 import com.xmlcalabash.namespace.NsCx
 import com.xmlcalabash.runtime.ProcessMatch
 import com.xmlcalabash.runtime.ProcessMatchingNodes
-import com.xmlcalabash.runtime.parameters.StepParameters
 import com.xmlcalabash.util.HashUtils
 import net.sf.saxon.om.AttributeMap
-import net.sf.saxon.om.EmptyAttributeMap
 import net.sf.saxon.s9api.QName
 import net.sf.saxon.s9api.XdmNode
 import net.sf.saxon.s9api.XdmValue
@@ -18,13 +15,10 @@ import net.sf.saxon.s9api.XdmValue
 open class HashStep(): AbstractAtomicStep(), ProcessMatchingNodes {
     companion object {
         private val _key = QName("key")
-        private val _context = QName("context")
         private val _sharedSecret = QName("shared-secret")
         private val _senderId = QName("sender-id")
         private val _recipientId = QName("recipient-id")
     }
-
-    lateinit var document: XProcDocument
 
     var value: ByteArray = byteArrayOf()
     var algorithm = NsCx.unusedValue
@@ -37,13 +31,10 @@ open class HashStep(): AbstractAtomicStep(), ProcessMatchingNodes {
     val matcher: ProcessMatch
         get() = _matcher ?: throw RuntimeException("Configuration error...")
 
-    override fun input(port: String, doc: XProcDocument) {
-        document = doc
-    }
-
     override fun run() {
         super.run()
 
+        val document = queues["source"]!!.first()
         matchPattern = stringBinding(Ns.match)!!
         value = stringBinding(Ns.value)!!.toByteArray()
         algorithm = qnameBinding(Ns.algorithm)!!

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/HttpRequestStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/HttpRequestStep.kt
@@ -47,12 +47,9 @@ open class HttpRequestStep(): AbstractAtomicStep() {
     private var authmethod: String? = null
     private var sendauth = false
 
-    override fun input(port: String, doc: XProcDocument) {
-        documents.add(doc)
-    }
-
     override fun run() {
         super.run()
+        documents.addAll(queues["source"]!!)
 
         href = uriBinding(Ns.href)!!
         method = stringBinding(Ns.method)!!

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/IdentityStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/IdentityStep.kt
@@ -1,27 +1,15 @@
 package com.xmlcalabash.steps
 
-import com.xmlcalabash.documents.XProcDocument
-
 open class IdentityStep(): AbstractAtomicStep() {
-    val cache = mutableListOf<XProcDocument>()
-
-    // In principle, input() can just immediately send the output to the receiver.
-    // But in practice, it's easier to understand the runtime behavior of the
-    // pipeline if we cache and then send them when the step actually runs.
-    override fun input(port: String, doc: XProcDocument) {
-        cache.add(doc)
-    }
-
     override fun run() {
         super.run()
-        while (cache.isNotEmpty()) {
-            receiver.output("result", cache.removeFirst());
+        for (doc in queues["source"]!!) {
+            receiver.output("result", doc)
         }
     }
 
     override fun reset() {
         super.reset()
-        cache.clear()
     }
 
     override fun toString(): String = "p:identity"

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/InsertStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/InsertStep.kt
@@ -19,7 +19,6 @@ class InsertStep(): AbstractAtomicStep(), ProcessMatchingNodes {
         private const val AFTER = "after"
     }
 
-    var document: XProcDocument? = null
     var insertions = mutableListOf<XProcDocument>()
     var pattern = ""
     var position = AFTER
@@ -27,27 +26,21 @@ class InsertStep(): AbstractAtomicStep(), ProcessMatchingNodes {
     val matcher: ProcessMatch
         get() = _matcher ?: throw RuntimeException("Configuration error...")
 
-    override fun input(port: String, doc: XProcDocument) {
-        if (port == "source") {
-            document = doc
-        } else {
-            insertions.add(doc)
-        }
-    }
-
     override fun run() {
         super.run()
+
+        val document = queues["source"]!!.first()
+        insertions.addAll(queues["insertion"]!!)
 
         pattern = stringBinding(Ns.match)!!
         position = stringBinding(Ns.position)!!
         _matcher = ProcessMatch(stepConfig, this, valueBinding(Ns.match).context.inscopeNamespaces)
-        matcher.process(document!!.value as XdmNode, pattern)
-        receiver.output("result", XProcDocument.ofXml(matcher.result, stepConfig, document!!.properties))
+        matcher.process(document.value as XdmNode, pattern)
+        receiver.output("result", XProcDocument.ofXml(matcher.result, stepConfig, document.properties))
     }
 
     override fun reset() {
         super.reset()
-        document = null
         insertions.clear()
     }
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/JsonJoinStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/JsonJoinStep.kt
@@ -3,22 +3,16 @@ package com.xmlcalabash.steps
 import com.xmlcalabash.documents.XProcDocument
 import com.xmlcalabash.exceptions.XProcError
 import com.xmlcalabash.namespace.Ns
-import com.xmlcalabash.util.S9Api
 import net.sf.saxon.s9api.XdmArray
 import net.sf.saxon.s9api.XdmAtomicValue
 import net.sf.saxon.s9api.XdmMap
 import net.sf.saxon.s9api.XdmNode
 
 open class JsonJoinStep(): AbstractAtomicStep() {
-    val inputs = mutableListOf<XProcDocument>()
-
-    override fun input(port: String, doc: XProcDocument) {
-        inputs.add(doc)
-    }
-
     override fun run() {
         super.run()
 
+        val inputs = queues["source"]!!
         val flatten = stringBinding(Ns.flattenToDepth)
         val depth = when (flatten) {
             null -> 0

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/JsonMergeStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/JsonMergeStep.kt
@@ -8,18 +8,14 @@ import com.xmlcalabash.runtime.parameters.StepParameters
 import net.sf.saxon.s9api.*
 
 open class JsonMergeStep(): AbstractAtomicStep() {
-    val inputs = mutableListOf<XProcDocument>()
     var duplicates = "use-first"
     var key = ""
     var index = 0
 
-    override fun input(port: String, doc: XProcDocument) {
-        inputs.add(doc)
-    }
-
     override fun run() {
         super.run()
 
+        val inputs = queues["source"]!!
         duplicates = stringBinding(Ns.duplicates) ?: "use-first"
         key = stringBinding(Ns.key) ?: "concat(\"_\",\$p:index)"
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/LabelElementsStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/LabelElementsStep.kt
@@ -20,8 +20,6 @@ import net.sf.saxon.s9api.XdmNode
 import net.sf.saxon.type.BuiltInAtomicType
 
 open class LabelElementsStep(): AbstractAtomicStep(), ProcessMatchingNodes {
-    lateinit var document: XProcDocument
-
     var matchPattern = "*"
     lateinit var attribute: QName
     lateinit var label: String
@@ -32,13 +30,10 @@ open class LabelElementsStep(): AbstractAtomicStep(), ProcessMatchingNodes {
     val matcher: ProcessMatch
         get() = _matcher ?: throw RuntimeException("Configuration error...")
 
-    override fun input(port: String, doc: XProcDocument) {
-        document = doc
-    }
-
     override fun run() {
         super.run()
 
+        val document = queues["source"]!!.first()
         matchPattern = stringBinding(Ns.match)!!
         attribute = qnameBinding(Ns.attribute)!!
         label = stringBinding(Ns.label)!!

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/LoadStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/LoadStep.kt
@@ -9,10 +9,6 @@ import net.sf.saxon.s9api.XdmEmptySequence
 import java.net.URISyntaxException
 
 open class LoadStep(): AbstractAtomicStep() {
-    override fun input(port: String, doc: XProcDocument) {
-        // there are none
-    }
-
     override fun run() {
         super.run()
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/MakeAbsoluteUrisStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/MakeAbsoluteUrisStep.kt
@@ -13,8 +13,6 @@ import net.sf.saxon.s9api.XdmNode
 import java.net.URI
 
 open class MakeAbsoluteUrisStep(): AbstractAtomicStep(), ProcessMatchingNodes {
-    lateinit var document: XProcDocument
-
     var matchPattern = "*"
     var baseUri: URI? = null
 
@@ -22,13 +20,10 @@ open class MakeAbsoluteUrisStep(): AbstractAtomicStep(), ProcessMatchingNodes {
     val matcher: ProcessMatch
         get() = _matcher ?: throw RuntimeException("Configuration error...")
 
-    override fun input(port: String, doc: XProcDocument) {
-        document = doc
-    }
-
     override fun run() {
         super.run()
 
+        val document = queues["source"]!!.first()
         matchPattern = stringBinding(Ns.match)!!
         baseUri = uriBinding(Ns.baseUri)
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/MarkdownToHtml.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/MarkdownToHtml.kt
@@ -19,16 +19,12 @@ open class MarkdownToHtml(): AbstractAtomicStep() {
         private val q_configurers = QName(NsCx.namespace,"cx:configurers")
     }
 
-    lateinit var document: XProcDocument
     private val markdownExtensions = MarkdownExtensions()
-
-    override fun input(port: String, doc: XProcDocument) {
-        document = doc
-    }
 
     override fun run() {
         super.run()
 
+        val document = queues["source"]!!.first()
         val parameters = qnameMapBinding(Ns.parameters)
         val extensions = parameters[q_extensions]
         if (extensions != null) {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/NamespaceDeleteStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/NamespaceDeleteStep.kt
@@ -1,31 +1,25 @@
 package com.xmlcalabash.steps
 
-import com.xmlcalabash.datamodel.MediaType
-import com.xmlcalabash.documents.DocumentProperties
 import com.xmlcalabash.documents.XProcDocument
 import com.xmlcalabash.exceptions.XProcError
 import com.xmlcalabash.namespace.Ns
 import com.xmlcalabash.runtime.ProcessMatch
 import com.xmlcalabash.runtime.ProcessMatchingNodes
-import net.sf.saxon.om.*
+import net.sf.saxon.om.AttributeMap
+import net.sf.saxon.om.NamespaceUri
 import net.sf.saxon.s9api.QName
 import net.sf.saxon.s9api.XdmNode
 
 open class NamespaceDeleteStep(): AbstractAtomicStep(), ProcessMatchingNodes {
-    lateinit var document: XProcDocument
-
     val excludeNamespaces = mutableSetOf<NamespaceUri>()
     var _matcher: ProcessMatch? = null
     val matcher: ProcessMatch
         get() = _matcher ?: throw RuntimeException("Configuration error...")
 
-    override fun input(port: String, doc: XProcDocument) {
-        document = doc
-    }
-
     override fun run() {
         super.run()
 
+        val document = queues["source"]!!.first()
         val prefixes = stringBinding(Ns.prefixes)!!
         val prefixesContext = options[Ns.prefixes]!!.context
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/NamespaceRenameStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/NamespaceRenameStep.kt
@@ -3,23 +3,15 @@ package com.xmlcalabash.steps
 import com.xmlcalabash.documents.XProcDocument
 import com.xmlcalabash.exceptions.XProcError
 import com.xmlcalabash.namespace.Ns
-import com.xmlcalabash.namespace.NsXml
 import com.xmlcalabash.runtime.ProcessMatch
 import com.xmlcalabash.runtime.ProcessMatchingNodes
-import com.xmlcalabash.util.*
 import net.sf.saxon.event.ReceiverOption
 import net.sf.saxon.om.*
-import net.sf.saxon.s9api.Axis
-import net.sf.saxon.s9api.QName
 import net.sf.saxon.s9api.XdmNode
-import net.sf.saxon.s9api.XdmNodeKind
 import net.sf.saxon.type.BuiltInAtomicType
 import net.sf.saxon.type.Untyped
-import java.net.URI
 
 open class NamespaceRenameStep(): AbstractAtomicStep(), ProcessMatchingNodes {
-    lateinit var document: XProcDocument
-
     var fromNS = NamespaceUri.NULL
     var toNS = NamespaceUri.NULL
     var applyTo = "all"
@@ -28,12 +20,9 @@ open class NamespaceRenameStep(): AbstractAtomicStep(), ProcessMatchingNodes {
     val matcher: ProcessMatch
         get() = _matcher ?: throw RuntimeException("Configuration error...")
 
-    override fun input(port: String, doc: XProcDocument) {
-        document = doc
-    }
-
     override fun run() {
         super.run()
+        val document = queues["source"]!!.first()
 
         if (uriBinding(Ns.from) != null) {
             fromNS = NamespaceUri.of(stringBinding(Ns.from).toString())

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/PackStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/PackStep.kt
@@ -9,22 +9,14 @@ import com.xmlcalabash.util.SaxonTreeBuilder
 import net.sf.saxon.om.EmptyAttributeMap
 
 open class PackStep(): AbstractAtomicStep() {
-    private val source = mutableListOf<XProcDocument>()
-    private val alternate = mutableListOf<XProcDocument>()
-    private var wrapperName = NsCx.unusedValue
-
-    override fun input(port: String, doc: XProcDocument) {
-        if (port == "source") {
-            source.add(doc)
-        } else {
-            alternate.add(doc)
-        }
-    }
-
     override fun run() {
         super.run()
+        val source = mutableListOf<XProcDocument>()
+        source.addAll(queues["source"]!!)
+        val alternate = mutableListOf<XProcDocument>()
+        alternate.addAll(queues["alternate"]!!)
+        val wrapperName = qnameBinding(Ns.wrapper)!!
 
-        wrapperName = qnameBinding(Ns.wrapper)!!
         while (source.isNotEmpty() || alternate.isNotEmpty()) {
             val builder = SaxonTreeBuilder(stepConfig)
             builder.startDocument(null)

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/RenameStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/RenameStep.kt
@@ -1,47 +1,35 @@
 package com.xmlcalabash.steps
 
-import com.xmlcalabash.documents.XProcDocument
 import com.xmlcalabash.exceptions.XProcError
 import com.xmlcalabash.namespace.Ns
 import com.xmlcalabash.namespace.NsCx
 import com.xmlcalabash.runtime.ProcessMatch
 import com.xmlcalabash.runtime.ProcessMatchingNodes
-import com.xmlcalabash.runtime.parameters.StepParameters
 import net.sf.saxon.om.AttributeInfo
 import net.sf.saxon.om.AttributeMap
 import net.sf.saxon.om.FingerprintedQName
 import net.sf.saxon.om.NamespaceUri
-import net.sf.saxon.s9api.QName
 import net.sf.saxon.s9api.XdmNode
 
 class RenameStep(): AbstractAtomicStep(), ProcessMatchingNodes {
-    companion object {
-        private val MATCH = QName("match")
-    }
-
-    var document: XProcDocument? = null
-
     var matchPattern = "/*"
     var newName = NsCx.unusedValue
     var _matcher: ProcessMatch? = null
     val matcher: ProcessMatch
         get() = _matcher ?: throw RuntimeException("Configuration error...")
 
-    override fun input(port: String, doc: XProcDocument) {
-        document = doc
-    }
-
     override fun run() {
         super.run()
 
+        val document = queues["source"]!!.first()
         matchPattern = stringBinding(Ns.match)!!
         newName = qnameBinding(Ns.newName)!!
 
         _matcher = ProcessMatch(stepConfig, this, valueBinding(Ns.match).context.inscopeNamespaces)
-        matcher.process(document!!.value as XdmNode, matchPattern)
+        matcher.process(document.value as XdmNode, matchPattern)
 
         val doc = matcher.result
-        val result = document!!.with(doc)
+        val result = document.with(doc)
 
         receiver.output("result", result)
     }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/ReplaceStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/ReplaceStep.kt
@@ -7,13 +7,11 @@ import com.xmlcalabash.exceptions.XProcError
 import com.xmlcalabash.namespace.Ns
 import com.xmlcalabash.runtime.ProcessMatch
 import com.xmlcalabash.runtime.ProcessMatchingNodes
-import com.xmlcalabash.runtime.parameters.StepParameters
 import com.xmlcalabash.util.S9Api
 import net.sf.saxon.om.AttributeMap
-import net.sf.saxon.s9api.*
+import net.sf.saxon.s9api.XdmNode
 
 class ReplaceStep(): AbstractAtomicStep(), ProcessMatchingNodes {
-    lateinit var document: XProcDocument
     lateinit var replacement: XProcDocument
 
     var pattern = ""
@@ -21,16 +19,10 @@ class ReplaceStep(): AbstractAtomicStep(), ProcessMatchingNodes {
     val matcher: ProcessMatch
         get() = _matcher ?: throw RuntimeException("Configuration error...")
 
-    override fun input(port: String, doc: XProcDocument) {
-        if (port == "source") {
-            document = doc
-        } else {
-            replacement = doc
-        }
-    }
-
     override fun run() {
         super.run()
+        val document = queues["source"]!!.first()
+        replacement = queues["replacement"]!!.first()
 
         pattern = stringBinding(Ns.match)!!
         _matcher = ProcessMatch(stepConfig, this, valueBinding(Ns.match).context.inscopeNamespaces)
@@ -51,7 +43,6 @@ class ReplaceStep(): AbstractAtomicStep(), ProcessMatchingNodes {
 
     override fun reset() {
         super.reset()
-        document = XProcDocument.ofEmpty(stepConfig)
         replacement = XProcDocument.ofEmpty(stepConfig)
     }
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/SetAttributesStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/SetAttributesStep.kt
@@ -1,39 +1,25 @@
 package com.xmlcalabash.steps
 
-import com.xmlcalabash.documents.XProcDocument
 import com.xmlcalabash.exceptions.XProcError
 import com.xmlcalabash.namespace.Ns
-import com.xmlcalabash.namespace.NsXml
-import com.xmlcalabash.namespace.NsXmlns
 import com.xmlcalabash.runtime.ProcessMatch
 import com.xmlcalabash.runtime.ProcessMatchingNodes
-import com.xmlcalabash.runtime.parameters.StepParameters
-import com.xmlcalabash.util.NodeLocation
 import net.sf.saxon.om.AttributeMap
 import net.sf.saxon.s9api.QName
 import net.sf.saxon.s9api.XdmAtomicValue
 import net.sf.saxon.s9api.XdmNode
 
 class SetAttributesStep(): AbstractAtomicStep(), ProcessMatchingNodes {
-    companion object {
-        private val MATCH = QName("match")
-    }
-
-    var document: XProcDocument? = null
-
     var matchPattern = "/*"
     val attributeSet = mutableMapOf<QName,String?>()
     var _matcher: ProcessMatch? = null
     val matcher: ProcessMatch
         get() = _matcher ?: throw RuntimeException("Configuration error...")
 
-    override fun input(port: String, doc: XProcDocument) {
-        document = doc
-    }
-
     override fun run() {
         super.run()
 
+        val document = queues["source"]!!.first()
         val attrMap = qnameMapBinding(Ns.attributes)
         for ((key, value) in attrMap) {
             forbidNamespaceAttribute(key)
@@ -42,10 +28,10 @@ class SetAttributesStep(): AbstractAtomicStep(), ProcessMatchingNodes {
 
         matchPattern = stringBinding(Ns.match)!!
         _matcher = processMatcher(Ns.match)
-        matcher.process(document!!.value as XdmNode, matchPattern)
+        matcher.process(document.value as XdmNode, matchPattern)
 
         val doc = matcher.result
-        val result = document!!.with(doc)
+        val result = document.with(doc)
 
         receiver.output("result", result)
     }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/SetPropertiesStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/SetPropertiesStep.kt
@@ -15,15 +15,10 @@ import java.net.URI
 import java.net.URISyntaxException
 
 open class SetPropertiesStep(): AbstractAtomicStep() {
-    lateinit var document: XProcDocument
-
-    override fun input(port: String, doc: XProcDocument) {
-        document = doc
-    }
-
     override fun run() {
         super.run()
 
+        val document = queues["source"]!!.first()
         val merge = booleanBinding(Ns.merge) ?: true
         val setProperties = mutableMapOf<QName,XdmValue>()
         setProperties.putAll(qnameMapBinding(Ns.properties))

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/SinkStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/SinkStep.kt
@@ -1,11 +1,5 @@
 package com.xmlcalabash.steps
 
-import com.xmlcalabash.documents.XProcDocument
-
 open class SinkStep(): AbstractAtomicStep() {
-    override fun input(port: String, doc: XProcDocument) {
-        // ignore them
-    }
-
     override fun toString(): String = "p:sink"
 }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/SleepStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/SleepStep.kt
@@ -1,21 +1,10 @@
 package com.xmlcalabash.steps
 
-import com.xmlcalabash.documents.XProcDocument
 import com.xmlcalabash.exceptions.XProcError
 import com.xmlcalabash.namespace.Ns
-import net.sf.saxon.str.BMPString
-import net.sf.saxon.type.ValidationFailure
-import net.sf.saxon.value.DayTimeDurationValue
-import net.sf.saxon.value.DurationValue
 import org.apache.logging.log4j.kotlin.logger
 
 open class SleepStep(): AbstractAtomicStep() {
-    val cache = mutableListOf<XProcDocument>()
-
-    override fun input(port: String, doc: XProcDocument) {
-        cache.add(doc)
-    }
-
     override fun run() {
         super.run()
 
@@ -32,8 +21,8 @@ open class SleepStep(): AbstractAtomicStep() {
             throw stepConfig.exception(XProcError.xdBadType("Invalid duration: ${duration}"), ex)
         }
 
-        while (cache.isNotEmpty()) {
-            receiver.output("result", cache.removeFirst());
+        for (doc in queues["source"]!!) {
+            receiver.output("result", doc)
         }
     }
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/SplitSequenceStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/SplitSequenceStep.kt
@@ -1,22 +1,14 @@
 package com.xmlcalabash.steps
 
-import com.xmlcalabash.documents.XProcDocument
 import com.xmlcalabash.namespace.Ns
-import com.xmlcalabash.runtime.parameters.StepParameters
 import net.sf.saxon.om.Item
-import net.sf.saxon.s9api.XdmNode
 import net.sf.saxon.tree.iter.ManualIterator
 
 open class SplitSequenceStep(): AbstractAtomicStep() {
-    private val documents = mutableListOf<XProcDocument>()
-
-    override fun input(port: String, doc: XProcDocument) {
-        documents.add(doc)
-    }
-
     override fun run() {
         super.run()
 
+        val documents = queues["source"]!!
         val test = stringBinding(Ns.test)!!
         val testContext = options[Ns.test]!!.context
         val initialOnly = booleanBinding(Ns.initialOnly) ?: false

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/StoreStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/StoreStep.kt
@@ -1,32 +1,18 @@
 package com.xmlcalabash.steps
 
-import com.xmlcalabash.datamodel.MediaType
-import com.xmlcalabash.documents.XProcBinaryDocument
 import com.xmlcalabash.documents.XProcDocument
 import com.xmlcalabash.exceptions.XProcError
 import com.xmlcalabash.io.XProcSerializer
 import com.xmlcalabash.namespace.Ns
 import com.xmlcalabash.namespace.NsC
-import com.xmlcalabash.util.S9Api
 import com.xmlcalabash.util.SaxonTreeBuilder
-import net.sf.saxon.s9api.QName
-import net.sf.saxon.s9api.Serializer
-import net.sf.saxon.s9api.XdmValue
-import java.io.File
 import java.io.FileOutputStream
-import java.lang.RuntimeException
-import java.net.URI
 
 open class StoreStep(): AbstractAtomicStep() {
-    var document: XProcDocument? = null
-
-    override fun input(port: String, doc: XProcDocument) {
-        document = doc
-    }
-
     override fun run() {
         super.run()
 
+        val document = queues["source"]!!.first()
         val href = try {
             uriBinding(Ns.href)!!
         } catch (ex: Exception) {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/StringReplaceStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/StringReplaceStep.kt
@@ -1,8 +1,6 @@
 package com.xmlcalabash.steps
 
-import com.xmlcalabash.datamodel.XProcExpression
 import com.xmlcalabash.documents.DocumentProperties
-import com.xmlcalabash.documents.XProcDocument
 import com.xmlcalabash.namespace.Ns
 import com.xmlcalabash.runtime.ExpressionEvaluator
 import com.xmlcalabash.runtime.ProcessMatch
@@ -13,8 +11,6 @@ import net.sf.saxon.s9api.QName
 import net.sf.saxon.s9api.XdmNode
 
 open class StringReplaceStep(): AbstractAtomicStep(), ProcessMatchingNodes {
-    lateinit var document: XProcDocument
-
     var matchPattern = "/*"
     var replace: String = ""
 
@@ -22,13 +18,10 @@ open class StringReplaceStep(): AbstractAtomicStep(), ProcessMatchingNodes {
     val matcher: ProcessMatch
         get() = _matcher ?: throw RuntimeException("Configuration error...")
 
-    override fun input(port: String, doc: XProcDocument) {
-        document = doc
-    }
-
     override fun run() {
         super.run()
 
+        val document = queues["source"]!!.first()
         matchPattern = stringBinding(Ns.match)!!
         replace = stringBinding(Ns.replace)!!
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/TextCountStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/TextCountStep.kt
@@ -10,8 +10,9 @@ import javax.xml.transform.sax.SAXSource
 open class TextCountStep(): AbstractTextStep() {
     override fun run() {
         super.run()
+        val document = queues["source"]!!.first()
 
-        val count = textLines().size
+        val count = textLines(document).size
 
         val result = "<c:result xmlns:c='${NsC.namespace}'>${count}</c:result>"
         val inputStream = ByteArrayInputStream(result.toByteArray(Charsets.UTF_8))

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/TextHeadStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/TextHeadStep.kt
@@ -1,7 +1,6 @@
 package com.xmlcalabash.steps
 
 import com.xmlcalabash.namespace.Ns
-import com.xmlcalabash.runtime.parameters.StepParameters
 import kotlin.math.max
 import kotlin.math.min
 
@@ -9,8 +8,9 @@ open class TextHeadStep(): AbstractTextStep() {
     override fun run() {
         super.run()
 
+        val source = queues["source"]!!.first()
         val count = integerBinding(Ns.count)!!
-        val lines = textLines()
+        val lines = textLines(source)
         val sb = StringBuilder()
 
         if (count == 0) {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/TextJoinStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/TextJoinStep.kt
@@ -9,15 +9,10 @@ import com.xmlcalabash.namespace.Ns
 import com.xmlcalabash.runtime.parameters.StepParameters
 
 open class TextJoinStep(): AbstractTextStep() {
-    val documents = mutableListOf<XProcDocument>()
-
-    override fun input(port: String, doc: XProcDocument) {
-        documents.add(doc)
-    }
-
     override fun run() {
         super.run()
 
+        val documents = queues["source"]!!
         val prefix = stringBinding(Ns.prefix)
         val suffix = stringBinding(Ns.suffix)
         val separator = stringBinding(Ns.separator)

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/TextReplaceStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/TextReplaceStep.kt
@@ -9,10 +9,11 @@ open class TextReplaceStep(): AbstractTextStep() {
     override fun run() {
         super.run()
 
+        val source = queues["source"]!!.first()
         val pattern = stringBinding(Ns.pattern)
         val replacement = stringBinding(Ns.replacement)
         val flags = stringBinding(Ns.flags) ?: ""
-        val text = text()
+        val text = text(source)
 
         val compiler = stepConfig.processor.newXPathCompiler()
         compiler.declareVariable(Ns.pattern)

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/TextSortStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/TextSortStep.kt
@@ -19,6 +19,7 @@ open class TextSortStep(): AbstractTextStep() {
     override fun run() {
         super.run()
 
+        val source = queues["source"]!!.first()
         val sortKey = stringBinding(Ns.sortKey) ?: "."
         val order = stringBinding(Ns.order)
         val caseOrder = stringBinding(Ns.caseOrder)
@@ -38,7 +39,7 @@ open class TextSortStep(): AbstractTextStep() {
         }
 
         // Make sure we do line handling...
-        val text = textLines()
+        val text = textLines(source)
         val sb = StringBuilder()
         for (index in text.indices) {
             if (index > 0) {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/TextTailStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/TextTailStep.kt
@@ -8,8 +8,9 @@ open class TextTailStep(): AbstractTextStep() {
     override fun run() {
         super.run()
 
+        val source = queues["source"]!!.first()
         val count = integerBinding(Ns.count)!!
-        val lines = textLines()
+        val lines = textLines(source)
         val sb = StringBuilder()
 
         if (count == 0) {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/UnarchiveStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/UnarchiveStep.kt
@@ -12,14 +12,10 @@ import org.apache.commons.compress.utils.SeekableInMemoryByteChannel
 import java.net.URI
 
 open class UnarchiveStep(): AbstractArchiveStep() {
-    override fun input(port: String, doc: XProcDocument) {
-        archives.add(doc)
-    }
-
     override fun run() {
         super.run()
 
-        val archive = archives.first()
+        val archive = queues["source"]!!.first()
         val format = qnameBinding(Ns.format) ?: Ns.zip
         val relativeTo = relativeTo()
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/UnwrapStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/UnwrapStep.kt
@@ -15,19 +15,15 @@ import net.sf.saxon.s9api.XdmNode
 import net.sf.saxon.s9api.XdmValue
 
 class UnwrapStep(): AbstractAtomicStep(), ProcessMatchingNodes {
-    lateinit var document: XProcDocument
     var pattern = ""
     var _matcher: ProcessMatch? = null
     val matcher: ProcessMatch
         get() = _matcher ?: throw RuntimeException("Configuration error...")
 
-    override fun input(port: String, doc: XProcDocument) {
-        document = doc
-    }
-
     override fun run() {
         super.run()
 
+        val document = queues["source"]!!.first()
         pattern = stringBinding(Ns.match)!!
         _matcher = ProcessMatch(stepConfig, this, valueBinding(Ns.match).context.inscopeNamespaces)
         matcher.process(document.value as XdmNode, pattern)

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/UuidStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/UuidStep.kt
@@ -12,20 +12,16 @@ import net.sf.saxon.s9api.QName
 import net.sf.saxon.s9api.XdmNode
 
 open class UuidStep(): AbstractAtomicStep(), ProcessMatchingNodes {
-    lateinit var document: XProcDocument
     lateinit var matcher: ProcessMatch
 
     var matchPattern = "/*"
     var version = 0
     var uuid = ""
 
-    override fun input(port: String, doc: XProcDocument) {
-        document = doc
-    }
-
     override fun run() {
         super.run()
 
+        val document = queues["source"]!!.first()
         matchPattern = stringBinding(Ns.match)!!
         version = integerBinding(Ns.version) ?: 4
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/WrapSequenceStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/WrapSequenceStep.kt
@@ -19,13 +19,10 @@ open class WrapSequenceStep(): AbstractAtomicStep() {
     private var groupAdjacentContext: DocumentContext? = null
     var index = 0
 
-    override fun input(port: String, doc: XProcDocument) {
-        documents.add(doc)
-    }
-
     override fun run() {
         super.run()
 
+        documents.addAll(queues["source"]!!)
         wrapperName = qnameBinding(Ns.wrapper)!!
         groupAdjacent = stringBinding(Ns.groupAdjacent)
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/WrapStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/WrapStep.kt
@@ -15,7 +15,6 @@ import net.sf.saxon.s9api.XdmNodeKind
 import java.util.*
 
 class WrapStep(): AbstractAtomicStep(), ProcessMatchingNodes {
-    var document: XProcDocument? = null
     var pattern = ""
     var _matcher: ProcessMatch? = null
     val matcher: ProcessMatch
@@ -25,13 +24,10 @@ class WrapStep(): AbstractAtomicStep(), ProcessMatchingNodes {
     private var groupAdjacent: String? = null
     private var groupAdjacentContext: DocumentContext? = null
 
-    override fun input(port: String, doc: XProcDocument) {
-        document = doc
-    }
-
     override fun run() {
         super.run()
 
+        val document = queues["source"]!!.first()
         wrapper = qnameBinding(Ns.wrapper)!!
         pattern = stringBinding(Ns.match)!!
         groupAdjacent = stringBinding(Ns.groupAdjacent)
@@ -42,13 +38,12 @@ class WrapStep(): AbstractAtomicStep(), ProcessMatchingNodes {
         inGroup.push(false)
 
         _matcher = ProcessMatch(stepConfig, this, valueBinding(Ns.match).context.inscopeNamespaces)
-        matcher.process(document!!.value as XdmNode, pattern)
-        receiver.output("result", XProcDocument.ofXml(matcher.result, stepConfig, document!!.properties))
+        matcher.process(document.value as XdmNode, pattern)
+        receiver.output("result", XProcDocument.ofXml(matcher.result, stepConfig, document.properties))
     }
 
     override fun reset() {
         super.reset()
-        document = null
     }
 
     override fun startDocument(node: XdmNode): Boolean {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/WwwFormUrlDecodeStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/WwwFormUrlDecodeStep.kt
@@ -10,10 +10,6 @@ import net.sf.saxon.s9api.XdmValue
 import java.net.URLDecoder
 
 open class WwwFormUrlDecodeStep(): AbstractAtomicStep() {
-    override fun input(port: String, doc: XProcDocument) {
-        // nop, no inputs
-    }
-
     override fun run() {
         super.run()
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/WwwFormUrlEncodeStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/WwwFormUrlEncodeStep.kt
@@ -1,21 +1,13 @@
 package com.xmlcalabash.steps
 
-import com.xmlcalabash.documents.DocumentProperties
 import com.xmlcalabash.documents.XProcDocument
 import com.xmlcalabash.namespace.Ns
-import com.xmlcalabash.namespace.NsCx
-import net.sf.saxon.s9api.XdmAtomicValue
 import net.sf.saxon.s9api.XdmEmptySequence
 import net.sf.saxon.s9api.XdmMap
 import net.sf.saxon.s9api.XdmValue
-import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
 
 open class WwwFormUrlEncodeStep(): AbstractAtomicStep() {
-    override fun input(port: String, doc: XProcDocument) {
-        // nop, no inputs
-    }
-
     override fun run() {
         super.run()
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/XIncludeStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/XIncludeStep.kt
@@ -10,15 +10,10 @@ import com.xmlcalabash.namespace.NsCx
 import net.sf.saxon.s9api.XdmNode
 
 open class XIncludeStep(): AbstractAtomicStep() {
-    lateinit var document: XProcDocument
-
-    override fun input(port: String, doc: XProcDocument) {
-        document = doc
-    }
-
     override fun run() {
         super.run()
 
+        val document = queues["source"]!!.first()
         val defaultResolver = DefaultDocumentResolver()
         val xincluder = XInclude(XiResolver(defaultResolver))
         xincluder.trimText = booleanBinding(NsCx.trim) ?: false

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/XQueryStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/XQueryStep.kt
@@ -33,16 +33,10 @@ open class XQueryStep(): AbstractAtomicStep() {
     private var primaryDestination: Destination? = null
     private var outputProperties = mutableMapOf<QName, XdmValue>()
 
-    override fun input(port: String, doc: XProcDocument) {
-        if (port == "source") {
-            sources.add(doc)
-        } else {
-            query = doc
-        }
-    }
-
     override fun run() {
         super.run()
+        sources.addAll(queues["source"]!!)
+        query = queues["query"]!!.first()
 
         parameters.putAll(qnameMapBinding(Ns.parameters))
         version = stringBinding(Ns.version) ?: "3.1"
@@ -52,6 +46,12 @@ open class XQueryStep(): AbstractAtomicStep() {
             "3.0" -> xquery30()
             else -> throw stepConfig.exception(XProcError.xcXQueryVersionNotAvailable(version))
         }
+    }
+
+    override fun reset() {
+        super.reset()
+        sources.clear()
+        query = XProcDocument.ofEmpty(stepConfig)
     }
 
     private fun xquery30() {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/XslFormatterStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/XslFormatterStep.kt
@@ -20,20 +20,16 @@ open class XslFormatterStep(): AbstractAtomicStep() {
         val genericXslFormatter = URI("https://xmlcalabash.com/paged-media/xsl-formatter")
     }
 
-    private lateinit var document: XProcDocument
     private val extensionAttributes = mutableMapOf<QName, String>()
 
     override fun extensionAttributes(attributes: Map<QName, String>) {
         extensionAttributes.putAll(attributes)
     }
 
-    override fun input(port: String, doc: XProcDocument) {
-        document = doc
-    }
-
     override fun run() {
         super.run()
 
+        val document = queues["source"]!!.first()
         val contentType = mediaTypeBinding(Ns.contentType, MediaType.PDF)
         val parameters = qnameMapBinding(Ns.parameters)
         var xslManager: PagedMediaManager? = null

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/XsltStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/XsltStep.kt
@@ -45,16 +45,10 @@ open class XsltStep(): AbstractAtomicStep() {
     private var primaryDestination: Destination? = null
     private var primaryOutputProperties = mutableMapOf<QName, XdmValue>()
 
-    override fun input(port: String, doc: XProcDocument) {
-        if (port == "source") {
-            sources.add(doc)
-        } else {
-            stylesheet = doc
-        }
-    }
-
     override fun run() {
         super.run()
+        sources.addAll(queues["source"]!!)
+        stylesheet = queues["stylesheet"]!!.first()
 
         parameters.putAll(qnameMapBinding(Ns.parameters))
         staticParameters.putAll(qnameMapBinding(Ns.staticParameters))
@@ -81,6 +75,12 @@ open class XsltStep(): AbstractAtomicStep() {
             "1.0" -> xslt10()
             else -> throw stepConfig.exception(XProcError.xcVersionNotAvailable(version ?: "null"))
         }
+    }
+
+    override fun reset() {
+        super.reset()
+        sources.clear()
+        stylesheet = XProcDocument.ofEmpty(stepConfig)
     }
 
     private fun xslt30() {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/extension/CacheDocument.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/extension/CacheDocument.kt
@@ -1,19 +1,11 @@
 package com.xmlcalabash.steps.extension
 
-import com.xmlcalabash.documents.XProcDocument
 import com.xmlcalabash.steps.AbstractAtomicStep
 
 open class CacheDocument(): AbstractAtomicStep() {
-    val cache = mutableListOf<XProcDocument>()
-
-    override fun input(port: String, doc: XProcDocument) {
-        cache.add(doc)
-    }
-
     override fun run() {
         super.run()
-        while (cache.isNotEmpty()) {
-            val doc = cache.removeFirst()
+        for (doc in queues["source"]!!) {
             if (doc.baseURI != null) {
                 stepConfig.environment.documentManager.cache(doc)
             }
@@ -21,5 +13,5 @@ open class CacheDocument(): AbstractAtomicStep() {
         }
     }
 
-    override fun toString(): String = "cx:cache-add-document"
+    override fun toString(): String = "cx:cache-add"
 }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/extension/UncacheDocument.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/extension/UncacheDocument.kt
@@ -1,19 +1,11 @@
 package com.xmlcalabash.steps.extension
 
-import com.xmlcalabash.documents.XProcDocument
 import com.xmlcalabash.steps.AbstractAtomicStep
 
 open class UncacheDocument(): AbstractAtomicStep() {
-    val cache = mutableListOf<XProcDocument>()
-
-    override fun input(port: String, doc: XProcDocument) {
-        cache.add(doc)
-    }
-
     override fun run() {
         super.run()
-        while (cache.isNotEmpty()) {
-            val doc = cache.removeFirst()
+        for (doc in queues["source"]!!) {
             if (doc.baseURI != null) {
                 stepConfig.environment.documentManager.uncache(doc)
             }
@@ -21,5 +13,5 @@ open class UncacheDocument(): AbstractAtomicStep() {
         }
     }
 
-    override fun toString(): String = "cx:cache-remove-document"
+    override fun toString(): String = "cx:cache-delete"
 }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/file/CreateTempfileStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/file/CreateTempfileStep.kt
@@ -15,10 +15,6 @@ import java.nio.file.Path
 import java.nio.file.Paths
 
 class CreateTempfileStep(): FileStep(NsP.fileCreateTempfile) {
-    override fun input(port: String, doc: XProcDocument) {
-        // never called
-    }
-
     override fun run() {
         super.run()
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/file/DirectoryListStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/file/DirectoryListStep.kt
@@ -16,10 +16,6 @@ class DirectoryListStep(): FileStep(NsP.directoryList) {
     var includeFilters = mutableListOf<String>()
     var excludeFilters = mutableListOf<String>()
 
-    override fun input(port: String, doc: XProcDocument) {
-        // never called
-    }
-
     override fun run() {
         super.run()
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/file/FileCopyOrMove.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/file/FileCopyOrMove.kt
@@ -11,10 +11,6 @@ import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 
 abstract class FileCopyOrMove(stepType: QName): FileStep(stepType) {
-    override fun input(port: String, doc: XProcDocument) {
-        // never called
-    }
-
     protected fun copyOrMove() {
         val href = try {
             uriBinding(Ns.href)!!

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/file/FileCopyStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/file/FileCopyStep.kt
@@ -1,20 +1,8 @@
 package com.xmlcalabash.steps.file
 
-import com.xmlcalabash.documents.XProcDocument
-import com.xmlcalabash.exceptions.XProcError
-import com.xmlcalabash.namespace.Ns
 import com.xmlcalabash.namespace.NsP
-import net.sf.saxon.s9api.QName
-import java.io.File
-import java.io.IOException
-import java.nio.file.Files
-import java.nio.file.StandardCopyOption
 
 class FileCopyStep(): FileCopyOrMove(NsP.fileCopy) {
-    override fun input(port: String, doc: XProcDocument) {
-        // never called
-    }
-
     override fun run() {
         super.run()
         copyOrMove()

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/file/FileDeleteStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/file/FileDeleteStep.kt
@@ -2,15 +2,12 @@ package com.xmlcalabash.steps.file
 
 import com.xmlcalabash.documents.XProcDocument
 import com.xmlcalabash.exceptions.XProcError
-import com.xmlcalabash.namespace.*
+import com.xmlcalabash.namespace.Ns
+import com.xmlcalabash.namespace.NsP
 import java.io.File
 import java.io.IOException
 
 class FileDeleteStep(): FileStep(NsP.fileDelete) {
-    override fun input(port: String, doc: XProcDocument) {
-        // never called
-    }
-
     override fun run() {
         super.run()
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/file/FileInfoStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/file/FileInfoStep.kt
@@ -9,10 +9,6 @@ import java.io.File
 import java.nio.file.Files
 
 class FileInfoStep(): FileStep(NsP.fileInfo) {
-    override fun input(port: String, doc: XProcDocument) {
-        // never called
-    }
-
     override fun run() {
         super.run()
 
@@ -26,7 +22,7 @@ class FileInfoStep(): FileStep(NsP.fileInfo) {
             throw stepConfig.exception(XProcError.xcUnsupportedFileInfoScheme(href.scheme))
         }
 
-        failOnError = booleanBinding(Ns.failOnError) ?: true
+        failOnError = booleanBinding(Ns.failOnError) != false
 
         val file = File(href.path)
         if (!file.exists()) {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/file/FileMkdirStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/file/FileMkdirStep.kt
@@ -7,10 +7,6 @@ import java.io.File
 import java.io.IOException
 
 class FileMkdirStep(): FileStep(NsP.fileDelete) {
-    override fun input(port: String, doc: XProcDocument) {
-        // never called
-    }
-
     override fun run() {
         super.run()
 
@@ -24,7 +20,7 @@ class FileMkdirStep(): FileStep(NsP.fileDelete) {
             throw stepConfig.exception(XProcError.xcUnsupportedFileMkdirScheme(href.scheme))
         }
 
-        failOnError = booleanBinding(Ns.failOnError) ?: true
+        failOnError = booleanBinding(Ns.failOnError) != false
 
         val file = File(href.path)
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/file/FileMoveStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/file/FileMoveStep.kt
@@ -1,13 +1,8 @@
 package com.xmlcalabash.steps.file
 
-import com.xmlcalabash.documents.XProcDocument
 import com.xmlcalabash.namespace.NsP
 
 class FileMoveStep(): FileCopyOrMove(NsP.fileMove) {
-    override fun input(port: String, doc: XProcDocument) {
-        // never called
-    }
-
     override fun run() {
         super.run()
         copyOrMove()

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/file/FileTouchStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/file/FileTouchStep.kt
@@ -2,7 +2,8 @@ package com.xmlcalabash.steps.file
 
 import com.xmlcalabash.documents.XProcDocument
 import com.xmlcalabash.exceptions.XProcError
-import com.xmlcalabash.namespace.*
+import com.xmlcalabash.namespace.Ns
+import com.xmlcalabash.namespace.NsP
 import net.sf.saxon.value.DateTimeValue
 import java.io.File
 import java.io.IOException
@@ -10,10 +11,6 @@ import java.time.ZoneId
 import java.time.ZonedDateTime
 
 class FileTouchStep(): FileStep(NsP.fileTouch) {
-    override fun input(port: String, doc: XProcDocument) {
-        // never called
-    }
-
     override fun run() {
         super.run()
 
@@ -34,7 +31,7 @@ class FileTouchStep(): FileStep(NsP.fileTouch) {
             ZonedDateTime.now().withZoneSameInstant(ZoneId.of("UTC"))
         }
 
-        failOnError = booleanBinding(Ns.failOnError) ?: true
+        failOnError = booleanBinding(Ns.failOnError) != false
 
         val file = File(href.path)
         try {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/internal/DocumentStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/internal/DocumentStep.kt
@@ -11,24 +11,7 @@ import net.sf.saxon.s9api.*
 import java.net.URISyntaxException
 
 open class DocumentStep(val params: DocumentStepParameters): AbstractAtomicStep() {
-    private var suppress = false
-
-    override fun input(port: String, doc: XProcDocument) {
-        // nop
-    }
-
-    internal fun suppress() {
-        suppress = true
-    }
-
     override fun run() {
-        if (suppress) {
-            // No one cares what this produces; but produce something so that
-            // we don't run afoul of the sequence property of the output
-            receiver.output("result", XProcDocument.ofEmpty(stepConfig))
-            return
-        }
-
         super.run()
 
         val props = DocumentProperties()
@@ -76,7 +59,6 @@ open class DocumentStep(val params: DocumentStepParameters): AbstractAtomicStep(
 
     override fun reset() {
         super.reset()
-        suppress = false
     }
 
     override fun toString(): String = "cx:document"

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/internal/EmptyStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/internal/EmptyStep.kt
@@ -1,14 +1,9 @@
 package com.xmlcalabash.steps.internal
 
-import com.xmlcalabash.documents.XProcDocument
 import com.xmlcalabash.runtime.parameters.EmptyStepParameters
 import com.xmlcalabash.steps.AbstractAtomicStep
 
 class EmptyStep(val params: EmptyStepParameters): AbstractAtomicStep() {
-    override fun input(port: String, doc: XProcDocument) {
-        // like that's going to happen!
-    }
-
     override fun run() {
         super.run()
         // nop

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/internal/ExpressionStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/internal/ExpressionStep.kt
@@ -21,17 +21,10 @@ open class ExpressionStep(val params: ExpressionStepParameters): AbstractAtomicS
     val expression = params.expression
     val collection = params.collection
 
-    override fun input(port: String, doc: XProcDocument) {
-        contextItems.add(doc)
-    }
-
-    override fun reset() {
-        super.reset()
-        contextItems.clear()
-    }
-
     override fun run() {
         super.run()
+        // Expression steps are unusual in that source may not exist
+        contextItems.addAll(queues["source"] ?: emptyList())
 
         if (override != null) {
             receiver.output("result", override!!)
@@ -94,6 +87,11 @@ open class ExpressionStep(val params: ExpressionStepParameters): AbstractAtomicS
         } else {
             receiver.output("result", XProcDocument(lazy(), stepConfig))
         }
+    }
+
+    override fun reset() {
+        super.reset()
+        contextItems.clear()
     }
 
     override fun toString(): String {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/internal/GuardStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/internal/GuardStep.kt
@@ -1,21 +1,11 @@
 package com.xmlcalabash.steps.internal
 
-import com.xmlcalabash.documents.XProcDocument
 import com.xmlcalabash.steps.AbstractAtomicStep
 
 class GuardStep(): AbstractAtomicStep() {
-    internal lateinit var value: XProcDocument
-
-    override fun input(port: String, doc: XProcDocument) {
-        value = doc
-    }
-
     fun effectiveBooleanValue(): Boolean {
+        val value = queues["source"]!!.first()
         return value.value.underlyingValue.effectiveBooleanValue()
-    }
-
-    override fun run() {
-        //println("Running ${this}: ${effectiveBooleanValue()}")
     }
 
     override fun toString(): String = "cx:guard"

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/internal/InlineStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/internal/InlineStep.kt
@@ -15,20 +15,15 @@ import java.nio.charset.StandardCharsets
 import java.util.*
 
 open class InlineStep(val params: InlineStepParameters): AbstractAtomicStep() {
-    var contextItem: XProcDocument? = null
-    private var contextSequence = false
-
-    override fun input(port: String, doc: XProcDocument) {
-        contextSequence = contextItem != null
-        contextItem = doc
-    }
-
     override fun run() {
+        super.run()
+
+        val contextItem = queues["source"]!!.firstOrNull()
+        val contextSequence = queues["source"]!!.size > 1
+
         if (contextSequence && !params.filter.isStatic()) {
             throw stepConfig.exception(XProcError.xdInlineContextSequence().at(stepParams.location))
         }
-
-        super.run()
 
         val xml = if (params.filter.isStatic()) {
             params.filter.getNode()
@@ -149,8 +144,6 @@ open class InlineStep(val params: InlineStepParameters): AbstractAtomicStep() {
 
     override fun reset() {
         super.reset()
-        contextItem = null
-        contextSequence = false
     }
 
     private fun parseJson(bytes: ByteArray, contentType: MediaType?): XdmValue {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/internal/JoinerStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/internal/JoinerStep.kt
@@ -1,6 +1,5 @@
 package com.xmlcalabash.steps.internal
 
-import com.xmlcalabash.documents.XProcDocument
 import com.xmlcalabash.runtime.XProcStepConfiguration
 import com.xmlcalabash.runtime.api.Receiver
 import com.xmlcalabash.runtime.parameters.RuntimeStepParameters
@@ -8,30 +7,24 @@ import com.xmlcalabash.steps.AbstractAtomicStep
 
 open class JoinerStep(): AbstractAtomicStep() {
     val inputPorts = mutableListOf<String>()
-    val queues = mutableMapOf<String,MutableList<XProcDocument>>()
     val outputPorts = mutableListOf<String>()
 
     override fun setup(stepConfig: XProcStepConfiguration, receiver: Receiver, stepParams: RuntimeStepParameters) {
         super.setup(stepConfig, receiver, stepParams)
         for (input in stepParams.inputs.keys) {
             inputPorts.add(input)
-            queues.put(input, mutableListOf())
         }
         for (output in stepParams.outputs.keys) {
             outputPorts.add(output)
         }
     }
 
-    override fun input(port: String, doc: XProcDocument) {
-        queues[port]?.add(doc)
-    }
-
     override fun run() {
         super.run()
         for (iport in inputPorts) {
             for (oport in outputPorts) {
-                while (queues[iport]!!.isNotEmpty()) {
-                    receiver.output(oport, queues[iport]!!.removeFirst())
+                for (doc in queues[iport] ?: emptyList()) {
+                    receiver.output(oport, doc)
                 }
             }
         }
@@ -39,9 +32,6 @@ open class JoinerStep(): AbstractAtomicStep() {
 
     override fun reset() {
         super.reset()
-        for ((_, list) in queues) {
-            list.clear()
-        }
     }
 
     override fun toString(): String = "cx:joiner"

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/internal/OptionExpressionStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/internal/OptionExpressionStep.kt
@@ -1,10 +1,11 @@
 package com.xmlcalabash.steps.internal
 
-import com.xmlcalabash.documents.XProcDocument
 import com.xmlcalabash.runtime.parameters.OptionStepParameters
 
 class OptionExpressionStep(params: OptionStepParameters): ExpressionStep(params) {
+    /*
     fun setExternalValue(value: XProcDocument) {
         override = value.with(stepConfig.checkType(null, value.value, params.asType, params.values))
     }
+     */
 }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/internal/SelectStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/internal/SelectStep.kt
@@ -1,24 +1,13 @@
 package com.xmlcalabash.steps.internal
 
-import com.xmlcalabash.documents.XProcDocument
 import com.xmlcalabash.runtime.parameters.SelectStepParameters
 import com.xmlcalabash.steps.AbstractAtomicStep
 import com.xmlcalabash.util.S9Api
-import net.sf.saxon.s9api.XdmItem
 
 open class SelectStep(val params: SelectStepParameters): AbstractAtomicStep() {
-    val documents = mutableListOf<XProcDocument>()
-
-    override fun input(port: String, doc: XProcDocument) {
-        if (doc.value is XdmItem) {
-            documents.add(doc)
-        } else {
-            throw RuntimeException("Attempt to select on something that isn't an xdmitem?")
-        }
-    }
-
     override fun run() {
         super.run()
+        val documents = queues["source"]!!
 
         for (document in documents) {
             params.select.reset()
@@ -35,11 +24,6 @@ open class SelectStep(val params: SelectStepParameters): AbstractAtomicStep() {
                 receiver.output("result", doc)
             }
         }
-    }
-
-    override fun reset() {
-        super.reset()
-        documents.clear()
     }
 
     override fun toString(): String = "cx:selector"

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/internal/SplitterStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/internal/SplitterStep.kt
@@ -1,6 +1,5 @@
 package com.xmlcalabash.steps.internal
 
-import com.xmlcalabash.documents.XProcDocument
 import com.xmlcalabash.runtime.XProcStepConfiguration
 import com.xmlcalabash.runtime.api.Receiver
 import com.xmlcalabash.runtime.parameters.RuntimeStepParameters
@@ -8,7 +7,6 @@ import com.xmlcalabash.steps.AbstractAtomicStep
 
 open class SplitterStep(): AbstractAtomicStep() {
     val outputPorts = mutableListOf<String>()
-    val queue = mutableListOf<XProcDocument>()
 
     override fun setup(stepConfig: XProcStepConfiguration, receiver: Receiver, stepParams: RuntimeStepParameters) {
         super.setup(stepConfig, receiver, stepParams)
@@ -17,23 +15,13 @@ open class SplitterStep(): AbstractAtomicStep() {
         }
     }
 
-    override fun input(port: String, doc: XProcDocument) {
-        queue.add(doc)
-    }
-
     override fun run() {
         super.run()
-        while (queue.isNotEmpty()) {
-            val doc = queue.removeFirst()
+        for (doc in queues["source"]!!) {
             for (port in outputPorts) {
                 receiver.output(port, doc)
             }
         }
-    }
-
-    override fun reset() {
-        super.reset()
-        queue.clear()
     }
 
     override fun toString(): String = "cx:splitter"

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/internal/UnimplementedStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/internal/UnimplementedStep.kt
@@ -1,15 +1,10 @@
 package com.xmlcalabash.steps.internal
 
-import com.xmlcalabash.documents.XProcDocument
 import com.xmlcalabash.exceptions.XProcError
 import com.xmlcalabash.runtime.parameters.UnimplementedStepParameters
 import com.xmlcalabash.steps.AbstractAtomicStep
 
 open class UnimplementedStep(val params: UnimplementedStepParameters): AbstractAtomicStep() {
-    override fun input(port: String, doc: XProcDocument) {
-        // Just ignore the inputs, if there are any.
-    }
-
     override fun run() {
         super.run()
         throw stepConfig.exception(XProcError.xsMissingStepDeclaration(params.unimplemented))

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/os/OsExec.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/os/OsExec.kt
@@ -18,15 +18,10 @@ import java.nio.file.Files
 import java.nio.file.Paths
 
 class OsExec(): AbstractAtomicStep() {
-    var documents = mutableListOf<XProcDocument>()
-
-    override fun input(port: String, doc: XProcDocument) {
-        documents.add(doc)
-    }
-
     override fun run() {
         super.run()
 
+        val documents = queues["source"]!!
         if (documents.size > 1) {
             throw stepConfig.exception(XProcError.xcOsExecMultipleInputs())
         }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/os/OsInfo.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/os/OsInfo.kt
@@ -27,10 +27,6 @@ class OsInfo(): AbstractAtomicStep() {
 
     var onlyStandardProperties = false
 
-    override fun input(port: String, doc: XProcDocument) {
-        // none
-    }
-
     override fun extensionAttributes(attributes: Map<QName, String>) {
         super.extensionAttributes(attributes)
         val value = attributes[NsCx.onlyStandard]

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/validation/ValidateWithDTD.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/validation/ValidateWithDTD.kt
@@ -23,13 +23,10 @@ class ValidateWithDTD(): AbstractAtomicStep() {
     lateinit var source: XProcDocument
     val errors = mutableListOf<XmlProcessingError>()
 
-    override fun input(port: String, doc: XProcDocument) {
-        source = doc
-    }
-
     override fun run() {
         super.run()
 
+        source = queues["source"]!!.first()
         val assertValid = booleanBinding(Ns.assertValid) ?: true
 
         val stepSerialization = if (options[Ns.serialization] != null) {
@@ -88,6 +85,11 @@ class ValidateWithDTD(): AbstractAtomicStep() {
             xvrlReport(ex)
             receiver.output("result", source)
         }
+    }
+
+    override fun reset() {
+        super.reset()
+        source = XProcDocument.ofEmpty(stepConfig)
     }
 
     private fun serializeSource(serialization: Map<QName,XdmValue>): String {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/validation/ValidateWithJsonSchema.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/validation/ValidateWithJsonSchema.kt
@@ -12,19 +12,11 @@ import java.io.ByteArrayOutputStream
 import java.nio.charset.StandardCharsets
 
 open class ValidateWithJsonSchema(): AbstractAtomicStep() {
-    lateinit var document: XProcDocument
-    lateinit var schema: XProcDocument
-
-    override fun input(port: String, doc: XProcDocument) {
-        if (port == "source") {
-            document = doc
-        } else {
-            schema = doc
-        }
-    }
-
     override fun run() {
         super.run()
+
+        val document = queues["source"]!!.first()
+        val schema = queues["schema"]!!.first()
 
         val assertValid = booleanBinding(Ns.assertValid) ?: true
         val defaultVersion = stringBinding(Ns.defaultVersion)

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/validation/ValidateWithRelaxNG.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/validation/ValidateWithRelaxNG.kt
@@ -24,19 +24,11 @@ open class ValidateWithRelaxNG(): AbstractAtomicStep() {
         private val dtdIdIdrefWarnings = QName("dtd-id-idref-warnings")
     }
 
-    lateinit var document: XProcDocument
-    lateinit var schema: XProcDocument
-
-    override fun input(port: String, doc: XProcDocument) {
-        if (port == "source") {
-            document = doc
-        } else {
-            schema = doc
-        }
-    }
-
     override fun run() {
         super.run()
+
+        val document = queues["source"]!!.first()
+        val schema = queues["schema"]!!.first()
 
         val dtdAttributeValues = booleanBinding(dtdAttributeValues) ?: false
         val dtdIdIdRefWarnings = booleanBinding(dtdIdIdrefWarnings) ?: false

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/validation/ValidateWithSchematron.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/validation/ValidateWithSchematron.kt
@@ -21,20 +21,13 @@ open class ValidateWithSchematron(): AbstractAtomicStep() {
         private val _phase = QName("phase")
     }
 
-    lateinit var document: XProcDocument
-    lateinit var schema: XProcDocument
     private var svrlToXvrl: Xslt30Transformer? = null
-
-    override fun input(port: String, doc: XProcDocument) {
-        if (port == "source") {
-            document = doc
-        } else {
-            schema = doc
-        }
-    }
 
     override fun run() {
         super.run()
+
+        val document = queues["source"]!!.first()
+        val schema = queues["schema"]!!.first()
 
         val parameters = qnameMapBinding(Ns.parameters)
         val assertValid = booleanBinding(Ns.assertValid) ?: true

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/validation/ValidateWithXmlSchema.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/validation/ValidateWithXmlSchema.kt
@@ -26,22 +26,23 @@ open class ValidateWithXmlSchema(): AbstractAtomicStep() {
     lateinit var document: XProcDocument
     val schemas = mutableListOf<XProcDocument>()
 
-    override fun input(port: String, doc: XProcDocument) {
-        if (port == "source") {
-            document = doc
-        } else {
-            schemas.add(doc)
-        }
-    }
-
     override fun run() {
         super.run()
+
+        document = queues["source"]!!.first()
+        schemas.addAll(queues["schema"]!!)
 
         val manager = stepConfig.processor.getSchemaManager()
         if (manager == null) {
             throw RuntimeException("Schema manager not found, XSD validation requires Saxon EE")
         }
         validateWithSaxon(manager)
+    }
+
+    override fun reset() {
+        super.reset()
+        document = XProcDocument.ofEmpty(stepConfig)
+        schemas.clear()
     }
 
     private fun validateWithSaxon(manager: SchemaManager) {


### PR DESCRIPTION
The previous API didn’t require inputs to be cached. But almost every step had to cache them, so the burden was repeated over and over again. And it introduced bugs when steps, for example, failed to clear their caches when reset.