### PR TITLE
Update configuration to make @licensed more sensible

### DIFF
--- a/app/src/main/kotlin/com/xmlcalabash/app/XmlCalabashCli.kt
+++ b/app/src/main/kotlin/com/xmlcalabash/app/XmlCalabashCli.kt
@@ -338,7 +338,11 @@ class XmlCalabashCli private constructor() {
             println("(build ${XmlCalabashBuildConfig.BUILD_ID}, ${dateFormatter.format(date)})")
             println("Running with Saxon ${proc.saxonEdition} version ${proc.saxonProductVersion}")
             if (edition != proc.saxonEdition) {
-                println("(You appear to have ${edition}; perhaps a license wasn't found?)")
+                if (xmlCalabash.xmlCalabashConfig.licensed) {
+                    println("(You appear to have ${edition}; perhaps a license wasn't found?)")
+                } else {
+                    println("(You appear to have ${edition} but the license is explicitly disabled.)")
+                }
             }
         }
     }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/config/ConfigurationLoader.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/config/ConfigurationLoader.kt
@@ -133,7 +133,10 @@ class ConfigurationLoader private constructor(private val config: XmlCalabashCon
             }
         }
 
-        config.licensed = booleanAttribute(root.getAttributeValue(_licensed), "licensed")
+        if (root.getAttributeValue(_licensed) != null) {
+            config.licensed = booleanAttribute(root.getAttributeValue(_licensed), "licensed")
+        }
+
         config.verbosity = verbosityAttribute(root.getAttributeValue(_verbosity))
 
         for (child in root.axisIterator(Axis.CHILD)) {


### PR DESCRIPTION
If the configuration property @licensed is explicitly “false”, create an unlicensed configuration, otherwise attempt to create a licensed one if we can.

Fix #124 