### PR TITLE
Added piped mode to support processing XML in a unix-style pipeline

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -167,6 +167,11 @@ val copyScripts = tasks.register<Copy>("copyScripts") {
   outputs.file(layout.buildDirectory.file("stage/xmlcalabash.sh"))
   outputs.file(layout.buildDirectory.file("stage/xmlcalabash.ps1"))
 
+  doFirst {
+    // Never let different versions get co-staged
+    delete(layout.buildDirectory.dir("stage"))
+  }
+
   from(layout.projectDirectory.dir("src/main/scripts"))
   into(layout.buildDirectory.dir("stage"))
   include("xmlcalabash.sh")

--- a/app/src/main/kotlin/com/xmlcalabash/app/FileOutputReceiver.kt
+++ b/app/src/main/kotlin/com/xmlcalabash/app/FileOutputReceiver.kt
@@ -8,26 +8,53 @@ import net.sf.saxon.s9api.Processor
 import org.apache.logging.log4j.kotlin.logger
 import java.io.FileOutputStream
 
-class FileOutputReceiver(xmlCalabash: XmlCalabash, processor: Processor, val files: Map<String,OutputFilename>
+class FileOutputReceiver(xmlCalabash: XmlCalabash,
+                         processor: Processor,
+                         val files: Map<String,OutputFilename>,
+                         val stdout: String?
 ): DefaultOutputReceiver(xmlCalabash, processor) {
+
     private val wroteTo = mutableSetOf<String>()
+
+    init {
+        if (stdout != null) {
+            logger.debug { "Writing on ${stdout} to stdout" }
+        }
+    }
+
     override fun output(port: String, document: XProcDocument) {
         if (port in files) {
             val output = files[port]!!
-            val outfile = files[port]!!.nextFile()
+            val fos = if (output.pattern == CommandLine.STDIO_NAME) {
+                logger.debug { "Writing $port to stdout" }
+                System.out
+            } else {
+                val outfile = files[port]!!.nextFile()
 
-            if (wroteTo.contains(port)) {
-                if (!output.isSequential()) {
-                    logger.warn { "Overwriting ${outfile.absolutePath}"}
+                logger.debug { "Writing $port to ${outfile.absolutePath}" }
+
+                if (wroteTo.contains(port)) {
+                    if (!output.isSequential()) {
+                        logger.warn { "Overwriting ${outfile.absolutePath}"}
+                    }
                 }
-            }
-            wroteTo.add(port)
+                wroteTo.add(port)
 
-            val fos = FileOutputStream(outfile)
+                FileOutputStream(outfile)
+            }
             DocumentWriter(document, fos).write()
             fos.close()
         } else {
-            super.output(port, document)
+            if (stdout != null) {
+                if (stdout in files && files[stdout]?.pattern == "-") {
+                    logger.debug { "Discarding output to ${port}, ${stdout} writes to stdout" }
+                } else {
+                    logger.debug { "Discarding output to ${port}, implicit pipe output to ${stdout} is bound elsewhere" }
+                }
+            } else {
+                logger.debug { "Sending output to ${port} to default output receiver" }
+                super.output(port, document)
+            }
         }
     }
 }

--- a/app/src/main/resources/com/xmlcalabash/help.txt
+++ b/app/src/main/resources/com/xmlcalabash/help.txt
@@ -15,6 +15,7 @@ Where options are:
   --graph:file          To write the graph description to "file"
   --description:file    To write the pipeline description to "file"
   --debug               To enable additional debugging output
+  --pipe                To enable piped input on stdin and output on stdout
   --verbosity:value     To set the general level of verbosity to "value"
                         Values are: trace, debug, info, warn, error
   --explain             Provide more detailed explanatory messages for errors

--- a/documentation/src/userguide/config.xml
+++ b/documentation/src/userguide/config.xml
@@ -56,6 +56,21 @@ The command-line setting takes precedence.</para>
 linkend="cli-verbosity">on the command line</link>. The command-line setting takes precedence.</para>
 </listitem>
 </varlistentry>
+<varlistentry><term><tag class="attribute">piped-io</tag></term>
+<listitem>
+<para>If <tag class="attribute">piped-io</tag> is <literal>true</literal>, XML Calabash
+will behave like a Unix pipeline. If there is no binding for the primary input port, it will
+read it from standard input. If there is no binding for the primary output port, it will
+write it to standard output. Irrespective of this setting, an <emphasis>explicit</emphasis>
+binding to standard input is possible with the <option linkend="cli-input">--input</option>
+option
+and an explicit binding to standard output is possible with
+<option linkend="cli-output">--output</option> option.</para>
+<para>When standard input is read, it will be parsed as the (first) content type listed
+on the primary input port. It will be parsed as XML if the primary input port doesn’t
+specify any content types.</para>
+</listitem>
+</varlistentry>
 </variablelist>
 
 <para>For simplicity, the content model of <tag>cc:xml-calabash</tag> allows every element to

--- a/documentation/src/userguide/run.xml
+++ b/documentation/src/userguide/run.xml
@@ -65,6 +65,7 @@ given, the <command>run</command> command is assumed.</para>
   <arg choice="opt">run</arg>
   <arg rep="norepeat" linkend="cli-configuration">--configuration:<replaceable>configuration-file</replaceable></arg>
   <sbr/>
+  <arg rep="norepeat" linkend="cli-pipe">--pipe</arg>
   <arg rep="repeat" linkend="cli-input">--input:<replaceable>port</replaceable>=<replaceable>uri</replaceable></arg>
   <arg rep="repeat" linkend="cli-output">--output:<replaceable>port</replaceable>=<replaceable>filespec</replaceable></arg>
   <sbr/>
@@ -114,6 +115,17 @@ directory and then in your home directory.</para>
 </listitem>
 </varlistentry>
 
+<varlistentry xml:id="cli-pipe">
+  <term><option>--pipe<replaceable>:boolean</replaceable></option>, sets piped mode</term>
+<listitem>
+<para>If piped mode is enabled, XML Calabash
+will behave like a Unix pipeline. If there is no binding for the primary input port, it will
+read it from standard input. If there is no binding for the primary output port, it will
+write it to standard output. If not specified, the default setting comes from
+the <option linkend="cc.xml-calabash">piped-io</option> configuration setting.</para>
+</listitem>
+</varlistentry>
+
 <varlistentry xml:id="cli-input">
   <term><option>--input:<replaceable>port</replaceable>=<replaceable>uri</replaceable></option>, identifies
   an input</term>
@@ -123,6 +135,10 @@ the input port named <replaceable>port</replaceable>. If the <option>--input</op
 is repeated for the same <replaceable>port</replaceable>, the resources become a sequence of
 documents on that port, in the order specified.</para>
 <para>The pipeline must have an input port named <replaceable>port</replaceable>.</para>
+<para>If the input <replaceable>uri</replaceable> provided is “<literal>-</literal>”, input
+will be read from standard input. When standard input is read, it will be parsed
+as the (first) content type listed on the named input port. It will be parsed
+as XML if the input port doesn’t specify any content types.</para>
 </listitem>
 </varlistentry>
 
@@ -145,9 +161,20 @@ in the <replaceable>filespec</replaceable>.</para>
 of the outputs on the port will be concatenated to the same file.
 You may not repeat the <option>--output</option> option for the same port.</para>
 <para>The pipeline must have an output port named <replaceable>port</replaceable>.</para>
-<para>If the pipeline writes to a port for which there is no corresponding
-<option>--output</option> option, the results will be written to “standard output”, usually
-the terminal window. When writing to the terminal:</para>
+
+<para>If the output <replaceable>filespec</replaceable> provided is “<literal>-</literal>”, output
+from that port will be written to standard output. At most one output port may be explicitly bound
+to standard output.</para>
+
+<para>In piped mode, at most one port will write to standard output. If there is no explicit
+binding to standard output, the primary output port writes to standard output. If the primary
+output port is bound to some other output, no output will be sent to standard output.</para>
+
+<para>If piped mode is not enabled, and no port is explicitly bound to standard
+output, the pipeline will write the output from all otherwise unbound output
+ports to standard output. If standard output appears to be going to a terminal
+window:</para>
+
 <itemizedlist>
 <listitem>
 <para>A header is printed before the output identifying the port name, document
@@ -168,7 +195,7 @@ one document is output).</para>
 <para>The method for determining whether output is going to a terminal or being
 redirected isn’t terribly sophisticated and may be wrong in some
 circumstances. It’s safer to use <option>--output</option> to write to a file
-if you want to save the output.</para>
+if you want to save the output or enable piped mode.</para>
 </listitem>
 </varlistentry>
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/config/ConfigurationLoader.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/config/ConfigurationLoader.kt
@@ -47,6 +47,7 @@ class ConfigurationLoader private constructor(private val config: XmlCalabashCon
         private val _mpt = QName("mpt")
         private val _password = QName("password")
         private val _port = QName("port")
+        private val _piped_io = QName("piped-io")
         private val _saxonConfiguration = QName("saxon-configuration")
         private val _scheme = QName("scheme")
         private val _trimWhitespace = QName("trim-whitespace")
@@ -54,7 +55,6 @@ class ConfigurationLoader private constructor(private val config: XmlCalabashCon
         private val _username = QName("username")
         private val _value = QName("value")
         private val _verbosity = QName("verbosity")
-        private val _visualizer = QName("visualizer")
         private val _xslFormatter = QName("xsl-formatter")
         private val _bufferSize = QName("buffer-size")
 
@@ -137,6 +137,7 @@ class ConfigurationLoader private constructor(private val config: XmlCalabashCon
             config.licensed = booleanAttribute(root.getAttributeValue(_licensed), "licensed")
         }
 
+        config.pipe = booleanAttribute(root.getAttributeValue(_piped_io), "piped-io")
         config.verbosity = verbosityAttribute(root.getAttributeValue(_verbosity))
 
         for (child in root.axisIterator(Axis.CHILD)) {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/config/XmlCalabashConfiguration.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/config/XmlCalabashConfiguration.kt
@@ -31,6 +31,7 @@ abstract class XmlCalabashConfiguration {
     var trace: File? = null
     var traceDocuments: File? = null
     var debugger = false
+    var pipe = false
     var mimetypes: Map<String, String> = emptyMap()
     var sendmail: Map<String, String> = emptyMap()
     var pagedMediaManagers: List<PagedMediaManager> = emptyList()

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/XProcError.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/XProcError.kt
@@ -10,6 +10,8 @@ import java.util.*
 
 class XProcError private constructor(val code: QName, val variant: Int, val location: Location, val inputLocation: Location, vararg val details: Any) {
     companion object {
+        val DEBUGGER_ABORT = 9997
+
         private fun staticError(code: Int): QName {
             return NsErr.xs(code)
         }
@@ -397,7 +399,9 @@ class XProcError private constructor(val code: QName, val variant: Int, val loca
         fun xiXvrlInvalidWorst(worst: String) = internal(307, worst)
         fun xiXvrlNullCode() = internal(308)
 
-        fun xiAbortDebugger() = internal(9997)
+        fun xiAtMostOneStdout() = internal(320)
+
+        fun xiAbortDebugger() = internal(DEBUGGER_ABORT) // 9997
         fun xiImpossible(message: String) = internal(9998, message)
         fun xiNotImplemented(message: String) = internal(9999, message)
     }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/XProcPipeline.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/XProcPipeline.kt
@@ -19,7 +19,7 @@ import com.xmlcalabash.visualizers.Silent
 import net.sf.saxon.s9api.QName
 import java.io.FileOutputStream
 
-class XProcPipeline internal constructor(private val runtime: XProcRuntime, pipeline: CompoundStepModel, val config: XProcStepConfiguration) {
+class XProcPipeline internal constructor(runtime: XProcRuntime, pipeline: CompoundStepModel, val config: XProcStepConfiguration) {
     val inputManifold = pipeline.inputs
     val outputManifold = pipeline.outputs
     val optionManifold = pipeline.options

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/api/RuntimePort.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/api/RuntimePort.kt
@@ -5,7 +5,7 @@ import com.xmlcalabash.io.MediaType
 import net.sf.saxon.s9api.XdmMap
 import net.sf.saxon.s9api.XdmNode
 
-open class RuntimePort(val name: String, val unbound: Boolean, val sequence: Boolean, val contentTypes: List<MediaType>, val serialization: XdmMap = XdmMap()) {
+open class RuntimePort(val name: String, val unbound: Boolean, val primary: Boolean, val sequence: Boolean, val contentTypes: List<MediaType>, val serialization: XdmMap = XdmMap()) {
     val assertions = mutableListOf<XdmNode>()
     val defaultBindings = mutableListOf<ConnectionInstruction>()
     internal var weldedShut = false

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/model/StepModel.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/model/StepModel.kt
@@ -34,7 +34,7 @@ abstract class StepModel(val runtime: XProcRuntime, model: Model) {
     init {
         val ports = mutableMapOf<String, RuntimePort>()
         for ((name, port) in model.inputs) {
-            val rtport = RuntimePort(name, port.unbound, port.sequence, port.contentTypes)
+            val rtport = RuntimePort(name, port.unbound, port.primary, port.sequence, port.contentTypes)
             rtport.weldedShut = port.weldedShut
             rtport.assertions.addAll(port.assertions)
             if (port is ModelInputPort) {
@@ -46,7 +46,7 @@ abstract class StepModel(val runtime: XProcRuntime, model: Model) {
 
         ports.clear()
         for ((name, port) in model.outputs) {
-            val rtport = RuntimePort(name, port.unbound, port.sequence, port.contentTypes, port.serialization)
+            val rtport = RuntimePort(name, port.unbound, port.primary, port.sequence, port.contentTypes, port.serialization)
             rtport.weldedShut = port.weldedShut
             rtport.assertions.addAll(port.assertions)
             ports[name] = rtport

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/AbstractStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/AbstractStep.kt
@@ -187,8 +187,8 @@ abstract class AbstractStep(val stepConfig: XProcStepConfiguration, step: StepMo
         when (binding) {
             is InlineInstruction -> {
                 val inlineReceiver = BufferingReceiver()
-                val source = RuntimePort("source", false, true, emptyList())
-                val result = RuntimePort("result", false, false, emptyList())
+                val source = RuntimePort("source", false, true, true, emptyList())
+                val result = RuntimePort("result", false, true, false, emptyList())
                 val inlineStepParams = InlineStepParameters("!inline", binding.stepConfig.location,
                     mapOf("source" to source), mapOf("result" to result), emptyMap(), binding.valueTemplateFilter, binding.contentType, binding.encoding)
                 val inlineStep = InlineStep(inlineStepParams)

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/DefaultOutputReceiver.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/DefaultOutputReceiver.kt
@@ -35,16 +35,23 @@ open class DefaultOutputReceiver(val xmlCalabash: XmlCalabash, val processor: Pr
     }
 
     fun write(port: String, document: XProcDocument, position: Int, total: Int) {
+        val contentType = document.contentType
+        val writer = DocumentWriter(document, System.out)
+
+        if (xmlCalabash.xmlCalabashConfig.pipe) {
+            writer.write()
+            return
+        }
+
         val header = if (total > 0) {
             "=== ${port} :: ${position}/${total} :: ${document.baseURI} ===".padEnd(72, '=')
         } else {
             "=== ${port} :: ${position} :: ${document.baseURI} ===".padEnd(72, '=')
         }
+
         if (writingToTerminal) {
             println(header)
         }
-        val contentType = document.contentType
-        val writer = DocumentWriter(document, System.out)
 
         if (writingToTerminal && contentType != null) {
             if (contentType.classification() in listOf(MediaClassification.XML, MediaClassification.XHTML, MediaClassification.HTML)) {

--- a/xmlcalabash/src/main/resources/com/xmlcalabash/explain-errors.txt
+++ b/xmlcalabash/src/main/resources/com/xmlcalabash/explain-errors.txt
@@ -1486,6 +1486,13 @@ Invalid value for the "worst" attribute: $1
 cxerr:XI0308
 No code specified for xvrl:detection element.
 
+cxerr:XI0320
+At most one output port can be bound to standard output.
+When piped output is enabled, at most one output port can be directed to
+standard output. If no explicit binding is provided, and the pipeline has a
+primary output port, the output of the primary output port will go to standard
+output.
+
 cxerr:XI9997
 User aborted execution from the debugger.
 

--- a/xmlcalabash/src/main/resources/com/xmlcalabash/xml-calabash.rnc
+++ b/xmlcalabash/src/main/resources/com/xmlcalabash/xml-calabash.rnc
@@ -9,6 +9,7 @@ cc.xmlCalabash =
         attribute saxon-configuration { text }?,
         attribute licensed { xsd:boolean }?,
         attribute verbosity { "trace" | "debug" | "progress" | "info" | "warn" | "error" }?,
+        attribute piped-io { xsd:boolean }?,
         (cc.graphviz
         | cc.inline
         | cc.mimetype


### PR DESCRIPTION
In piped mode, the primary input comes from stdin by default and the primary output goes to stdout by default. Explicit bindings are still possible. The pretty printing associated with console output is disabled.