### PR TITLE
Check for schema support if psvi-required=true

### DIFF
--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/XProcError.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/XProcError.kt
@@ -151,6 +151,7 @@ class XProcError private constructor(val code: QName, val variant: Int, val loca
         fun xdInvalidFunctionSelection() = dynamic(Pair(16, 2))
         fun xdValueNotAllowed(value: XdmValue, allowed: List<XdmAtomicValue>) = dynamic(19, value, allowed)
         fun xdInvalidSerializationProperty() = dynamic(Pair(20,1))
+        fun xdPsviUnsupported() = dynamic(22)
         fun xdNotDtdValid(msg: String) = dynamic(23, msg)
         fun xdValueDoesNotSatisfyType(value: String, type: String) = dynamic(28, value, type)
         fun xdStepFailed(message: String) = dynamic(30, message)

--- a/xmlcalabash/src/main/resources/com/xmlcalabash/explain-errors.txt
+++ b/xmlcalabash/src/main/resources/com/xmlcalabash/explain-errors.txt
@@ -67,6 +67,11 @@ Serialization properties are not compatible.
 It is a dynamic error if the combination of serialization options specified or
 defaulted is not allowed.
 
+XD0022
+Saxon EE is required for XML Schema support.
+It is a dynamic error if a processor that does not support PSVI annotations
+attempts to invoke a step which asserts that they are required.
+
 XD0023
 DTD validation failed: “$1”.
 It is a dynamic error if a DTD validation is performed and either the document


### PR DESCRIPTION
Proactively report that the pipeline will fail, rather than waiting for it to crash.