### PR TITLE
More Java version improvements

### DIFF
--- a/buildSrc/src/main/kotlin/buildlogic.kotlin-common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildlogic.kotlin-common-conventions.gradle.kts
@@ -60,7 +60,7 @@ dependencies {
 // Apply a specific Java toolchain to ease working on different environments.
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(11)
     }
 }
 

--- a/ext/polyglot/build.gradle.kts
+++ b/ext/polyglot/build.gradle.kts
@@ -24,6 +24,12 @@ dependencies {
   xmlcalabash(project(":xmlcalabash"))
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
 val xmlbuild = the<XmlCalabashBuildExtension>()
 
 val isGraalVM = Files.exists(Paths.get("${System.getProperty("java.home")}/lib/graalvm"))

--- a/template/java/src/main/java/com/xmlcalabash/ext/templatejava/TemplateJava.java
+++ b/template/java/src/main/java/com/xmlcalabash/ext/templatejava/TemplateJava.java
@@ -31,18 +31,22 @@ public class TemplateJava extends AbstractAtomicStep {
             } else {
                 MediaClassification ctc = doc.getContentClassification();
                 switch (ctc) {
-                    case XML, XHTML, HTML -> {
+                    case XML:
+                    case XHTML:
+                    case HTML:
                         markup++;
-                    }
-                    case JSON, YAML, TOML -> {
+                        break;
+                    case JSON:
+                    case YAML:
+                    case TOML:
                         json++;
-                    }
-                    case TEXT -> {
+                        break;
+                    case TEXT:
                         text++;
-                    }
-                    case BINARY -> {
+                        break;
+                    case BINARY:
                         unknown++;
-                    }
+                        break;
                 }
             }
         }

--- a/test-driver/build.gradle.kts
+++ b/test-driver/build.gradle.kts
@@ -41,6 +41,12 @@ dependencies {
   transformation ("net.sf.saxon:Saxon-HE:${saxonVersion}")
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
 val xmlbuild = the<XmlCalabashBuildExtension>()
 
 if (project.findProperty("testPattern") == null) {


### PR DESCRIPTION
Set the basic Java requirement back to Java 11

The polyglot steps (and by extension the test-driver, which isn't in the distribution) require Java 17