### PR TITLE
Don't fail validation if `try-namespaces` fails to find a schema

### DIFF
--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/XProcError.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/XProcError.kt
@@ -147,7 +147,7 @@ class XProcError private constructor(val code: QName, val variant: Int, val loca
         fun xdInputSequenceForbidden(port: String) = dynamic(6, port)
         fun xdOutputSequenceForbidden(port: String) = dynamic(7, port)
         fun xdViewportOnAttribute(expr: String) = dynamic(10, expr)
-        fun xdDoesNotExist(path: String) = dynamic(Pair(11, 1), path)
+        fun xdDoesNotExist(path: String, message: String) = dynamic(Pair(11, 1), path, message)
         fun xdIsNotReadable(path: String, message: String) = dynamic(Pair(11, 2), path, message)
         fun xdInvalidQName(name: String) = dynamic(Pair(15, 1), name)
         fun xdNoBindingInScope(message: String) = dynamic(Pair(15, 2), message)
@@ -496,6 +496,11 @@ class XProcError private constructor(val code: QName, val variant: Int, val loca
 
     fun with(newCode: QName): XProcError {
         return XProcError(newCode, 1, location, inputLocation, *details)
+    }
+
+    fun with(cause: Throwable): XProcError {
+        _throwable = cause
+        return this
     }
 
     fun exception(): XProcException {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/io/DocumentLoader.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/io/DocumentLoader.kt
@@ -69,7 +69,7 @@ class DocumentLoader(val context: XProcStepConfiguration,
             try {
                 return loadFile()
             } catch (ex: IOException) {
-                throw context.exception(XProcError.xdDoesNotExist(absURI.path), ex)
+                throw context.exception(XProcError.xdDoesNotExist(absURI.path, ex.message ?: "???"), ex)
             }
         }
 
@@ -81,7 +81,7 @@ class DocumentLoader(val context: XProcStepConfiguration,
                 throw context.exception(XProcError.xdIsNotReadable(absURI.toString(), "HTTP response code: ${resp.statusCode}"))
             }
             if (resp.statusCode >= 400) {
-                throw context.exception(XProcError.xdDoesNotExist(absURI.toString()))
+                throw context.exception(XProcError.xdDoesNotExist(absURI.toString(), "HTTP response code: ${resp.statusCode}"))
             }
 
             return resp.response.first()

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/ArchiveStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/ArchiveStep.kt
@@ -177,7 +177,7 @@ open class ArchiveStep(): AbstractArchiveStep() {
                     } catch (ex: XProcException) {
                         throw ex
                     } catch (ex: Exception) {
-                        throw stepConfig.exception(XProcError.xdDoesNotExist(entry.href.toString()))
+                        throw stepConfig.exception(XProcError.xdDoesNotExist(entry.href.toString(), ex.message ?: "???"), ex)
                     }
                 }
             }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/file/CreateTempfileStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/file/CreateTempfileStep.kt
@@ -38,7 +38,7 @@ class CreateTempfileStep(): FileStep(NsP.fileCreateTempfile) {
                 dir = Paths.get(href.path)
                 if (!Files.exists(dir) || !Files.isDirectory(dir)) {
                     if (failOnError) {
-                        throw stepConfig.exception(XProcError.xdDoesNotExist(dir.toString()))
+                        throw stepConfig.exception(XProcError.xdDoesNotExist(dir.toString(), "path is not a directory"))
                     } else {
                         val err = errorDocument(href, NsErr.xd(11))
                         receiver.output("result", XProcDocument.ofXml(err, stepConfig))

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/file/FileCopyOrMove.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/file/FileCopyOrMove.kt
@@ -46,7 +46,7 @@ abstract class FileCopyOrMove(stepType: QName): FileStep(stepType) {
 
         val source = File(href.path)
         if (!source.exists()) {
-            maybeThrow(XProcError.xdDoesNotExist(href.path), href)
+            maybeThrow(XProcError.xdDoesNotExist(href.path, "path does not exist"), href)
             return
         }
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/file/FileInfoStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/file/FileInfoStep.kt
@@ -26,7 +26,7 @@ class FileInfoStep(): FileStep(NsP.fileInfo) {
 
         val file = File(href.path)
         if (!file.exists()) {
-            maybeThrow(XProcError.xdDoesNotExist(href.path), href)
+            maybeThrow(XProcError.xdDoesNotExist(href.path, "path does not exist"), href)
             return
         }
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/file/FileTouchStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/file/FileTouchStep.kt
@@ -37,7 +37,7 @@ class FileTouchStep(): FileStep(NsP.fileTouch) {
         try {
             if (!file.exists()) {
                 if (!file.createNewFile()) {
-                    maybeThrow(XProcError.xdDoesNotExist(href.path), href)
+                    maybeThrow(XProcError.xdDoesNotExist(href.path, "does not exist and failed to create"), href)
                     return
                 }
             }
@@ -45,7 +45,7 @@ class FileTouchStep(): FileStep(NsP.fileTouch) {
             val millis = timestamp.toInstant().toEpochMilli()
             file.setLastModified(millis)
         } catch (ex: IOException) {
-            maybeThrow(XProcError.xdDoesNotExist(href.path), href)
+            maybeThrow(XProcError.xdDoesNotExist(href.path, ex.message ?: "???").with(ex), href)
             return
         }
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/validation/CachingErrorListener.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/validation/CachingErrorListener.kt
@@ -151,8 +151,6 @@ class CachingErrorListener(val stepConfig: XProcStepConfiguration, val errors: E
         }
 
         errors.xsdValidationError(failure)
-
-        stepConfig.info { "${failure.message}" }
     }
 
     override fun endReporting(): Sequence {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/validation/ValidateWithXmlSchema.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/validation/ValidateWithXmlSchema.kt
@@ -112,8 +112,12 @@ open class ValidateWithXmlSchema(): AbstractAtomicStep() {
             val ns = sourceNode.nodeName.namespaceUri
             if (ns != NamespaceUri.NULL) {
                 val docManager = stepConfig.environment.documentManager
-                val doc = docManager.load(URI(ns.toString()), stepConfig)
-                schemaDocuments.add(doc.value as XdmNode)
+                try {
+                    val doc = docManager.load(URI(ns.toString()), stepConfig)
+                    schemaDocuments.add(doc.value as XdmNode)
+                } catch (ex: Exception) {
+                    stepConfig.debug { "Failed to load XML Shema from ${ns}: ${ex.message}" }
+                }
             }
         }
 

--- a/xmlcalabash/src/main/resources/com/xmlcalabash/explain-errors.txt
+++ b/xmlcalabash/src/main/resources/com/xmlcalabash/explain-errors.txt
@@ -28,7 +28,7 @@ It is a dynamic error if the match expression on p:viewport matches an attribute
 or a namespace node.
 
 XD0011/1
-URI does not exist: “$1”.
+URI does not exist “$1”: “$2”.
 It is a dynamic error if the resource referenced by the href option does not
 exist, cannot be accessed or is not a file.
 


### PR DESCRIPTION
Fix #157 

I can't positively confirm that this is the cause of the error, but it's my best guess. It's a circumstance that *would* have caused the error, and there's no other circumstance that I can think of.

If the `try-namespaces` option is true on `p:validate-with-xml-schema`, don't make the step fail if no schema is found at the location of the namespace URI.

Cleaned up some exceptions and error reporting.