### PR TITLE
Rename a few build properties

### DIFF
--- a/app/src/main/kotlin/com/xmlcalabash/app/XmlCalabashCli.kt
+++ b/app/src/main/kotlin/com/xmlcalabash/app/XmlCalabashCli.kt
@@ -88,6 +88,7 @@ class XmlCalabashCli private constructor() {
             config.traceDocuments = commandLine.traceDocuments
             config.debugger = commandLine.debugger
             config.assertions = commandLine.assertions
+            config.licensed = config.licensed && commandLine.licensed
 
             if (config.trace == null && config.traceDocuments != null) {
                 config.trace = config.traceDocuments!!.resolve("trace.xml")
@@ -312,9 +313,8 @@ class XmlCalabashCli private constructor() {
             println("PRODUCT_NAME=${XmlCalabashBuildConfig.PRODUCT_NAME}")
             println("VERSION=${XmlCalabashBuildConfig.VERSION}")
             println("BUILD_DATE=${XmlCalabashBuildConfig.BUILD_DATE}")
-            println("BUILD_HASH=${XmlCalabashBuildConfig.BUILD_HASH}")
-            println("SAXON=${proc.saxonEdition}")
-            println("SAXON_LICENSE=${license}")
+            println("BUILD_ID=${XmlCalabashBuildConfig.BUILD_ID}")
+            println("SAXON_EDITION=${proc.saxonEdition}")
             println("VENDOR_NAME=${XmlCalabashBuildConfig.VENDOR_NAME}")
             println("VENDOR_URI=${XmlCalabashBuildConfig.VENDOR_URI}")
             for (name in deplist) {
@@ -328,16 +328,8 @@ class XmlCalabashCli private constructor() {
             val dateFormatter = DateTimeFormatter.ofPattern("dd LLLL yyyy")
 
             print("${XmlCalabashBuildConfig.PRODUCT_NAME} version ${XmlCalabashBuildConfig.VERSION} ")
-            println("(build ${XmlCalabashBuildConfig.BUILD_HASH}, ${dateFormatter.format(date)})")
-            print("Running with Saxon ${proc.saxonEdition} version ${proc.saxonProductVersion}")
-            if (proc.saxonEdition != "HE") {
-                if (license) {
-                    print(" (with a license)")
-                } else {
-                    print(" (without a license)")
-                }
-            }
-            println()
+            println("(build ${XmlCalabashBuildConfig.BUILD_ID}, ${dateFormatter.format(date)})")
+            println("Running with Saxon ${proc.saxonEdition} version ${proc.saxonProductVersion}")
             if (edition != proc.saxonEdition) {
                 println("(You appear to have ${edition}; perhaps a license wasn't found?)")
             }

--- a/buildSrc/src/main/kotlin/xmlcalabash-build-plugin.kt
+++ b/buildSrc/src/main/kotlin/xmlcalabash-build-plugin.kt
@@ -24,6 +24,7 @@ interface XmlCalabashBuildExtension {
   abstract val vendorUri: Property<String>
   abstract val buildTime: Property<String>
   abstract val buildDate: Property<String>
+  abstract val buildDateId: Property<String>
 
   fun jarArchiveFilename(): String {
     return "${name.get()}-${version.get()}.jar"
@@ -55,6 +56,10 @@ interface XmlCalabashBuildExtension {
     }
 
     return stdout.toString().trim()
+  }
+
+  fun buildId(): String {
+    return "${gitHash()}.${buildDateId.get()}"
   }
 }
 
@@ -91,5 +96,9 @@ class XmlCalabashBuildPlugin : Plugin<Project> {
     extension.vendorUri.set("https://xmlcalabash.com/")
     extension.buildTime.set(DateTimeFormatter.ISO_INSTANT.format(buildTime))
     extension.buildDate.set(DateTimeFormatter.ofPattern("yyyy-MM-dd").format(buildTime))
+    extension.buildDateId.set(String.format("%02x%x.%02x%02x%02x",
+                                            buildTime.year % 100,
+                                            buildTime.monthValue,
+                                            buildTime.dayOfMonth, buildTime.hour, buildTime.minute))
   }
 }

--- a/documentation/build.gradle.kts
+++ b/documentation/build.gradle.kts
@@ -236,24 +236,7 @@ val reference = tasks.register<SaxonXsltTask>("reference") {
   parameters (
       mapOf(
           "mediaobject-input-base-uri" to "file:${layout.buildDirectory.get()}/reference/",
-          "chunk-output-base-uri" to "${layout.buildDirectory.get()}/reference/",
-          "dep_saxon" to project.findProperty("saxonVersion").toString(),
-          "dep_brotliDec" to project.findProperty("brotliDec").toString(),
-          "dep_commonsCodec" to project.findProperty("commonsCodec").toString(),
-          "dep_commonsCompress" to project.findProperty("commonsCompress").toString(),
-          "dep_flexmarkAll" to project.findProperty("flexmarkAll").toString(),
-          "dep_graalvmJS" to project.findProperty("graalvmJS").toString(),
-          "dep_htmlparser" to project.findProperty("htmlparser").toString(),
-          "dep_httpClient" to project.findProperty("httpClient").toString(),
-          "dep_jing" to project.findProperty("jing").toString(),
-          "dep_jsonSchemaValidator" to project.findProperty("jsonSchemaValidator").toString(),
-          "dep_schxslt2" to project.findProperty("schxslt2").toString(),
-          "dep_sinclude" to project.findProperty("sinclude").toString(),
-          "dep_slf4j" to project.findProperty("slf4j").toString(),
-          "dep_tukaaniXz" to project.findProperty("tukaaniXz").toString(),
-          "dep_uuidCreator" to project.findProperty("uuidCreator").toString(),
-          "dep_xercesImpl" to project.findProperty("xercesImpl").toString(),
-          "dep_xmlResolver" to project.findProperty("xmlResolver").toString()
+          "chunk-output-base-uri" to "${layout.buildDirectory.get()}/reference/"
       )
   )
 
@@ -377,24 +360,7 @@ val userguide = tasks.register<SaxonXsltTask>("userguide") {
   parameters (
       mapOf(
           "mediaobject-input-base-uri" to "file:${layout.buildDirectory.get()}/userguide/",
-          "chunk-output-base-uri" to "${layout.buildDirectory.get()}/userguide/",
-          "dep_saxon" to project.findProperty("saxonVersion").toString(),
-          "dep_brotliDec" to project.findProperty("brotliDec").toString(),
-          "dep_commonsCodec" to project.findProperty("commonsCodec").toString(),
-          "dep_commonsCompress" to project.findProperty("commonsCompress").toString(),
-          "dep_flexmarkAll" to project.findProperty("flexmarkAll").toString(),
-          "dep_graalvmJS" to project.findProperty("graalvmJS").toString(),
-          "dep_htmlparser" to project.findProperty("htmlparser").toString(),
-          "dep_httpClient" to project.findProperty("httpClient").toString(),
-          "dep_jing" to project.findProperty("jing").toString(),
-          "dep_jsonSchemaValidator" to project.findProperty("jsonSchemaValidator").toString(),
-          "dep_schxslt2" to project.findProperty("schxslt2").toString(),
-          "dep_sinclude" to project.findProperty("sinclude").toString(),
-          "dep_slf4j" to project.findProperty("slf4j").toString(),
-          "dep_tukaaniXz" to project.findProperty("tukaaniXz").toString(),
-          "dep_uuidCreator" to project.findProperty("uuidCreator").toString(),
-          "dep_xercesImpl" to project.findProperty("xercesImpl").toString(),
-          "dep_xmlResolver" to project.findProperty("xmlResolver").toString()
+          "chunk-output-base-uri" to "${layout.buildDirectory.get()}/userguide/"
       )
   )
 

--- a/documentation/src/reference/functions.xml
+++ b/documentation/src/reference/functions.xml
@@ -106,7 +106,7 @@
   <varlistentry>
     <term><varname>cx:product-build</varname></term>
     <listitem>
-      <para>Returns the product build identifier, for example “<literal><?version build-hash?></literal>”.
+      <para>Returns the product build identifier, for example “<literal><?version build-id?></literal>”.
       </para>
     </listitem>
   </varlistentry>

--- a/documentation/src/userguide/run.xml
+++ b/documentation/src/userguide/run.xml
@@ -408,14 +408,13 @@ command line arguments are ignored.</para>
   <command>xmlcalabash</command>
   <arg choice="plain">version</arg>
   <arg rep="norepeat" linkend="cli-verbosity">--verbosity:<replaceable>verbosity</replaceable></arg>
-  <arg rep="norepeat" linkend="cli-debug">--debug</arg>
 </cmdsynopsis>
 
 <para>Displays the XML Calabash version and the version of Saxon:</para>
 
 <screen><userinput><prompt>$</prompt> xmlcalabash version</userinput>
-<computeroutput>XML Calabash version <?version?> (build <?version build-hash?>, <?version build-date display?>)
-Running with Saxon EE version 12.5 (with a license)</computeroutput></screen>
+<computeroutput>XML Calabash version <?version?> (build <?version build-id?>, <?version build-date display?>)
+Running with Saxon <?version saxon-edition?> version <?dep saxon?></computeroutput></screen>
 
 <para>Most options are ignored when the <command>version</command> command is
 used, but if the <literal>debug</literal> level of <option>--verbosity</option>
@@ -427,9 +426,8 @@ is formatted in a way that can more easily be parsed, for example by a shell scr
 <computeroutput>PRODUCT_NAME=XML Calabash
 VERSION=<?version VERSION?>
 BUILD_DATE=<?version BUILD_DATE?>
-BUILD_HASH=<?version BUILD_HASH?>
-SAXON=<?version SAXON?>
-SAXON_LICENSE=<?version SAXON_LICENSE?>
+BUILD_ID=<?version BUILD_ID?>
+SAXON_EDITION=<?version SAXON_EDITION?>
 VENDOR_NAME=Norm Tovey-Walsh
 VENDOR_URI=https://xmlcalabash.com/
 DEPENDENCY_brotliDec=<?version DEPENDENCY_brotliDec?>

--- a/documentation/src/xsl/common.xsl
+++ b/documentation/src/xsl/common.xsl
@@ -108,29 +108,17 @@
   </xsl:choose>
 </xsl:template>
 
-<xsl:template match="processing-instruction('dep')">
+<xsl:template match="processing-instruction('dep')" as="xs:string">
   <xsl:variable name="dep" select="normalize-space(.)"/>
+  <xsl:variable name="value" select="map:get($VERSION, 'DEPENDENCY_' || $dep)"/>
 
   <xsl:choose>
-    <xsl:when test="$dep = 'brotliDec'">{$dep_brotliDec}</xsl:when>
-    <xsl:when test="$dep = 'commonsCodec'">{$dep_commonsCodec}</xsl:when>
-    <xsl:when test="$dep = 'commonsCompress'">{$dep_commonsCompress}</xsl:when>
-    <xsl:when test="$dep = 'flexmarkAll'">{$dep_flexmarkAll}</xsl:when>
-    <xsl:when test="$dep = 'graalvmJS'">{$dep_graalvmJS}</xsl:when>
-    <xsl:when test="$dep = 'htmlparser'">{$dep_htmlparser}</xsl:when>
-    <xsl:when test="$dep = 'httpClient'">${dep_httpClient}</xsl:when>
-    <xsl:when test="$dep = 'jing'">${dep_jing}</xsl:when>
-    <xsl:when test="$dep = 'jsonSchemaValidator'">{$dep_jsonSchemaValidator}</xsl:when>
-    <xsl:when test="$dep = 'schxslt2'">{$dep_schxslt2}</xsl:when>
-    <xsl:when test="$dep = 'sinclude'">${dep_sinclude}</xsl:when>
-    <xsl:when test="$dep = 'slf4j'">${dep_slf4j}</xsl:when>
-    <xsl:when test="$dep = 'tukaaniXz'">{$dep_tukaaniXz}</xsl:when>
-    <xsl:when test="$dep = 'uuidCreator'">{$dep_uuidCreator}</xsl:when>
-    <xsl:when test="$dep = 'xercesImpl'">${dep_xercesImpl}</xsl:when>
-    <xsl:when test="$dep = 'xmlResolver'">${dep_xmlResolver}</xsl:when>
-    <xsl:otherwise>
+    <xsl:when test="empty($value)">
       <xsl:message select="'Unrecognized dependency: ' || $dep"/>
       <xsl:sequence select="'UNRECOGNIZED'"/>
+    </xsl:when>
+    <xsl:otherwise>
+      <xsl:sequence select="string($value)"/>
     </xsl:otherwise>
   </xsl:choose>
 </xsl:template>

--- a/documentation/src/xsl/ref-custom.xsl
+++ b/documentation/src/xsl/ref-custom.xsl
@@ -43,7 +43,7 @@
           </div>
           <div class="version">
             <xsl:text>for XML Calabash </xsl:text>
-            <span title="{$VERSION?BUILD_HASH} {$VERSION?BUILD_DATE}">{$VERSION?VERSION}</span>
+            <span title="Build id: {$VERSION?BUILD_ID}">{$VERSION?VERSION}</span>
           </div>
           <div class="date">
             <xsl:text>Updated: </xsl:text>

--- a/documentation/src/xsl/user-custom.xsl
+++ b/documentation/src/xsl/user-custom.xsl
@@ -55,7 +55,7 @@
           </div>
           <div class="version">
             <xsl:text>for XML Calabash </xsl:text>
-            <span title="{$VERSION?BUILD_HASH} {$VERSION?BUILD_DATE}">{$VERSION?VERSION}</span>
+            <span title="Build id: {$VERSION?BUILD_ID}">{$VERSION?VERSION}</span>
           </div>
           <div class="date">
             <xsl:text>Updated: </xsl:text>

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ saxonVersion=12.5
 xmlResolverVersion=6.0.11
 
 xmlcalabashGroup=com.xmlcalabash
-xmlcalabashVersion=3.0.0-alpha8
+xmlcalabashVersion=3.0.0-alpha9-SNAPSHOT
 // name is defined in settings.gradle.kts
 
 builtBy=Norm Tovey-Walsh

--- a/test-driver/src/main/kotlin/com/xmlcalabash/testdriver/TestDriver.kt
+++ b/test-driver/src/main/kotlin/com/xmlcalabash/testdriver/TestDriver.kt
@@ -2,13 +2,10 @@ package com.xmlcalabash.testdriver
 
 import com.xmlcalabash.config.XmlCalabash
 import com.xmlcalabash.util.BufferingMessageReporter
-import com.xmlcalabash.util.DefaultMessageReporter
 import com.xmlcalabash.util.DefaultXmlCalabashConfiguration
-import com.xmlcalabash.util.LoggingMessageReporter
 import com.xmlcalabash.util.NopMessageReporter
 import com.xmlcalabash.util.SaxonTreeBuilder
 import com.xmlcalabash.util.SchematronAssertions
-import com.xmlcalabash.util.Verbosity
 import net.sf.saxon.event.ReceiverOption
 import net.sf.saxon.om.AttributeInfo
 import net.sf.saxon.om.AttributeMap
@@ -314,7 +311,7 @@ class TestDriver(val testOptions: TestOptions, val exclusions: Map<String, Strin
         val env = saxonConfig.environment
         property(report, "processor", env.productName)
         property(report, "version", env.productVersion)
-        property(report, "gitHash", env.gitHash)
+        property(report, "buildId", env.buildId)
         property(report, "saxonVersion", "${saxonConfig.processor.saxonProductVersion}/${saxonConfig.processor.saxonEdition}")
         property(report, "vendor", env.vendor)
         property(report, "vendorURI", env.vendorUri)

--- a/xmlcalabash/build.gradle.kts
+++ b/xmlcalabash/build.gradle.kts
@@ -107,7 +107,7 @@ buildConfig {
   buildConfigField("VENDOR_NAME", xmlbuild.vendorName.get())
   buildConfigField("VENDOR_URI", xmlbuild.vendorUri.get())
   buildConfigField("BUILD_DATE", xmlbuild.buildDate.get())
-  buildConfigField("BUILD_HASH", xmlbuild.gitHash())
+  buildConfigField("BUILD_ID", xmlbuild.buildId())
   buildConfigField("SCHXSLT2", project.findProperty("schxslt2").toString())
 
   val sb = StringBuilder()

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/PipelineCompilerContext.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/PipelineCompilerContext.kt
@@ -33,7 +33,7 @@ class PipelineCompilerContext(override val xmlCalabash: XmlCalabash): PipelineEn
     override val locale = Locale.getDefault().toString().replace("_", "-")
     override val productName = XmlCalabashBuildConfig.PRODUCT_NAME
     override val productVersion = XmlCalabashBuildConfig.VERSION
-    override val gitHash = XmlCalabashBuildConfig.BUILD_HASH
+    override val buildId = XmlCalabashBuildConfig.BUILD_ID
     override val vendor = XmlCalabashBuildConfig.VENDOR_NAME
     override val vendorUri = XmlCalabashBuildConfig.VENDOR_URI
     override val version = "3.0"

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/PipelineEnvironment.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/PipelineEnvironment.kt
@@ -3,11 +3,9 @@ package com.xmlcalabash.datamodel
 import com.xmlcalabash.config.CommonEnvironment
 import com.xmlcalabash.config.ExecutionContextManager
 import com.xmlcalabash.config.XmlCalabash
-import com.xmlcalabash.debugger.Debugger
 import com.xmlcalabash.exceptions.ErrorExplanation
 import com.xmlcalabash.io.DocumentManager
 import com.xmlcalabash.runtime.Monitor
-import com.xmlcalabash.tracing.TraceListener
 import com.xmlcalabash.api.MessageReporter
 import com.xmlcalabash.util.SchematronAssertions
 import net.sf.saxon.s9api.QName
@@ -21,7 +19,7 @@ interface PipelineEnvironment: ExecutionContextManager {
     val locale: String
     val productName: String
     val productVersion: String
-    val gitHash: String
+    val buildId: String
     val vendor: String
     val vendorUri: String
     val version: String

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/functions/SystemPropertyFunction.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/functions/SystemPropertyFunction.kt
@@ -58,7 +58,7 @@ class SystemPropertyFunction(private val config: SaxonConfiguration): ExtensionF
                 NsP.psviSupported -> config.processor.isSchemaAware.toString()
                 NsCx.saxonVersion -> config.processor.saxonProductVersion
                 NsCx.saxonEdition -> config.processor.saxonEdition
-                NsCx.productBuild -> env.gitHash
+                NsCx.productBuild -> env.buildId
                 else -> ""
             }
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/PipelineContext.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/PipelineContext.kt
@@ -34,7 +34,7 @@ class PipelineContext(compilerContext: PipelineCompilerContext): PipelineEnviron
     override val locale = Locale.getDefault().toString().replace("_", "-")
     override val productName = XmlCalabashBuildConfig.PRODUCT_NAME
     override val productVersion = XmlCalabashBuildConfig.VERSION
-    override val gitHash = XmlCalabashBuildConfig.BUILD_HASH
+    override val buildId = XmlCalabashBuildConfig.BUILD_ID
     override val vendor = XmlCalabashBuildConfig.VENDOR_NAME
     override val vendorUri = XmlCalabashBuildConfig.VENDOR_URI
     override val version = "3.0"


### PR DESCRIPTION
Renamed BUILD_HASH to BUILD_ID, extended it with a few more bits. Renamed SAXON to SAXON_EDITION. Removed SAXON_LICENSED; that’s effectively determined by the edition.