### PR TITLE
Improve version command

### DIFF
--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/validation/ValidateWithXmlSchema.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/validation/ValidateWithXmlSchema.kt
@@ -43,10 +43,10 @@ open class ValidateWithXmlSchema(): AbstractAtomicStep() {
         schemas.addAll(queues["schema"]!!)
 
         val manager = stepConfig.processor.getSchemaManager()
-        manager.errorReporter = errorReporter
         if (manager == null) {
             throw RuntimeException("Schema manager not found, XSD validation requires Saxon EE")
         }
+        manager.errorReporter = errorReporter
         validateWithSaxon(manager)
     }
 


### PR DESCRIPTION
This PR attempts to improve the `version` command so that it detects a missing license:

```
java -jar xmlcalabash-app-3.0.0-alpha8.jar version
XML Calabash version 3.0.0-alpha8 (build 713c7df, 28 December 2024)
Running with Saxon HE version 12.5
(You appear to have EE; perhaps a license wasn't found?)
```

Related to #74 
