### PR TITLE
Add a crude Powershell script to the distribution

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -163,10 +163,14 @@ tasks.jar {
 
 val copyScripts = tasks.register<Copy>("copyScripts") {
   inputs.file(layout.projectDirectory.file("src/main/scripts/xmlcalabash.sh"))
+  inputs.file(layout.projectDirectory.file("src/main/scripts/xmlcalabash.ps1"))
   outputs.file(layout.buildDirectory.file("stage/xmlcalabash.sh"))
+  outputs.file(layout.buildDirectory.file("stage/xmlcalabash.ps1"))
+
   from(layout.projectDirectory.dir("src/main/scripts"))
   into(layout.buildDirectory.dir("stage"))
   include("xmlcalabash.sh")
+  include("xmlcalabash.ps1")
   filter { line ->
     line.replace("@@VERSION@@", xmlbuild.version.get())
   }

--- a/app/src/main/scripts/xmlcalabash.ps1
+++ b/app/src/main/scripts/xmlcalabash.ps1
@@ -1,0 +1,25 @@
+# This is a fairly naive Powershell script that constructs a classpath for
+# running XML Calabash. The idea is that it puts jar files from the "extra"
+# directory ahead of jar files from the "lib" directory. This should support
+# overriding jars. And supports running steps that require extra libraries.
+
+$cp = "$PSScriptRoot\xmlcalabash-app-@@VERSION@@.jar"
+
+if (![System.IO.File]::Exists("$cp")) {
+  Write-Host "XML Calabash script did not find the @@VERSION@@ distribution jar"
+  Exit 1
+}
+
+Get-ChildItem "$PSScriptRoot\extra" -Filter *.jar |
+ForEach-Object {
+  $cp = "$cp;$PSScriptroot\lib\$_"
+}
+
+Get-ChildItem "$PSScriptRoot\lib" -Filter *.jar |
+ForEach-Object {
+  $cp = "$cp;$PSScriptroot\lib\$_"
+}
+
+# FIXME: should there be some attempt to look for $Env:JAVA_HOME here?
+
+java -cp "$cp" com.xmlcalabash.app.Main "$args"

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ saxonVersion=12.5
 xmlResolverVersion=6.0.11
 
 xmlcalabashGroup=com.xmlcalabash
-xmlcalabashVersion=3.0.0-alpha14
+xmlcalabashVersion=3.0.0-alpha15-SNAPSHOT
 // name is defined in settings.gradle.kts
 
 builtBy=Norm Tovey-Walsh


### PR DESCRIPTION
If it's possible to do this with a Windows batch file, I couldn't work out how. The path is longer than the allowed length of an environment variable and I don't think there are any other ways to store variables in Windows batch files. But it's been a couple of decades since I ran Windows with any regularity.