### PR TITLE
Make sure directories are created before attempting to write files

### DIFF
--- a/app/src/main/kotlin/com/xmlcalabash/app/FileOutputReceiver.kt
+++ b/app/src/main/kotlin/com/xmlcalabash/app/FileOutputReceiver.kt
@@ -30,6 +30,7 @@ class FileOutputReceiver(xmlCalabash: XmlCalabash,
                 System.out
             } else {
                 val outfile = files[port]!!.nextFile()
+                outfile.parentFile.mkdirs()
 
                 logger.debug { "Writing $port to ${outfile.absolutePath}" }
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/XProcError.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/XProcError.kt
@@ -149,6 +149,7 @@ class XProcError private constructor(val code: QName, val variant: Int, val loca
         fun xdViewportOnAttribute(expr: String) = dynamic(10, expr)
         fun xdDoesNotExist(path: String, message: String) = dynamic(Pair(11, 1), path, message)
         fun xdIsNotReadable(path: String, message: String) = dynamic(Pair(11, 2), path, message)
+        fun xdIsNotWriteable(path: String, message: String) = dynamic(Pair(11, 3), path, message)
         fun xdInvalidQName(name: String) = dynamic(Pair(15, 1), name)
         fun xdNoBindingInScope(message: String) = dynamic(Pair(15, 2), message)
         fun xdInvalidSelection(name: QName) = dynamic(Pair(16, 1), name)

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/XProcPipeline.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/XProcPipeline.kt
@@ -133,6 +133,7 @@ class XProcPipeline internal constructor(runtime: XProcRuntime, pipeline: Compou
 
         val trace = config.environment.xmlCalabash.xmlCalabashConfig.trace
         if (trace != null && traceListener != null) {
+            trace.parentFile.mkdirs()
             val doc = XProcDocument.ofXml(traceListener!!.summary(config), config)
             val fos = FileOutputStream(trace)
             val writer = DocumentWriter(doc, fos)

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/StoreStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/StoreStep.kt
@@ -5,9 +5,8 @@ import com.xmlcalabash.exceptions.XProcError
 import com.xmlcalabash.io.DocumentWriter
 import com.xmlcalabash.namespace.Ns
 import com.xmlcalabash.namespace.NsC
+import com.xmlcalabash.util.FileUtils
 import com.xmlcalabash.util.SaxonTreeBuilder
-import java.io.File
-import java.io.FileOutputStream
 
 open class StoreStep(): AbstractAtomicStep() {
     override fun run() {
@@ -25,8 +24,7 @@ open class StoreStep(): AbstractAtomicStep() {
         }
 
         val serialization = qnameMapBinding(Ns.serialization)
-        val outFile = File(href.path)
-        val fos = FileOutputStream(outFile)
+        val fos = FileUtils.outputStream(href)
         DocumentWriter(document, fos, serialization).write()
         fos.close()
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/archives/ArOutputArchive.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/archives/ArOutputArchive.kt
@@ -3,6 +3,7 @@ package com.xmlcalabash.steps.archives
 import com.xmlcalabash.namespace.Ns
 import com.xmlcalabash.namespace.NsCx
 import com.xmlcalabash.runtime.XProcStepConfiguration
+import com.xmlcalabash.util.FileUtils
 import org.apache.commons.compress.archivers.ar.ArArchiveEntry
 import org.apache.commons.compress.archivers.ar.ArArchiveOutputStream
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry
@@ -25,7 +26,7 @@ open class ArOutputArchive(stepConfig: XProcStepConfiguration): OutputArchive(st
             archiveFile = file.toPath()
         }
 
-        val stream = BufferedOutputStream(FileOutputStream(archiveFile.toFile()))
+        val stream = BufferedOutputStream(FileUtils.outputStream(archiveFile))
         arStream = ArArchiveOutputStream(stream)
     }
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/archives/CpioOutputArchive.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/archives/CpioOutputArchive.kt
@@ -3,6 +3,7 @@ package com.xmlcalabash.steps.archives
 import com.xmlcalabash.namespace.Ns
 import com.xmlcalabash.namespace.NsCx
 import com.xmlcalabash.runtime.XProcStepConfiguration
+import com.xmlcalabash.util.FileUtils
 import org.apache.commons.compress.archivers.cpio.CpioArchiveEntry
 import org.apache.commons.compress.archivers.cpio.CpioArchiveOutputStream
 import org.apache.commons.compress.archivers.cpio.CpioConstants
@@ -22,7 +23,7 @@ open class CpioOutputArchive(stepConfig: XProcStepConfiguration): OutputArchive(
             archiveFile = file.toPath()
         }
 
-        val stream = BufferedOutputStream(FileOutputStream(archiveFile.toFile()))
+        val stream = BufferedOutputStream(FileUtils.outputStream(archiveFile))
         cpioStream = CpioArchiveOutputStream(stream)
     }
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/archives/InputArchive.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/archives/InputArchive.kt
@@ -2,7 +2,7 @@ package com.xmlcalabash.steps.archives
 
 import com.xmlcalabash.documents.XProcBinaryDocument
 import com.xmlcalabash.runtime.XProcStepConfiguration
-import java.io.FileOutputStream
+import com.xmlcalabash.util.FileUtils
 import java.io.InputStream
 import java.net.URI
 import java.nio.file.Files
@@ -19,7 +19,7 @@ abstract class InputArchive(stepConfig: XProcStepConfiguration, val doc: XProcBi
         archiveFile = Files.createTempFile(tdir, null, ext)
         archiveFile.toFile().deleteOnExit()
         temporary = true
-        val stream = FileOutputStream(archiveFile.toFile())
+        val stream = FileUtils.outputStream(archiveFile)
         stream.write(doc.binaryValue)
         stream.close()
     }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/archives/TarOutputArchive.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/archives/TarOutputArchive.kt
@@ -3,14 +3,13 @@ package com.xmlcalabash.steps.archives
 import com.xmlcalabash.namespace.Ns
 import com.xmlcalabash.namespace.NsCx
 import com.xmlcalabash.runtime.XProcStepConfiguration
-import org.apache.commons.compress.archivers.cpio.CpioArchiveEntry
+import com.xmlcalabash.util.FileUtils
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream
 import org.apache.commons.compress.archivers.tar.TarConstants
 import java.io.BufferedOutputStream
 import java.io.ByteArrayOutputStream
 import java.io.File
-import java.io.FileOutputStream
 import java.nio.file.attribute.FileTime
 import java.time.Instant
 
@@ -25,7 +24,7 @@ open class TarOutputArchive(stepConfig: XProcStepConfiguration): OutputArchive(s
             archiveFile = file.toPath()
         }
 
-        val stream = BufferedOutputStream(FileOutputStream(archiveFile.toFile()))
+        val stream = BufferedOutputStream(FileUtils.outputStream(archiveFile))
         tarStream = TarArchiveOutputStream(stream)
     }
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/tracing/DetailTraceListener.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/tracing/DetailTraceListener.kt
@@ -6,6 +6,7 @@ import com.xmlcalabash.namespace.Ns
 import com.xmlcalabash.runtime.XProcStepConfiguration
 import com.xmlcalabash.runtime.steps.AbstractStep
 import com.xmlcalabash.runtime.steps.Consumer
+import com.xmlcalabash.util.FileUtils
 import com.xmlcalabash.util.SaxonTreeBuilder
 import net.sf.saxon.s9api.QName
 import org.apache.logging.log4j.kotlin.logger
@@ -25,7 +26,7 @@ class DetailTraceListener(val path: Path): StandardTraceListener() {
             val tempFile = Files.createTempFile(path, prefix, suffix).toFile()
             savedDocuments[document.id] = tempFile.absolutePath
 
-            val fos = FileOutputStream(tempFile)
+            val fos = FileUtils.outputStream(tempFile)
             try {
                 val writer = DocumentWriter(document, fos)
                 writer.set(Ns.method, "adaptive")

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/FileUtils.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/FileUtils.kt
@@ -1,0 +1,38 @@
+package com.xmlcalabash.util
+
+import com.xmlcalabash.exceptions.XProcError
+import java.io.File
+import java.io.FileOutputStream
+import java.io.OutputStream
+import java.net.URI
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.toPath
+
+class FileUtils {
+    companion object {
+        fun outputStream(uri: URI): OutputStream {
+            val target = UriUtils.cwdAsUri().resolve(uri)
+            if (target.scheme != "file") {
+                throw XProcError.xdIsNotWriteable(target.toString(), "Only file: URIs are supported for output").exception()
+            }
+            val file = target.toPath().toFile()
+            val parent = file.parentFile
+            parent.mkdirs()
+            return FileOutputStream(file)
+        }
+
+        fun outputStream(path: String): OutputStream {
+            return outputStream(UriUtils.cwdAsUri().resolve(path))
+        }
+
+        fun outputStream(file: File): OutputStream {
+            file.parentFile.mkdirs()
+            return FileOutputStream(file)
+        }
+
+        fun outputStream(path: Path): OutputStream {
+            return outputStream(path.toFile())
+        }
+    }
+}

--- a/xmlcalabash/src/main/resources/com/xmlcalabash/explain-errors.txt
+++ b/xmlcalabash/src/main/resources/com/xmlcalabash/explain-errors.txt
@@ -37,6 +37,11 @@ Cannot read URI “$1”: “$2”.
 It is a dynamic error if the resource referenced by the href option does not
 exist, cannot be accessed or is not a file.
 
+XD0011/3
+Cannot Write URI “$1”: “$2”.
+It is a dynamic error if the resource referenced by the href option does not
+exist, cannot be accessed or is not a file.
+
 XD0015/1
 Invalid QName: “$1”.
 It is a dynamic error if a QName is specified and it cannot be resolved with the


### PR DESCRIPTION
It’s very odd. Somehow, I’d convinced myself that Java did this automatically. And there are no tests that check this behavior, apparently.

Fix #175