### PR TITLE
Support for timeouts

### DIFF
--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/api/XProcStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/api/XProcStep.kt
@@ -14,6 +14,7 @@ interface XProcStep {
     fun option(name: QName, binding: LazyValue)
     fun input(port: String, doc: XProcDocument)
     fun run()
+    fun abort()
 
     fun reset()
     fun teardown()

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/StepDeclaration.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/StepDeclaration.kt
@@ -36,6 +36,7 @@ abstract class StepDeclaration(parent: XProcInstruction?, stepConfig: Instructio
 
     val location = stepConfig.location
 
+    internal var timeout = 0
     internal var depends = mutableSetOf<String>()
     internal val _staticOptions = mutableMapOf<QName, StaticOptionDetails>()
     val staticOptions: Map<QName, StaticOptionDetails>
@@ -222,6 +223,21 @@ abstract class StepDeclaration(parent: XProcInstruction?, stepConfig: Instructio
                 throw ex.error.asStatic().exception()
             }
         }
+    }
+
+    fun timeout(value: String) {
+        try {
+            timeout(value.toInt())
+        } catch (_: NumberFormatException) {
+            throw stepConfig.exception(XProcError.xsValueDoesNotSatisfyType(value, "xs:nonNegativeInteger"))
+        }
+    }
+
+    fun timeout(value: Int) {
+        if (value < 0) {
+            throw stepConfig.exception(XProcError.xsValueDoesNotSatisfyType(value.toString(), "xs:nonNegativeInteger"))
+        }
+        timeout = value
     }
 
     fun inputs(): List<PortBindingContainer> {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/XProcError.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/XProcError.kt
@@ -166,6 +166,7 @@ class XProcError private constructor(val code: QName, val variant: Int, val loca
         fun xdNotWellFormed() = dynamic(49)
         fun xdValueTemplateError(message: String) = dynamic(50, message)
         fun xdInvalidAvtResult(result: String) = dynamic(51, result)
+        fun xdStepTimeout(timeout: Long) = dynamic(53, timeout)
         fun xdEncodingWithXmlOrHtml(encoding: String) = dynamic(54, encoding)
         fun xdEncodingRequired(charset: String) = dynamic(55, charset)
         fun xdMarkupForbiddenWithEncoding(encoding: String) = dynamic(56, encoding)
@@ -238,6 +239,7 @@ class XProcError private constructor(val code: QName, val variant: Int, val loca
         fun xcDifferentContentTypes(contentType: MediaType, dataContentType: MediaType) = step(74, contentType, dataContentType)
         fun xcComparisonMethodNotSupported(method: QName) = step(76, method)
         fun xcComparisonNotPossible(sourceType: MediaType, altType: MediaType) = step(77, sourceType, altType)
+        fun xcFailOnTimeout(timeout: Int) = step(78, timeout)
         fun xcInvalidParameter(name: QName, value: String) = step(79, name, value)
         fun xcInvalidNumberOfArchives(number: Int) = step(80, number)
 
@@ -337,6 +339,7 @@ class XProcError private constructor(val code: QName, val variant: Int, val loca
 
         fun xiNoSuchOutputPort(port: String)= internal(1, port)
         fun xiImpossibleNodeType(type: XdmNodeKind) = internal(2, type)
+        fun xiThreadInterrupted() = internal(3)
         fun xiCannotCastTo(to: MediaType) = internal(4, to)
         fun xiConfigurationInvalid(file: String) = internal(Pair(17, 1), file)
         fun xiConfigurationInvalid(file: String, message: String) = internal(Pair(17, 2), file, message)

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/graph/CompoundModel.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/graph/CompoundModel.kt
@@ -5,6 +5,8 @@ import com.xmlcalabash.exceptions.XProcError
 import com.xmlcalabash.namespace.NsP
 
 open class CompoundModel internal constructor(graph: Graph, parent: Model?, step: CompoundStepDeclaration, id: String): Model(graph, parent, step, id) {
+    val timeout = step.timeout
+
     private val _head = Head(graph, this, "${id}_head")
     val head: Head
         get() = _head

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/namespace/NsErr.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/namespace/NsErr.kt
@@ -11,6 +11,8 @@ object NsErr {
     private val stepErrors = mutableMapOf<Int, QName>()
     private val internalErrors = mutableMapOf<Int, QName>()
 
+    val threadInterrupted = xi(3)
+
     fun xs(code: Int): QName {
         val err = staticErrors[code] ?: error(code, "XS")
         staticErrors[code] = err

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/parsers/xpl/XplParser.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/parsers/xpl/XplParser.kt
@@ -859,6 +859,19 @@ class XplParser internal constructor(val builder: PipelineBuilder) {
                                 }
                                 instruction.depends(value)
                             }
+                            Ns.timeout -> {
+                                if (node.node.nodeName.namespaceUri == NsP.namespace) {
+                                    instruction.timeout(value)
+                                } else {
+                                    errors.add(XProcError.xsAttributeForbidden(name).at(node.node).exception())
+                                }
+                            }
+                            NsP.timeout -> {
+                                if (node.node.nodeName.namespaceUri == NsP.namespace) {
+                                    throw XProcError.xsAttributeNotAllowed(name).at(node.node).exception()
+                                }
+                                instruction.depends(value)
+                            }
                             else -> {
                                 if (name.namespaceUri != NamespaceUri.NULL) {
                                     instruction.setExtensionAttribute(name, value)
@@ -927,6 +940,19 @@ class XplParser internal constructor(val builder: PipelineBuilder) {
                     }
                     NsP.inlineExpandText -> {
                         throw XProcError.xsNoSuchOption(NsP.inlineExpandText).at(node.node).exception()
+                    }
+                    Ns.timeout -> {
+                        if (node.node.nodeName.namespaceUri == NsP.namespace) {
+                            atomic.timeout(value)
+                        } else {
+                            errors.add(XProcError.xsAttributeForbidden(name).at(node.node).exception())
+                        }
+                    }
+                    NsP.timeout -> {
+                        if (node.node.nodeName.namespaceUri == NsP.namespace) {
+                            throw XProcError.xsAttributeNotAllowed(name).at(node.node).exception()
+                        }
+                        atomic.depends(value)
                     }
                     else -> {
                         if ((atomic.instructionType.namespaceUri == NsP.namespace && name == Ns.message)

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/model/CompoundStepModel.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/model/CompoundStepModel.kt
@@ -21,6 +21,7 @@ class CompoundStepModel(runtime: XProcRuntime, model: CompoundModel): StepModel(
     lateinit var params: RuntimeStepParameters
     val steps = mutableListOf<StepModel>()
     val edges = mutableListOf<ModelEdge>()
+    val timeout = model.timeout
 
     init {
         staticOptions.putAll(model.step.staticOptions)

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/AtomicOptionStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/AtomicOptionStep.kt
@@ -10,6 +10,8 @@ class AtomicOptionStep(config: XProcStepConfiguration, atomic: AtomicBuiltinStep
     var externalValue: XProcDocument? = null
     internal val atomicOptionValues = mutableMapOf<QName, LazyValue>()
 
+    override val stepTimeout: Long = 0
+
     override fun instantiate() {
         // nop
     }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/ChooseOtherwiseStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/ChooseOtherwiseStep.kt
@@ -9,8 +9,8 @@ open class ChooseOtherwiseStep(yconfig: XProcStepConfiguration, compound: Compou
             instantiate()
         }
 
-        stepsToRun.clear()
-        stepsToRun.addAll(runnables)
+        localStepsToRun.clear()
+        localStepsToRun.addAll(runnables)
 
         head.runStep()
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/ChooseStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/ChooseStep.kt
@@ -19,7 +19,7 @@ open class ChooseStep(config: XProcStepConfiguration, compound: CompoundStepMode
         val context = cache["!source"] ?: mutableListOf()
         cache.remove("!source")
 
-        val stepsToRun = mutableListOf<AbstractStep>()
+        stepsToRun.clear()
         stepsToRun.addAll(runnables.filter { it !is ChooseWhenStep })
 
         stepConfig.environment.newExecutionContext(stepConfig)
@@ -31,10 +31,7 @@ open class ChooseStep(config: XProcStepConfiguration, compound: CompoundStepMode
 
         head.runStep()
 
-        val left = runStepsExhaustively(stepsToRun)
-        if (left.isNotEmpty()) {
-            throw RuntimeException("did not run all steps")
-        }
+        runSubpipeline()
 
         for (step in runnables.filterIsInstance<ChooseWhenStep>()) {
             val guard = step.evaluateGuardExpression()

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/CompoundStepFoot.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/CompoundStepFoot.kt
@@ -14,6 +14,8 @@ class CompoundStepFoot(config: XProcStepConfiguration, val parent: CompoundStep,
     override val params = RuntimeStepParameters(NsCx.foot, "!foot",
         step.location, step.inputs, step.outputs, step.options)
 
+    override val stepTimeout: Long = 0
+
     override val readyToRun: Boolean
         get() = true
 
@@ -36,6 +38,10 @@ class CompoundStepFoot(config: XProcStepConfiguration, val parent: CompoundStep,
     }
 
     internal fun write(port: String, doc: XProcDocument) {
+        if (aborted) {
+            return
+        }
+
         val rpair = receiver[port]
         if (rpair == null) {
             println("No receiver for ${port} from ${this} (in foot)")

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/CompoundStepHead.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/CompoundStepHead.kt
@@ -29,6 +29,7 @@ class CompoundStepHead(config: XProcStepConfiguration, val parent: CompoundStep,
     internal val _cache = mutableMapOf<String, MutableList<XProcDocument>>()
     internal val _options = mutableMapOf<QName, MutableList<XProcDocument>>()
     private val inputErrors = mutableListOf<XProcError>()
+    override val stepTimeout: Long = 0
 
     val cache: Map<String, List<XProcDocument>>
         get() = _cache

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/GroupStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/GroupStep.kt
@@ -5,19 +5,15 @@ import com.xmlcalabash.runtime.model.CompoundStepModel
 
 open class GroupStep(config: XProcStepConfiguration, compound: CompoundStepModel): CompoundStep(config, compound) {
     override fun run() {
-        val stepsToRun = mutableListOf<AbstractStep>()
+        stepsToRun.clear()
         stepsToRun.addAll(runnables)
 
         stepConfig.environment.newExecutionContext(stepConfig)
 
         head.runStep()
-
-        val left = runStepsExhaustively(stepsToRun)
-        if (left.isNotEmpty()) {
-            throw RuntimeException("did not run all steps")
-        }
-
+        runSubpipeline()
         foot.runStep()
+
         stepConfig.environment.releaseExecutionContext()
     }
 }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/TryStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/TryStep.kt
@@ -19,13 +19,14 @@ open class TryStep(config: XProcStepConfiguration, compound: CompoundStepModel):
         var group: GroupStep? = null
         val catches = mutableListOf<TryCatchStep>()
         var finally: TryFinallyStep? = null
-        val others = mutableListOf<AbstractStep>()
+        stepsToRun.clear()
+
         for (step in runnables) {
             when (step) {
                 is TryFinallyStep -> finally = step
                 is TryCatchStep -> catches.add(step)
                 is GroupStep -> group = step
-                else -> others.add(step)
+                else -> stepsToRun.add(step)
             }
         }
 
@@ -35,10 +36,7 @@ open class TryStep(config: XProcStepConfiguration, compound: CompoundStepModel):
         var errorDocument: XProcDocument? = null
         var throwException: Exception? = null
         try {
-            val left = runStepsExhaustively(others)
-            if (left.isNotEmpty()) {
-                throw RuntimeException("did not run all steps")
-            }
+            runSubpipeline()
             group!!.runStep()
         } catch (ex: Exception) {
             foot.cache.clear() // anything that accumulated so far? nope.

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/ViewportStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/ViewportStep.kt
@@ -62,7 +62,7 @@ open class ViewportStep(config: XProcStepConfiguration, compound: CompoundStepMo
 
         val composer = XmlViewportComposer(stepConfig, match, bindings)
 
-        val stepsToRun = mutableListOf<AbstractStep>()
+        stepsToRun.clear()
         stepsToRun.addAll(runnables)
 
         val exec = stepConfig.environment.newExecutionContext(stepConfig)
@@ -97,10 +97,7 @@ open class ViewportStep(config: XProcStepConfiguration, compound: CompoundStepMo
 
                 head.runStep()
 
-                val remaining = runStepsExhaustively(stepsToRun)
-                if (remaining.isNotEmpty()) {
-                    throw stepConfig.exception(XProcError.xiNoRunnableSteps())
-                }
+                runSubpipeline()
 
                 val nodes = mutableListOf<XdmNode>()
                 for (doc in foot.cache[outputPort] ?: emptyList()) {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/AbstractAtomicStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/AbstractAtomicStep.kt
@@ -91,6 +91,10 @@ abstract class AbstractAtomicStep(): XProcStep {
         logger.debug { "Running ${this} (${stepParams.stepName}/${nodeId})" }
     }
 
+    override fun abort() {
+        // nop?
+    }
+
     internal fun forbidNamespaceAttribute(attName: QName) {
         if (attName.localName == "xmlns" || attName.prefix == "xmlns" || NsXmlns.namespace == attName.namespaceUri
             || (attName.prefix == "xml" && attName.namespaceUri != NsXml.namespace)

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/HttpRequestStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/HttpRequestStep.kt
@@ -167,6 +167,10 @@ open class HttpRequestStep(): AbstractAtomicStep() {
             throw stepConfig.exception(XProcError.xcHttpMultipartForbidden(href))
         }
 
+        if (response.statusCode == 408 && failOnTimeout) {
+            throw stepConfig.exception(XProcError.xcFailOnTimeout(timeout!!))
+        }
+
         val report = response.report!!
 
         if (assert != "") {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/internal/NullStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/internal/NullStep.kt
@@ -25,6 +25,10 @@ class NullStep(): XProcStep {
         // nop
     }
 
+    override fun abort() {
+        // nop
+    }
+
     override fun input(port: String, doc: XProcDocument) {
         throw RuntimeException("Configuration error: input called on null step")
     }

--- a/xmlcalabash/src/main/resources/com/xmlcalabash/explain-errors.txt
+++ b/xmlcalabash/src/main/resources/com/xmlcalabash/explain-errors.txt
@@ -135,6 +135,10 @@ Invalid result from attribute value template: “$1”.
 It is a dynamic error if the XPath expression in an AVT or TVT evaluates to
 something to other than a sequence containing atomic values or nodes.
 
+XD0053
+Step timeout; ran for more than “$1” seconds.
+It is a dynamic error if a step runs longer than its timeout value.
+
 XD0054
 Encoding “$1” specified on HTML or XML document.
 It is a dynamic error if an encoding is specified and the content type is an XML
@@ -879,6 +883,11 @@ XC0077
 Media types “$1” and “$2” are incompatible for the comparison.
 It is a dynamic error if the media types of the documents supplied are
 incompatible with the comparison method.
+
+XC0078
+HTTP request timeout, response took more than “$1” seconds.
+It is a dynamic error “fail-on-timeout” is true a HTTP status code 408 is
+encountered.
 
 XC0079
 Invalid $1 parameter value: “$2”.


### PR DESCRIPTION
* Support `timeout` and `fail-on-timeout` parameters on `p:http-request`
* Support `[p:]timeout` on atomic and compound steps
