### PR TITLE
Fix NVDL validation by adding an explicit XercesImpl dependency

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ saxonVersion=12.5
 xmlResolverVersion=6.0.11
 
 xmlcalabashGroup=com.xmlcalabash
-xmlcalabashVersion=3.0.0-alpha9
+xmlcalabashVersion=3.0.0-alpha10-SNAPSHOT
 // name is defined in settings.gradle.kts
 
 builtBy=Norm Tovey-Walsh

--- a/xmlcalabash/build.gradle.kts
+++ b/xmlcalabash/build.gradle.kts
@@ -37,6 +37,7 @@ val dep_flexmarkAll = project.findProperty("flexmarkAll").toString()
 val dep_htmlparser = project.findProperty("htmlparser").toString()
 val dep_httpClient = project.findProperty("httpClient").toString()
 val dep_jing = project.findProperty("jing").toString()
+val dep_xerces = project.findProperty("xercesImpl").toString()
 val dep_jsonSchemaValidator = project.findProperty("jsonSchemaValidator").toString()
 val dep_graalvmJS = project.findProperty("graalvmJS").toString()
 val dep_schxslt2 = project.findProperty("schxslt2").toString()
@@ -70,6 +71,7 @@ dependencies {
   implementation("org.relaxng:jing:${dep_jing}") {
     exclude(group="net.sf.saxon", module="Saxon-HE")
   }
+  implementation("xerces:xercesImpl:${dep_xerces}")
   implementation("com.networknt:json-schema-validator:${dep_jsonSchemaValidator}")
   implementation("org.graalvm.polyglot:js:${dep_graalvmJS}")
   implementation("org.xmlresolver:xmlresolver:${dep_xmlResolver}")


### PR DESCRIPTION
Fix #105 

It's not clear to me how anything else works without the dependency or why, given that it does, NVDL doesn't work. But this seems to fix it.