### PR TITLE
Setup the correct namespace context for p:if

### DIFF
--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/IfInstruction.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/IfInstruction.kt
@@ -6,7 +6,7 @@ import net.sf.saxon.s9api.QName
 
 class IfInstruction(parent: XProcInstruction): ChooseInstruction(parent, NsP.`if`) {
     override val contentModel = mapOf(NsP.withInput to '1', NsP.`when` to '*', NsP.otherwise to '?')
-    private val whenInstruction = WhenInstruction(this)
+    internal val whenInstruction = WhenInstruction(this)
 
     init {
         _children.add(whenInstruction)

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/parsers/xpl/XplParser.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/parsers/xpl/XplParser.kt
@@ -634,6 +634,7 @@ class XplParser internal constructor(val builder: PipelineBuilder) {
         val ifInstr = step.ifInstruction()
         val stepConfig = ifInstr.stepConfig
         stepConfig.updateWith(node.node)
+        ifInstr.whenInstruction.stepConfig.updateWith(node.node)
 
         val attributeMapping = mapOf<QName, (String) -> Unit>(
             Ns.name to { value -> ifInstr.name = value },


### PR DESCRIPTION
The p:if is rewritten as a p:choose containing a p:when. This PR makes sure that the p:when constructed for this purpose has the right namespace context.

Fix #153 
