### PR TITLE
Tinker with timeout and sleep duration

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ saxonVersion=12.5
 xmlResolverVersion=6.0.11
 
 xmlcalabashGroup=com.xmlcalabash
-xmlcalabashVersion=3.0.0-alpha10-SNAPSHOT
+xmlcalabashVersion=3.0.0-alpha10
 // name is defined in settings.gradle.kts
 
 builtBy=Norm Tovey-Walsh

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/StepDeclaration.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/StepDeclaration.kt
@@ -4,7 +4,9 @@ import com.xmlcalabash.exceptions.XProcError
 import com.xmlcalabash.exceptions.XProcException
 import com.xmlcalabash.util.AssertionsLevel
 import com.xmlcalabash.util.AssertionsMonitor
+import com.xmlcalabash.util.DurationUtils
 import net.sf.saxon.s9api.QName
+import java.time.Duration
 
 abstract class StepDeclaration(parent: XProcInstruction?, stepConfig: InstructionConfiguration, instructionType: QName): XProcInstruction(parent, stepConfig, instructionType) {
     private var nameAssigned = false
@@ -26,7 +28,7 @@ abstract class StepDeclaration(parent: XProcInstruction?, stepConfig: Instructio
 
     val location = stepConfig.location
 
-    internal var timeout = 0
+    internal var timeout = Duration.ZERO
     internal var depends = mutableSetOf<String>()
     internal val _staticOptions = mutableMapOf<QName, StaticOptionDetails>()
     val staticOptions: Map<QName, StaticOptionDetails>
@@ -216,18 +218,7 @@ abstract class StepDeclaration(parent: XProcInstruction?, stepConfig: Instructio
     }
 
     fun timeout(value: String) {
-        try {
-            timeout(value.toInt())
-        } catch (_: NumberFormatException) {
-            throw stepConfig.exception(XProcError.xsValueDoesNotSatisfyType(value, "xs:nonNegativeInteger"))
-        }
-    }
-
-    fun timeout(value: Int) {
-        if (value < 0) {
-            throw stepConfig.exception(XProcError.xsValueDoesNotSatisfyType(value.toString(), "xs:nonNegativeInteger"))
-        }
-        timeout = value
+        timeout = DurationUtils.parseDuration(stepConfig, value)
     }
 
     fun inputs(): List<PortBindingContainer> {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/XProcError.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/XProcError.kt
@@ -168,7 +168,7 @@ class XProcError private constructor(val code: QName, val variant: Int, val loca
         fun xdNotWellFormed() = dynamic(49)
         fun xdValueTemplateError(message: String) = dynamic(50, message)
         fun xdInvalidAvtResult(result: String) = dynamic(51, result)
-        fun xdStepTimeout(timeout: Long) = dynamic(53, timeout)
+        fun xdStepTimeout(timeout: String) = dynamic(53, timeout)
         fun xdEncodingWithXmlOrHtml(encoding: String) = dynamic(54, encoding)
         fun xdEncodingRequired(charset: String) = dynamic(55, charset)
         fun xdMarkupForbiddenWithEncoding(encoding: String) = dynamic(56, encoding)

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/AtomicOptionStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/AtomicOptionStep.kt
@@ -5,12 +5,13 @@ import com.xmlcalabash.runtime.LazyValue
 import com.xmlcalabash.runtime.XProcStepConfiguration
 import com.xmlcalabash.runtime.model.AtomicBuiltinStepModel
 import net.sf.saxon.s9api.QName
+import java.time.Duration
 
 class AtomicOptionStep(config: XProcStepConfiguration, atomic: AtomicBuiltinStepModel, val externalName: QName): AtomicStep(config, atomic) {
     var externalValue: XProcDocument? = null
     internal val atomicOptionValues = mutableMapOf<QName, LazyValue>()
 
-    override val stepTimeout: Long = 0
+    override val stepTimeout: Duration = Duration.ZERO
 
     override fun instantiate() {
         // nop

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/AtomicStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/AtomicStep.kt
@@ -21,7 +21,7 @@ open class AtomicStep(config: XProcStepConfiguration, atomic: AtomicBuiltinStepM
     val openPorts = mutableSetOf<String>()
     private var message: XdmValue? = null
     private val inputErrors = mutableListOf<XProcError>()
-    override val stepTimeout = atomic.model.step.timeout.toLong()
+    override val stepTimeout = atomic.model.step.timeout
 
     init {
         inputPorts.addAll(atomic.inputs.keys)

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/CompoundStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/CompoundStep.kt
@@ -44,7 +44,7 @@ abstract class CompoundStep(config: XProcStepConfiguration, compound: CompoundSt
     internal val foot = CompoundStepFoot(config, this, compound.foot)
     internal var stepName: String? = null
     internal var stepType: QName? = null
-    override val stepTimeout = compound.timeout.toLong()
+    override val stepTimeout = compound.timeout
     protected val stepsToRun = mutableListOf<AbstractStep>()
 
     override val readyToRun: Boolean

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/CompoundStepFoot.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/CompoundStepFoot.kt
@@ -6,6 +6,7 @@ import com.xmlcalabash.namespace.NsCx
 import com.xmlcalabash.runtime.XProcStepConfiguration
 import com.xmlcalabash.runtime.model.FootModel
 import com.xmlcalabash.runtime.parameters.RuntimeStepParameters
+import java.time.Duration
 
 class CompoundStepFoot(config: XProcStepConfiguration, val parent: CompoundStep, step: FootModel): AbstractStep(config, step, NsCx.foot, "${step.name}/foot") {
     internal var alwaysAllowSequences = false
@@ -14,7 +15,7 @@ class CompoundStepFoot(config: XProcStepConfiguration, val parent: CompoundStep,
     override val params = RuntimeStepParameters(NsCx.foot, "!foot",
         step.location, step.inputs, step.outputs, step.options)
 
-    override val stepTimeout: Long = 0
+    override val stepTimeout: Duration = Duration.ZERO
 
     override val readyToRun: Boolean
         get() = true

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/CompoundStepHead.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/CompoundStepHead.kt
@@ -14,6 +14,7 @@ import net.sf.saxon.s9api.XdmFunctionItem
 import net.sf.saxon.s9api.XdmNode
 import net.sf.saxon.s9api.XdmNodeKind
 import net.sf.saxon.s9api.XdmValue
+import java.time.Duration
 import kotlin.collections.component1
 import kotlin.collections.component2
 import kotlin.collections.iterator
@@ -29,7 +30,7 @@ class CompoundStepHead(config: XProcStepConfiguration, val parent: CompoundStep,
     internal val _cache = mutableMapOf<String, MutableList<XProcDocument>>()
     internal val _options = mutableMapOf<QName, MutableList<XProcDocument>>()
     private val inputErrors = mutableListOf<XProcError>()
-    override val stepTimeout: Long = 0
+    override val stepTimeout: Duration = Duration.ZERO
 
     val cache: Map<String, List<XProcDocument>>
         get() = _cache

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/SleepStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/SleepStep.kt
@@ -2,30 +2,27 @@ package com.xmlcalabash.steps
 
 import com.xmlcalabash.exceptions.XProcError
 import com.xmlcalabash.namespace.Ns
-import org.apache.logging.log4j.kotlin.logger
+import com.xmlcalabash.namespace.NsXs
+import com.xmlcalabash.util.DurationUtils
+import net.sf.saxon.s9api.XdmNode
+import net.sf.saxon.value.DayTimeDurationValue
+import java.time.Duration
 
 open class SleepStep(): AbstractAtomicStep() {
     override fun run() {
         super.run()
 
-        val duration = stringBinding(Ns.duration)!!
-        val ms = try {
-            duration.toLong()
-        } catch (ex: NumberFormatException) {
-            throw stepConfig.exception(XProcError.xdBadType("Invalid duration: ${duration}"), ex)
-        }
+        val duration = DurationUtils.parseDuration(stepConfig, stringBinding(Ns.duration)!!)
+        val ms = duration.toMillis()
 
-        if (ms < 0) {
-            throw stepConfig.exception(XProcError.xdBadType("Invalid duration: ${duration}"))
-        }
-
-        stepConfig.debug { "Sleeping for ${String.format("%1.1f", (1.0 * ms) / 1000.0)}s ... "}
+        stepConfig.debug { "Sleeping for ${DurationUtils.prettyPrint(duration)} ... "}
         Thread.sleep(ms)
 
         for (doc in queues["source"]!!) {
             receiver.output("result", doc)
         }
     }
+
 
     override fun toString(): String = "p:sleep"
 }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/DurationUtils.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/DurationUtils.kt
@@ -1,0 +1,71 @@
+package com.xmlcalabash.util
+
+import com.xmlcalabash.exceptions.XProcError
+import com.xmlcalabash.namespace.NsXs
+import com.xmlcalabash.runtime.XProcStepConfiguration
+import net.sf.saxon.value.DayTimeDurationValue
+import java.time.Duration
+
+class DurationUtils {
+    companion object {
+        fun parseDuration(stepConfig: XProcStepConfiguration, str: String): Duration {
+            var xdtStr = ""
+            try {
+                val s = str.toLong()
+                if (s < 0) {
+                    throw stepConfig.exception(XProcError.xdBadType("Invalid duration: ${str}"))
+                }
+                xdtStr = "PT%dS".format(s)
+            } catch (_: NumberFormatException) {
+                try {
+                    val s = str.toDouble()
+                    if (s < 0) {
+                        throw stepConfig.exception(XProcError.xdBadType("Invalid duration: ${str}"))
+                    }
+                    xdtStr = "PT%1.2fS".format(s)
+                } catch (_: NumberFormatException) {
+                    xdtStr = str
+                }
+            }
+
+            val xdt = try {
+                val compiler = stepConfig.newXPathCompiler()
+                val exec = compiler.compile("Q{${NsXs.namespace}}dayTimeDuration(\"${xdtStr}\")")
+                val selector = exec.load()
+                selector.evaluate()
+            } catch (ex: Exception) {
+                throw stepConfig.exception(XProcError.xdBadType("Invalid duration: ${str}"), ex)
+            }
+
+            return (xdt.underlyingValue as DayTimeDurationValue).toJavaDuration()
+        }
+
+        fun prettyPrint(duration: Duration): String {
+            val sb = StringBuilder()
+            val days = duration.toDaysPart()
+            if (days > 0) {
+                sb.append("${days} day${if (days != 1L) "s" else ""}, ")
+            }
+            val hours = duration.toHoursPart()
+            if (hours > 0) {
+                sb.append("${hours} hour${if (hours != 1) "s" else ""}, ")
+            }
+            val minutes = duration.toMinutesPart()
+            if (minutes > 0) {
+                sb.append("${minutes} minute${if (minutes != 1) "s" else ""}, ")
+            }
+            val seconds = duration.toSecondsPart()
+            val ms = duration.toMillisPart()
+            val frac = if (ms > 0) {
+                val fs = "%1.2f".format(ms / 1000.0)
+                fs.substring(1)
+            } else {
+                ""
+            }
+
+            sb.append("${seconds}${frac} second${if (seconds != 1 || frac != "") "s" else ""}")
+
+            return sb.toString()
+        }
+    }
+}


### PR DESCRIPTION
Sleep duration is now seconds, not milliseconds. Both values can now accept either a numerical number of seconds or an xs:dayTimeDuration string value.