### PR TITLE
Improve reporting of user-defined errors

### DIFF
--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/XProcError.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/XProcError.kt
@@ -8,7 +8,7 @@ import net.sf.saxon.s9api.*
 import java.net.URI
 import java.util.*
 
-class XProcError private constructor(val code: QName, val variant: Int, val location: Location, val inputLocation: Location, vararg val details: Any) {
+open class XProcError protected constructor(val code: QName, val variant: Int, val location: Location, val inputLocation: Location, vararg val details: Any) {
     companion object {
         val DEBUGGER_ABORT = 9997
 
@@ -411,14 +411,6 @@ class XProcError private constructor(val code: QName, val variant: Int, val loca
     val throwable: Throwable?
         get() = _throwable
     val stackTrace = Stack<ErrorStackFrame>()
-
-    // So that p:error can throw an error
-    constructor(code: QName, location: Location = Location.NULL, inputLocation: Location = Location.NULL, vararg details: Any): this(code, 1, location, inputLocation, *details)
-
-    private constructor(error: XProcError): this(error.code, error.variant, error.location, error.inputLocation, *error.details) {
-        _throwable = error.throwable
-        stackTrace.addAll(error.stackTrace)
-    }
 
     private constructor(error: XProcError, location: Location, inputLocation: Location): this(error.code, error.variant, location, inputLocation, *error.details) {
         _throwable = error.throwable

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/XProcUserError.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/XProcUserError.kt
@@ -1,0 +1,10 @@
+package com.xmlcalabash.exceptions
+
+import com.xmlcalabash.datamodel.Location
+import com.xmlcalabash.documents.XProcDocument
+import net.sf.saxon.s9api.QName
+
+class XProcUserError(code: QName, location: Location, inputLocation: Location, vararg documents: XProcDocument)
+    : XProcError(code, 1, location, inputLocation, *documents)
+{
+}

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/ErrorStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/ErrorStep.kt
@@ -3,6 +3,7 @@ package com.xmlcalabash.steps
 import com.xmlcalabash.datamodel.Location
 import com.xmlcalabash.documents.XProcDocument
 import com.xmlcalabash.exceptions.XProcError
+import com.xmlcalabash.exceptions.XProcUserError
 import com.xmlcalabash.namespace.Ns
 import com.xmlcalabash.namespace.NsC
 import com.xmlcalabash.namespace.NsP
@@ -75,7 +76,7 @@ class ErrorStep(): AbstractAtomicStep() {
             Location.NULL
         }
 
-        throw stepConfig.exception(XProcError(code, stepParams.location, location, XProcDocument.ofXml(builder.result, stepConfig)))
+        throw XProcUserError(code, stepParams.location, location, XProcDocument.ofXml(builder.result, stepConfig)).exception()
     }
 
     override fun toString(): String = "p:error"


### PR DESCRIPTION
If a pipeline author aborts a pipeline with p:error, make sure that any details provided are presented when the pipeline fails. (Don’t attempt to use the error explainer, it won’t know anything about that error.)

Fix #174