### PR TITLE
Add a namespace declaration to the cc:xml-calabash tableaux

### DIFF
--- a/documentation/src/rng/docbook.rnc
+++ b/documentation/src/rng/docbook.rnc
@@ -32,6 +32,7 @@ rng.pattern =
     element rng-pattern {
         attribute schema { text }?,
         attribute name { text },
+        attribute ns { text }?,
         attribute prefix { text }?,
         attribute format { "table" }?,
         empty

--- a/documentation/src/userguide/config.xml
+++ b/documentation/src/userguide/config.xml
@@ -22,6 +22,7 @@ The conventional prefix for this namespace in the documentation is <code>cc:</co
 </para>
 
 <rng-pattern schema="../../build/xml-calabash.rng"
+             ns="https://xmlcalabash.com/ns/configuration"
              name="cc.xmlCalabash"/>
 
 <variablelist>

--- a/documentation/src/xsl/rngsyntax.xsl
+++ b/documentation/src/xsl/rngsyntax.xsl
@@ -36,6 +36,8 @@
                     select="if (@prefix) then @prefix else substring-before($name, '.')"/>
     <xsl:with-param name="format" tunnel="yes"
                     select="@format"/>
+    <xsl:with-param name="namespace" tunnel="yes"
+                    select="@ns"/>
   </xsl:apply-templates>
 </xsl:template>
 
@@ -43,6 +45,7 @@
   <xsl:param name="schema" as="element(rng:grammar)" tunnel="yes"/>
   <xsl:param name="prefix" as="xs:string" tunnel="yes"/>
   <xsl:param name="format" as="xs:string?" tunnel="yes"/>
+  <xsl:param name="namespace" as="xs:string?" tunnel="yes"/>
 
   <xsl:variable name="rngpat" select="."/>
   <xsl:variable name="class" select="()"/>
@@ -387,6 +390,8 @@
 <!-- ============================================================ -->
 
 <xsl:template match="ss:element-summary">
+  <xsl:param name="namespace" as="xs:string?" tunnel="yes"/>
+
   <p id="{if (@xml:id) then @xml:id else generate-id(.)}">
     <!-- this generates the prefix= attribute ...
     <xsl:sequence select="f:html-attributes(., generate-id(.))"/>
@@ -408,6 +413,13 @@
 	  <xsl:value-of select="if (contains(@name,':'))
 				then substring-after(@name,':')
 				else @name"/>
+          <xsl:if test="$namespace">
+            <xsl:text> xmlns:</xsl:text>
+            <xsl:value-of select="@prefix"/>
+            <xsl:text>="</xsl:text>
+            <xsl:value-of select="$namespace"/>
+            <xsl:text>"</xsl:text>
+          </xsl:if>
 	</xsl:when>
 	<xsl:when test=".//ss:model[@name='subpipeline']">
 	  <var>

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ saxonVersion=12.5
 xmlResolverVersion=6.0.11
 
 xmlcalabashGroup=com.xmlcalabash
-xmlcalabashVersion=3.0.0-alpha12
+xmlcalabashVersion=3.0.0-alpha13-SNAPSHOT
 // name is defined in settings.gradle.kts
 
 builtBy=Norm Tovey-Walsh

--- a/test-driver/src/test/resources/exclusions.txt
+++ b/test-driver/src/test/resources/exclusions.txt
@@ -1,6 +1,5 @@
 ab-p-archive-067 because multiple archives are supported for create
 
-ab-xslt-094 because https://github.com/xproc/3.0-steps/issues/642
 ab-import-functions-008 because https://saxonica.plan.io/issues/6603
 ab-import-functions-009 because https://saxonica.plan.io/issues/6603
 


### PR DESCRIPTION
This is a doc fix so it won't get published until the next release. The output is now:

```xml
<cc:xml-calabash xmlns:cc="https://xmlcalabash.com/ns/configuration"
  version? = 1.0
  saxon-configuration? = string
  licensed? = boolean
  verbosity? = trace|debug|progress|info|warn|error>
    ([cc:graphviz](http://localhost:8126/configuration.html#cc.graphviz) |
  ...
```

I only added this to the tableaux for the root element, but it could be added elsewhere as well.