### PR TITLE
Added an --explain command line argument

### DIFF
--- a/app/src/main/kotlin/com/xmlcalabash/app/CommandLine.kt
+++ b/app/src/main/kotlin/com/xmlcalabash/app/CommandLine.kt
@@ -50,6 +50,7 @@ class CommandLine private constructor(val args: Array<out String>) {
     private var _debugger = false
     private var _visualizer: Monitor? = null
     private var _verbosity: Verbosity? = null
+    private var _explainErrors = false
     private var _assertions = AssertionsLevel.IGNORE
     private var _help = false
     private var _trace: File? = null
@@ -92,6 +93,10 @@ class CommandLine private constructor(val args: Array<out String>) {
     /** How chatty shall we be? */
     val verbosity: Verbosity?
         get() = _verbosity
+
+    /** Shall we try to explain errors? */
+    val explainErrors: Boolean
+        get() = _explainErrors
 
     /** Did we select a visualizer? */
     val visualizer: Monitor?
@@ -183,6 +188,7 @@ class CommandLine private constructor(val args: Array<out String>) {
         ArgumentDescription("--licensed", listOf(), ArgumentType.BOOLEAN, "true") { it -> _licensed = it == "true" },
         ArgumentDescription("--debug", listOf("-D"), ArgumentType.BOOLEAN, "true") { it -> _debug = it == "true" },
         ArgumentDescription("--debugger", listOf(), ArgumentType.BOOLEAN, "true") { it -> _debugger = it == "true" },
+        ArgumentDescription("--explain", listOf(), ArgumentType.BOOLEAN, "true") { it -> _explainErrors = it == "true" },
         ArgumentDescription("--help", listOf(), ArgumentType.BOOLEAN, "true") { it -> _help = it == "true" },
         ArgumentDescription("--trace", listOf(), ArgumentType.FILE) { it -> _trace = File(it) },
         ArgumentDescription("--trace-documents", listOf("--trace-docs"), ArgumentType.DIRECTORY) { it -> _traceDocuments = File(it) },

--- a/app/src/main/kotlin/com/xmlcalabash/app/XmlCalabashCli.kt
+++ b/app/src/main/kotlin/com/xmlcalabash/app/XmlCalabashCli.kt
@@ -195,12 +195,12 @@ class XmlCalabashCli private constructor() {
                 }
             }
 
-            if (commandLine.verbosity != null && commandLine.verbosity!! <= Verbosity.DEBUG) {
-                ex.printStackTrace()
-            }
             if (ex is XProcException) {
                 abort(errorExplanation, ex)
             } else {
+                if (commandLine.verbosity != null && commandLine.verbosity!! <= Verbosity.DEBUG) {
+                    ex.printStackTrace()
+                }
                 System.err.println(ex)
                 exitProcess(1)
             }
@@ -277,7 +277,7 @@ class XmlCalabashCli private constructor() {
 
         for (error in errors) {
             errorExplanation.message(error.error)
-            if (verbosity < Verbosity.INFO) {
+            if (commandLine.explainErrors) {
                 errorExplanation.explanation(error.error)
             }
         }

--- a/documentation/src/userguide/run.xml
+++ b/documentation/src/userguide/run.xml
@@ -77,6 +77,7 @@ given, the <command>run</command> command is assumed.</para>
   <arg rep="norepeat" linkend="cli-step">--step:<replaceable>step-name</replaceable></arg>
   <sbr/>
   <arg rep="norepeat" linkend="cli-verbosity">--verbosity:<replaceable>verbosity</replaceable></arg>
+  <arg rep="norepeat" linkend="cli-explain">--explain</arg>
   <arg rep="norepeat" linkend="cli-visualizer">--visualizer:<replaceable>name</replaceable></arg>
   <sbr/>
   <arg rep="norepeat" linkend="cli-trace">--trace:<replaceable>output-file</replaceable></arg>
@@ -258,6 +259,15 @@ detail is printed about the progress of a running pipeline.</para>
 </variablelist>
 <para>Setting the verbosity also sets the logging level.
 </para>
+</listitem>
+</varlistentry>
+
+<varlistentry xml:id="cli-explain">
+  <term><option>--explain</option>, explain errors</term>
+<listitem>
+<para>Enables error explanations. If error explanations are enabled, when a
+pipeline fails, in addition to the error message, a short explanation of the
+cause will be provided.</para>
 </listitem>
 </varlistentry>
 


### PR DESCRIPTION
Previously, this was tied to the verbosity level which doesn’t really make sense. I also fixed a bug where the stack trace was printed twice if debug verbosity was used.

Fix #122 
