### PR TITLE
Bug fixes

### DIFF
--- a/app/src/main/kotlin/com/xmlcalabash/app/XmlCalabashCli.kt
+++ b/app/src/main/kotlin/com/xmlcalabash/app/XmlCalabashCli.kt
@@ -91,12 +91,14 @@ class XmlCalabashCli private constructor() {
 
             if (config.verbosity != commandLine.verbosity) {
                 config.verbosity = commandLine.verbosity ?: config.verbosity
-                when (config.verbosity) {
-                    Verbosity.TRACE -> MDC.put("LOG_LEVEL", "TRACE")
-                    Verbosity.DEBUG -> MDC.put("LOG_LEVEL", "DEBUG")
-                    Verbosity.INFO -> MDC.put("LOG_LEVEL", "INFO")
-                    Verbosity.WARN -> MDC.put("LOG_LEVEL", "WARN")
-                    Verbosity.ERROR -> MDC.put("LOG_LEVEL", "ERROR")
+                if (commandLine.debug == true) {
+                    when (config.verbosity) {
+                        Verbosity.TRACE -> MDC.put("LOG_LEVEL", "TRACE")
+                        Verbosity.DEBUG -> MDC.put("LOG_LEVEL", "DEBUG")
+                        Verbosity.INFO -> MDC.put("LOG_LEVEL", "INFO")
+                        Verbosity.WARN -> MDC.put("LOG_LEVEL", "WARN")
+                        Verbosity.ERROR -> MDC.put("LOG_LEVEL", "ERROR")
+                    }
                 }
             }
 
@@ -270,7 +272,7 @@ class XmlCalabashCli private constructor() {
 
             optionManifold.putAll(pipeline.optionManifold)
             for ((name, value) in xprocParser.builder.staticOptionsManager.useWhenOptions) {
-                pipeline.option(name, XProcDocument.ofValue(value, stepConfig, MediaType.ANY, DocumentProperties()))
+                pipeline.option(name, XProcDocument.ofValue(value, stepConfig, MediaType.OCTET_STREAM, DocumentProperties()))
             }
 
             pipeline.receiver = FileOutputReceiver(xmlCalabash, xmlCalabash.saxonConfig.processor, commandLine.outputs, explicitStdout ?: implicitStdout)

--- a/test-driver/src/test/resources/exclusions.txt
+++ b/test-driver/src/test/resources/exclusions.txt
@@ -1,3 +1,5 @@
+nw-tvt-007 because there’s more work to be done
+
 ab-p-archive-067 because multiple archives are supported for create
 
 ab-import-functions-008 because https://saxonica.plan.io/issues/6603

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/AtomicExpressionStepInstruction.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/AtomicExpressionStepInstruction.kt
@@ -4,7 +4,13 @@ import com.xmlcalabash.namespace.NsCx
 import net.sf.saxon.s9api.QName
 
 class AtomicExpressionStepInstruction(parent: XProcInstruction, val expression: XProcExpression): AtomicStepInstruction(parent, NsCx.expression) {
-    internal var externalName: QName? = null
+    private var _externalName: QName? = null
+
+    internal var externalName: QName?
+        get() = _externalName
+        set(value) {
+            _externalName = value
+        }
 
     init {
         name = "!${instructionType.localName}_${stepConfig.nextId}"

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/InlineInstruction.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/InlineInstruction.kt
@@ -76,7 +76,7 @@ class InlineInstruction(parent: XProcInstruction, xmlDocument: XdmNode): Connect
         }
 
         _valueTemplateFilter = if (encoding == null && !isRunPipeline) {
-            ValueTemplateFilterXml(xml, inlineBaseUri)
+            ValueTemplateFilterXml(xml, contentType!!, inlineBaseUri)
         } else {
             ValueTemplateFilterNone(xml, inlineBaseUri)
         }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/LibraryInstruction.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/LibraryInstruction.kt
@@ -230,18 +230,12 @@ open class LibraryInstruction(stepConfig: InstructionConfiguration): XProcInstru
         findDefaultReadablePort(null)
         elaborateInstructions()
 
-        rewrite()
+        for (child in children.filterIsInstance<DeclareStepInstruction>()) {
+            child.validate()
+        }
     }
 
     // ========================================================================================
-
-    fun rewrite() {
-        for (child in children.filterIsInstance<DeclareStepInstruction>()) {
-            if (!child.isAtomic) {
-                child.rewrite()
-            }
-        }
-    }
 
     fun getPipeline(name: String?): DeclareStepInstruction {
         for (child in children.filterIsInstance<DeclareStepInstruction>()) {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/StepDeclaration.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/StepDeclaration.kt
@@ -148,7 +148,6 @@ abstract class StepDeclaration(parent: XProcInstruction?, stepConfig: Instructio
                 _staticOptions[option.name] = builder.staticOptionsManager.get(option)
             } else {
                 val exprStep = AtomicExpressionStepInstruction(this, option.select!!)
-                exprStep.externalName = option.name
                 exprStep.depends.addAll(depends)
                 stepConfig.addVisibleStepName(exprStep)
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/XProcSelectExpression.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/XProcSelectExpression.kt
@@ -30,7 +30,7 @@ class XProcSelectExpression private constructor(stepConfig: XProcStepConfigurati
         val compiler = config.newXPathCompiler()
 
         // Hack
-        val uri = config.baseUri
+        val uri = stepConfig.baseUri // stepConfig, not config!
         if (uri != null && !uri.toString().startsWith("?uniqueid")) {
             compiler.baseURI = uri
         }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/namespace/Ns.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/namespace/Ns.kt
@@ -3,6 +3,7 @@ package com.xmlcalabash.namespace
 import net.sf.saxon.s9api.QName
 
 object Ns {
+    val adaptive = QName("adaptive")
     val acceptMultipart = QName("accept-multipart")
     val accessKey = QName("access-key")
     val algorithm = QName("algorithm")
@@ -21,6 +22,7 @@ object Ns {
     val auth = QName("auth")
     val baseUri = QName("base-uri")
     val brotli = QName("brotli")
+    val byteOrderMark = QName("byte-order-mark")
     val bzip2 = QName("bzip2")
     val caseOrder = QName("case-order")
     val code = QName("code")

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/LazyValue.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/LazyValue.kt
@@ -2,6 +2,7 @@ package com.xmlcalabash.runtime
 
 import com.xmlcalabash.datamodel.XProcExpression
 import com.xmlcalabash.documents.DocumentContext
+import com.xmlcalabash.documents.XProcDocument
 import net.sf.saxon.s9api.XdmValue
 
 /**
@@ -14,7 +15,7 @@ import net.sf.saxon.s9api.XdmValue
  */
 class LazyValue private constructor(val context: DocumentContext, config: XProcStepConfiguration) {
     private var expression: XProcExpression? = null
-    private var constant: XdmValue? = null
+    private var constant: XProcDocument? = null
     private val resolvedConfig = config.copy()
 
     init {
@@ -25,13 +26,13 @@ class LazyValue private constructor(val context: DocumentContext, config: XProcS
         this.expression = expression
     }
 
-    constructor(context: DocumentContext, value: XdmValue, config: XProcStepConfiguration): this(context, config) {
-        this.constant = value
+    constructor(doc: XProcDocument, config: XProcStepConfiguration): this(doc.context, config) {
+        this.constant = doc
     }
 
     val value: XdmValue by lazy {
         if (constant != null) {
-            constant!!
+            constant!!.value
         } else {
             expression!!.evaluate(resolvedConfig)
         }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/XProcPipeline.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/XProcPipeline.kt
@@ -18,6 +18,8 @@ import com.xmlcalabash.util.AssertionsMonitor
 import com.xmlcalabash.visualizers.Silent
 import net.sf.saxon.s9api.QName
 import java.io.FileOutputStream
+import java.nio.file.Path
+import java.nio.file.Paths
 
 class XProcPipeline internal constructor(runtime: XProcRuntime, pipeline: CompoundStepModel, val config: XProcStepConfiguration) {
     val inputManifold = pipeline.inputs
@@ -56,7 +58,7 @@ class XProcPipeline internal constructor(runtime: XProcRuntime, pipeline: Compou
         if (xconfig.trace != null || xconfig.traceDocuments != null) {
             if (config.environment is PipelineContext) {
                 traceListener = if (xconfig.traceDocuments != null) {
-                    DetailTraceListener()
+                    DetailTraceListener(xconfig.traceDocuments!!.toPath())
                 } else {
                     StandardTraceListener()
                 }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/XProcStepConfigurationImpl.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/XProcStepConfigurationImpl.kt
@@ -316,16 +316,6 @@ open class XProcStepConfigurationImpl internal constructor(
                     return value
                 }
                 throw exception(XProcError.xdBadType("Empty sequence not allowed"))
-                /*
-                if (code == "AB") {
-                    return XdmAtomicValue(false)
-                }
-                if (varName == null) {
-                    throw exception(XProcError.xdBadType(value.underlyingValue.stringValue, sequenceType.underlyingSequenceType.toString()))
-                } else {
-                    throw exception(XProcError.xdBadType(varName, value.toString(), sequenceType.underlyingSequenceType.toString()))
-                }
-                 */
             }
 
             // We've got a bit of a hack here. If the input is a string, but the type is a
@@ -811,7 +801,7 @@ open class XProcStepConfigurationImpl internal constructor(
                 if (value.underlyingValue is Int64Value) {
                     return value
                 }
-                typeName = NsXs.decimal
+                typeName = NsXs.integer
             }
 
             "ADIN" -> {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/api/RuntimePort.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/api/RuntimePort.kt
@@ -10,6 +10,12 @@ open class RuntimePort(val name: String, val unbound: Boolean, val primary: Bool
     val defaultBindings = mutableListOf<ConnectionInstruction>()
     internal var weldedShut = false
 
+    constructor(port: RuntimePort): this(port.name, port.unbound, port.primary, port.sequence, port.contentTypes, port.serialization) {
+        assertions.addAll(port.assertions)
+        defaultBindings.addAll(port.defaultBindings)
+        weldedShut = port.weldedShut
+    }
+
     override fun toString(): String {
         return name
     }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/model/AtomicUserStepModel.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/model/AtomicUserStepModel.kt
@@ -18,6 +18,7 @@ class AtomicUserStepModel(runtime: XProcRuntime, model: AtomicModel, private val
     override fun initialize(model: Model) {
         super.initialize(model)
 
+        impl.userStep = this
         extensionAttributes.putAll(model.step.extensionAttributes)
 
         for ((name, moption) in model.options) {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/model/CompoundStepModel.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/model/CompoundStepModel.kt
@@ -16,6 +16,7 @@ import com.xmlcalabash.runtime.steps.AbstractStep
 import com.xmlcalabash.runtime.steps.CompoundStep
 
 class CompoundStepModel(runtime: XProcRuntime, model: CompoundModel): StepModel(runtime, model) {
+    internal var userStep: AtomicUserStepModel? = null
     lateinit var head: HeadModel
     lateinit var foot: FootModel
     lateinit var params: RuntimeStepParameters
@@ -70,7 +71,16 @@ class CompoundStepModel(runtime: XProcRuntime, model: CompoundModel): StepModel(
                 params = RunStepStepParameters(type, name, location, inputs, outputs, options, primaryInput, primaryOutput)
             }
             else -> {
-                params = RuntimeStepParameters(type, name, location, inputs, outputs, options)
+                val pinputs = mutableMapOf<String, RuntimePort>()
+                pinputs.putAll(inputs)
+                if (userStep != null) {
+                    for ((name, port) in userStep!!.inputs) {
+                        if (name !in pinputs && !port.weldedShut) {
+                            pinputs[name] = RuntimePort(port)
+                        }
+                    }
+                }
+                params = RuntimeStepParameters(type, name, location, pinputs, outputs, options)
             }
         }
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/AbstractStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/AbstractStep.kt
@@ -125,7 +125,7 @@ abstract class AbstractStep(val stepConfig: XProcStepConfiguration, step: StepMo
     }
 
     open fun runStep() {
-        logger.debug { "Running ${this}" }
+        stepConfig.debug { "Running ${this}" }
 
         try {
             prepare()

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/AtomicOptionStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/AtomicOptionStep.kt
@@ -8,7 +8,12 @@ import net.sf.saxon.s9api.QName
 import java.time.Duration
 
 class AtomicOptionStep(config: XProcStepConfiguration, atomic: AtomicBuiltinStepModel, val externalName: QName): AtomicStep(config, atomic) {
-    var externalValue: XProcDocument? = null
+    private var _externalValue: XProcDocument? = null
+    var externalValue: XProcDocument?
+        get() = _externalValue
+        set(value) {
+            _externalValue = value
+        }
     internal val atomicOptionValues = mutableMapOf<QName, LazyValue>()
 
     override val stepTimeout: Duration = Duration.ZERO
@@ -29,8 +34,10 @@ class AtomicOptionStep(config: XProcStepConfiguration, atomic: AtomicBuiltinStep
 
     override fun runImplementation() {
         if (externalValue == null) {
+            stepConfig.debug { "  Compute option value" }
             super.runImplementation()
         } else {
+            stepConfig.debug { "  Option value: ${externalValue!!.value}" }
             output("result", externalValue!!)
         }
     }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/AtomicStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/AtomicStep.kt
@@ -56,7 +56,7 @@ open class AtomicStep(config: XProcStepConfiguration, atomic: AtomicBuiltinStepM
                     || (type.namespaceUri != NsP.namespace && name == NsP.message)) {
                     message = doc.value
                 } else {
-                    implementation.option(name, LazyValue(doc.context, doc.value, stepConfig))
+                    implementation.option(name, LazyValue(doc, stepConfig))
                 }
                 return
             }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/CompoundStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/CompoundStep.kt
@@ -174,7 +174,7 @@ abstract class CompoundStep(config: XProcStepConfiguration, compound: CompoundSt
                     if (runMe.externalValue == null) {
                         atomicOptionValues[runMe.externalName] = LazyValue(runMe.stepConfig, (runMe.implementation as ExpressionStep).expression, stepConfig)
                     } else {
-                        atomicOptionValues[runMe.externalName] = LazyValue(runMe.stepConfig, runMe.externalValue!!.value, stepConfig)
+                        atomicOptionValues[runMe.externalName] = LazyValue(XProcDocument.ofValue(runMe.externalValue!!.value, runMe.stepConfig), stepConfig)
                     }
                 } else {
                     runMe.runStep()

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/CompoundStepHead.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/CompoundStepHead.kt
@@ -51,6 +51,13 @@ class CompoundStepHead(config: XProcStepConfiguration, val parent: CompoundStep,
                 openPorts.add(name)
             }
         }
+
+        // Also wait for any bindings that are expected
+        for ((name, port) in parent.params.inputs) {
+            if (name.startsWith("Q{") && !port.weldedShut) {
+                openPorts.add(name)
+            }
+        }
     }
 
     override val readyToRun: Boolean

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/ArchiveStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/ArchiveStep.kt
@@ -427,7 +427,7 @@ open class ArchiveStep(): AbstractArchiveStep() {
         val localUri = entry.archive?.baseUri?.resolve(entry.name)
         if (localUri?.scheme != "file") {
             if (localUri != null) {
-                logger.warn { "Ignoring update for non-file URI: ${localUri}" }
+                stepConfig.warn { "Ignoring update for non-file URI: ${localUri}" }
             }
             return false
         }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/archives/SevenZOutputArchive.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/archives/SevenZOutputArchive.kt
@@ -55,7 +55,7 @@ class SevenZOutputArchive(stepConfig: XProcStepConfiguration): OutputArchive(ste
                     "deflate" -> methods.add(SevenZMethodConfiguration(SevenZMethod.DEFLATE))
                     "deflate64" -> methods.add(SevenZMethodConfiguration(SevenZMethod.DEFLATE64))
                     "bzip2" -> methods.add(SevenZMethodConfiguration(SevenZMethod.BZIP2))
-                    else -> logger.debug("Ignoring unknown 7z compression method: ${token}")
+                    else -> stepConfig.debug { "Ignoring unknown 7z compression method: ${token}" }
                 }
             }
             if (methods.isNotEmpty()) {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/internal/InlineStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/internal/InlineStep.kt
@@ -40,7 +40,7 @@ open class InlineStep(val params: InlineStepParameters): AbstractAtomicStep() {
                 if (ex.message != null && ex.message!!.contains("Namespace prefix") && ex.message!!.contains("has not been declared")) {
                     throw stepConfig.exception(XProcError.xdNoBindingInScope(ex.message!!))
                 }
-                throw stepConfig.exception(XProcError.xsXPathStaticError(ex.message ?: ""), ex)
+                throw ex
             }
         }
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/internal/OptionExpressionStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/internal/OptionExpressionStep.kt
@@ -3,9 +3,4 @@ package com.xmlcalabash.steps.internal
 import com.xmlcalabash.runtime.parameters.OptionStepParameters
 
 class OptionExpressionStep(params: OptionStepParameters): ExpressionStep(params) {
-    /*
-    fun setExternalValue(value: XProcDocument) {
-        override = value.with(stepConfig.checkType(null, value.value, params.asType, params.values))
-    }
-     */
 }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/validation/ValidateWithDTD.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/validation/ValidateWithDTD.kt
@@ -111,7 +111,7 @@ class ValidateWithDTD(): AbstractAtomicStep() {
     inner class MyErrorReporter : ErrorReporter {
         override fun report(error: XmlProcessingError?) {
             if (error == null) {
-                logger.warn { "DTD validation reported \"null\" error?" }
+                stepConfig.warn { "DTD validation reported \"null\" error?" }
                 return
             }
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/tracing/DetailTraceListener.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/tracing/DetailTraceListener.kt
@@ -8,25 +8,31 @@ import com.xmlcalabash.runtime.steps.AbstractStep
 import com.xmlcalabash.runtime.steps.Consumer
 import com.xmlcalabash.util.SaxonTreeBuilder
 import net.sf.saxon.s9api.QName
+import org.apache.logging.log4j.kotlin.logger
 import java.io.FileOutputStream
 import java.nio.file.Files
-import kotlin.io.path.Path
+import java.nio.file.Path
 
-class DetailTraceListener: StandardTraceListener() {
+class DetailTraceListener(val path: Path): StandardTraceListener() {
     val savedDocuments = mutableMapOf<Long, String>()
 
     override fun sendDocument(from: Pair<AbstractStep, String>, to: Pair<Consumer, String>, document: XProcDocument): XProcDocument {
         super.sendDocument(from, to, document)
 
         if (document.id !in savedDocuments) {
-            val path = Path("/tmp/x/trace")
-            val prefix = "${from.first}."
+            val prefix = "${from.first.id}."
             val suffix = document.contentType?.extension() ?: ".bin"
             val tempFile = Files.createTempFile(path, prefix, suffix).toFile()
             savedDocuments[document.id] = tempFile.absolutePath
 
             val fos = FileOutputStream(tempFile)
-            DocumentWriter(document, fos).write()
+            try {
+                val writer = DocumentWriter(document, fos)
+                writer.set(Ns.method, "adaptive")
+                writer.write()
+            } catch (ex: Exception) {
+                logger.warn { "Failed to write trace document: ${ex.message}"}
+            }
             fos.close()
         }
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/DefaultMessageReporter.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/DefaultMessageReporter.kt
@@ -14,7 +14,11 @@ class DefaultMessageReporter(val printer: MessagePrinter, nextReporter: MessageR
                 Verbosity.WARN -> "Warning: "
                 Verbosity.ERROR -> "Error: "
             }
-            printer.println("${prefix}${message()}")
+            try {
+                printer.println("${prefix}${message()}")
+            } catch (ex: Exception) {
+                printer.println("${prefix} failed to evaluate message: ${ex.message}")
+            }
         }
         nextReporter?.report(verbosity, extraAttributes, message)
     }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/ValueTemplateFilter.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/ValueTemplateFilter.kt
@@ -1,9 +1,9 @@
 package com.xmlcalabash.util
 
-import com.xmlcalabash.runtime.XProcStepConfiguration
 import com.xmlcalabash.datamodel.XProcExpression
 import com.xmlcalabash.documents.XProcDocument
 import com.xmlcalabash.runtime.LazyValue
+import com.xmlcalabash.runtime.XProcStepConfiguration
 import net.sf.saxon.s9api.QName
 import net.sf.saxon.s9api.XdmNode
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/ValueTemplateFilterNone.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/ValueTemplateFilterNone.kt
@@ -1,12 +1,11 @@
 package com.xmlcalabash.util
 
-import com.xmlcalabash.runtime.XProcStepConfiguration
-import com.xmlcalabash.documents.XProcDocument
 import com.xmlcalabash.datamodel.XProcExpression
+import com.xmlcalabash.documents.XProcDocument
 import com.xmlcalabash.runtime.LazyValue
+import com.xmlcalabash.runtime.XProcStepConfiguration
 import net.sf.saxon.s9api.QName
 import net.sf.saxon.s9api.XdmNode
-import net.sf.saxon.s9api.XdmValue
 import java.net.URI
 
 class ValueTemplateFilterNone(val encodedNode: XdmNode, val baseUri: URI): ValueTemplateFilter {

--- a/xmlcalabash/src/main/resources/com/xmlcalabash/graph2dot.xsl
+++ b/xmlcalabash/src/main/resources/com/xmlcalabash/graph2dot.xsl
@@ -125,11 +125,15 @@
 
   <xsl:variable name="edges" select="//g:edge[@to = $this/@id]"/>
   <xsl:if test="count($edges) gt 1">
-    <xsl:message terminate="yes" select="'Not exactly one edge to sink: ' || $this/@id || '?'"/>
+    <xsl:message select="'Not exactly one edge to sink: ' || $this/@id || '?'"/>
   </xsl:if>
-  <xsl:if test="not(starts-with($edges/@from, '!foot'))">
-    <dot:node xml:id="{@gid}" dot:shape="point"/>
-  </xsl:if>
+
+  <xsl:for-each select="$edges">
+    <xsl:variable name="edge" select="."/>
+    <xsl:if test="not(starts-with($edge/@from, '!foot'))">
+      <dot:node xml:id="{$this/@gid}" dot:shape="point"/>
+    </xsl:if>
+  </xsl:for-each>
 </xsl:template>
 
 <xsl:template match="g:atomic[@tag='cx:sink']" priority="10">


### PR DESCRIPTION
This PR is a big, complex bag of bug fixes. It's the result of a couple of days effort to get a substantial "real world" pipeline to run. It's remarkable how many things can be completely wrong and still all the test suite tests pass. 

1. On user-defined steps, the implementation wasn't waiting for computed options to be provided. It just happens that in all of the relevant test suite tests, the steps that provide the options come first and are ready to run, so the tests pass accidentally.
2. There were, and are still, some bugs related to text value templates. See [#1131](https://github.com/xproc/3.0-specification/issues/1131) and [#810](https://github.com/xproc/3.0-test-suite/pull/810)
3. The base URI of an expression was sometimes the point-of-use rather than the point-of-declaration.
4. Options can have external assignments, *with-options* cannot!
5. Steps declared in libraries were incompletely validated and consequently would sometimes fail to run correctly.

Fix #156 


