### PR TITLE
Improve XPath parsing

### DIFF
--- a/test-driver/build.gradle.kts
+++ b/test-driver/build.gradle.kts
@@ -13,7 +13,7 @@ repositories {
 }
 
 val saxonVersion = project.properties["saxonVersion"].toString()
-val requirePass = project.findProperty("requirePass")?.toString() ?: "false"
+val requirePass = project.findProperty("requirePass")?.toString() ?: "true"
 
 val transformation by configurations.creating
 val testrunner by configurations.creating {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/VariableBindingContainer.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/VariableBindingContainer.kt
@@ -159,6 +159,9 @@ abstract class VariableBindingContainer(
         }
 
         for (name in select!!.variableRefs) {
+            if (name !in stepConfig.inscopeVariables) {
+                throw stepConfig.exception(XProcError.xsXPathStaticError("Expression refers to \$${name} which is not in scope."))
+            }
             val variable = stepConfig.inscopeVariables[name]!!
             if (variable.withOutput != null) {
                 val wi = exprStep!!.withInput()

--- a/xmlcalabash/src/main/resources/com/xmlcalabash/xpath.xsl
+++ b/xmlcalabash/src/main/resources/com/xmlcalabash/xpath.xsl
@@ -65,6 +65,9 @@
   <xsl:variable name="inlinefunc"
                 select="ancestor::nt:InlineFunctionExpr/nt:ParamList/nt:Param/t:QName[@name = $qname/@name]"/>
 
+  <xsl:variable name="for"
+                select="ancestor::nt:ForExpr/nt:SimpleForBinding/nt:VarName/t:QName[@name = $qname/@name]"/>
+
   <xsl:choose>
     <xsl:when test="some $v in $quantified satisfies $v/@name = $qname/@name and $v &lt;&lt; $qname">
       <!-- there's a local declaration -->
@@ -73,6 +76,9 @@
       <!-- there's a local declaration -->
     </xsl:when>
     <xsl:when test="some $v in $inlinefunc satisfies $v/@name = $qname/@name and $v &lt;&lt; $qname">
+      <!-- there's a local declaration -->
+    </xsl:when>
+    <xsl:when test="some $v in $for satisfies $v/@name = $qname/@name and $v &lt;&lt; $qname">
       <!-- there's a local declaration -->
     </xsl:when>
     <xsl:otherwise>

--- a/xmlcalabash/src/test/kotlin/com/xmlcalabash/test/XPathParserTest.kt
+++ b/xmlcalabash/src/test/kotlin/com/xmlcalabash/test/XPathParserTest.kt
@@ -287,4 +287,15 @@ class XPathParserTest {
         Assertions.assertNull(details.error)
     }
 
+    @Test
+    fun forExpr() {
+        val parser = XPathExpressionParser(stepConfig)
+        val details = parser.parse("(for \$d in (1,2,3,3) return \$d) => distinct-values()")
+        Assertions.assertFalse(details.contextRef)
+        Assertions.assertFalse(details.alwaysDynamic)
+        Assertions.assertTrue(details.variableRefs.isEmpty())
+        Assertions.assertTrue(details.functionRefs.isEmpty())
+        Assertions.assertNull(details.error)
+    }
+
 }


### PR DESCRIPTION
1. Handle variable declarations in for loops correctly
2. When things do fail, produce reasonable error message instead of an NPE

Fix #144 
