### PR TITLE
Rework how Graphviz visualizations are created and stored

### DIFF
--- a/app/src/main/kotlin/com/xmlcalabash/app/CommandLine.kt
+++ b/app/src/main/kotlin/com/xmlcalabash/app/CommandLine.kt
@@ -46,10 +46,9 @@ class CommandLine private constructor(val args: Array<out String>) {
     private val validCommands = listOf("version", "run", "help")
     private var _command: String = "run"
     private var _config: File? = null
-    private var _pipelineGraph: String? = null
+    private var _pipelineGraphs: String? = null
     private var _licensed = true
     private var _pipe: Boolean? = null
-    private var _pipelineDescription: String? = null
     private var _debug: Boolean? = null
     private var _debugger = false
     private var _visualizer: String? = null
@@ -78,8 +77,13 @@ class CommandLine private constructor(val args: Array<out String>) {
         get() = _config
 
     /** The pipeline graph description output filename. */
-    val pipelineGraph: String?
-        get() = _pipelineGraph
+    val pipelineGraphs: String?
+        get() {
+            if (_pipelineGraphs != null && _pipelineGraphs!!.endsWith("/")) {
+                return _pipelineGraphs
+            }
+            return "${_pipelineGraphs}/"
+        }
 
     /** Enable licensed features?
      * <p>Setting licensed to false will disable licensed features in Saxon PE and Saxon EE.</p>
@@ -90,10 +94,6 @@ class CommandLine private constructor(val args: Array<out String>) {
     /** Enable Unix-style pipeline processing of stdin and stdout? */
     val pipe: Boolean?
         get() = _pipe
-
-    /** The pipeline description output filename. */
-    val pipelineDescription: String?
-        get() = _pipelineDescription
 
     /** Enable debugging output? Adjust the logging level accordingly. */
     val debug: Boolean?
@@ -196,8 +196,7 @@ class CommandLine private constructor(val args: Array<out String>) {
         ArgumentDescription("--init", listOf(), ArgumentType.STRING) { it -> _initializers.add(it) },
         ArgumentDescription("--configuration", listOf("-c", "--config"), ArgumentType.EXISTING_FILE) { it -> _config = File(it) },
         ArgumentDescription("--step", listOf(), ArgumentType.STRING) { it -> _step = it },
-        ArgumentDescription("--graph", listOf(), ArgumentType.FILE) { it -> _pipelineGraph = it },
-        ArgumentDescription("--description", listOf(), ArgumentType.FILE) { it -> _pipelineDescription = it },
+        ArgumentDescription("--graphs", listOf(), ArgumentType.DIRECTORY) { it -> _pipelineGraphs = it },
         ArgumentDescription("--licensed", listOf(), ArgumentType.BOOLEAN, "true") { it -> _licensed = it == "true" },
         ArgumentDescription("--pipe", listOf(), ArgumentType.BOOLEAN, "true") { it -> _pipe = it == "true" },
         ArgumentDescription("--debug", listOf("-D"), ArgumentType.BOOLEAN, "true") { it -> _debug = it == "true" },

--- a/app/src/main/kotlin/com/xmlcalabash/app/XmlCalabashCli.kt
+++ b/app/src/main/kotlin/com/xmlcalabash/app/XmlCalabashCli.kt
@@ -226,18 +226,12 @@ class XmlCalabashCli private constructor() {
                 }
             }
 
-            if (commandLine.pipelineDescription != null || commandLine.pipelineGraph != null) {
-                val description = runtime.description()
-                if (commandLine.pipelineDescription != null) {
-                    VisualizerOutput.xml(xmlCalabash, description, commandLine.pipelineDescription!!)
-                }
-
-                if (commandLine.pipelineGraph != null) {
-                    if (config.graphviz == null) {
-                        logger.warn { "Cannot create SVG descriptions, graphviz is not configured"}
-                    } else {
-                        VisualizerOutput.svg(description, commandLine.pipelineGraph!!, config.graphviz!!.absolutePath)
-                    }
+            if (commandLine.pipelineGraphs != null) {
+                if (config.graphviz == null) {
+                    logger.warn { "Cannot create SVG, graphviz is not configured"}
+                } else {
+                    val description = runtime.description()
+                    VisualizerOutput.svg(description, commandLine.pipelineGraphs!!, config.graphviz!!.absolutePath)
                 }
             }
 
@@ -387,6 +381,9 @@ class XmlCalabashCli private constructor() {
 
         if (verbosity <= Verbosity.DEBUG) {
             errors[0].printStackTrace()
+            if (errors[0].cause != null && errors[0].cause != errors[0]) {
+                errors[0].cause!!.printStackTrace()
+            }
         }
 
         exitProcess(1)

--- a/app/src/main/scripts/xmlcalabash.ps1
+++ b/app/src/main/scripts/xmlcalabash.ps1
@@ -22,4 +22,4 @@ ForEach-Object {
 
 # FIXME: should there be some attempt to look for $Env:JAVA_HOME here?
 
-java -cp "$cp" com.xmlcalabash.app.Main "$args"
+java -cp "$cp" com.xmlcalabash.app.Main $args

--- a/documentation/src/userguide/run.xml
+++ b/documentation/src/userguide/run.xml
@@ -72,8 +72,7 @@ given, the <command>run</command> command is assumed.</para>
   <arg rep="repeat" linkend="cli-namespace">--namespace:<replaceable>prefix</replaceable>=<replaceable>uri</replaceable></arg>
   <arg rep="repeat" linkend="cli-init">--init:<replaceable>class-name</replaceable></arg>
   <sbr/>
-  <arg rep="norepeat" linkend="cli-description">--description:<replaceable>description-file</replaceable></arg>
-  <arg rep="norepeat" linkend="cli-graph">--graph:<replaceable>graph-file</replaceable></arg>
+  <arg rep="norepeat" linkend="cli-graphs">--graphs:<replaceable>graph-output-directory</replaceable></arg>
   <sbr/>
   <arg rep="norepeat" linkend="cli-step">--step:<replaceable>step-name</replaceable></arg>
   <sbr/>
@@ -227,25 +226,20 @@ API.)
 </listitem>
 </varlistentry>
 
-<varlistentry xml:id="cli-description">
-  <term><option>--description:<replaceable>description-file</replaceable></option>, pipeline description</term>
+<varlistentry xml:id="cli-graphs">
+  <term><option>--graphs:<replaceable>graph-output-directory</replaceable></option>, SVG graph outputs</term>
 <listitem>
-<para>This option writes an XML description of the pipeline and the corresponding graphs
-to <filename><replaceable>description-file</replaceable>.xml</filename>.
-</para>
-</listitem>
-</varlistentry>
-
-<varlistentry xml:id="cli-graph">
-  <term><option>--graph:<replaceable>graph-file</replaceable></option>, SVG graph outputs</term>
-<listitem>
-<para>This option writes two SVG descriptions of the pipeline. The first, named
-<filename><replaceable>graph-file</replaceable>.pipeline.svg</filename>, is a “boxes and arrows”
-diagram of the pipeline(s) to run, as interpreted by XML Calabash. The second, named
-<filename><replaceable>graph-file</replaceable>.graph.svg</filename>, is a diagram
-of the graph(s) that were constructed from the pipeline(s). The XML Calabash runtime executes
-the graphs, not the pipelines.
-</para>
+<para>This option writes hyperlinked SVG descriptions of pipelines, and their <link
+linkend="graphs">corresponding graphs</link>, to the
+<replaceable>graph-output-directory</replaceable>. The descriptions are “boxes and arrows”
+diagrams of the connections between the steps. One SVG diagram is produced for each declared
+pipeline and its corresponding graph. An HTML index in the
+<replaceable>graph-output-directory</replaceable> makes them easy to browse.</para>
+<note>
+<para>Some browsers have better support for SVG than others. If the diagrams are difficult
+to view, or if links don’t work correctly, a good first step is to try a different
+browser.</para>
+</note>
 </listitem>
 </varlistentry>
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/PipelineVisualization.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/PipelineVisualization.kt
@@ -92,6 +92,7 @@ class PipelineVisualization private constructor(private val instruction: XProcIn
 
     private fun declareStep(pipeline: DeclareStepInstruction) {
         startElement(pipeline.instructionType, mapOf(
+            "base-uri" to pipeline.stepConfig.baseUri?.toString(),
             "name" to pipeline.name,
             "id" to pipeline.id.toString(),
             "type" to pipeline.type?.toString(),

--- a/xmlcalabash/src/main/resources/com/xmlcalabash/dot-to-text.xsl
+++ b/xmlcalabash/src/main/resources/com/xmlcalabash/dot-to-text.xsl
@@ -6,30 +6,19 @@
                 xmlns:f="http://xmlcalabash.com/ns/functions"
                 xmlns:dot="http://xmlcalabash.com/ns/dot"
                 expand-text="yes"
+                default-mode="dot-to-text"
                 exclude-result-prefixes="#all"
                 version="3.0">
 
-<xsl:output method="text" encoding="utf-8"/>
-
-<xsl:strip-space elements="*"/>
-
 <xsl:variable name="nl" select="'&#10;'"/>
 
-<xsl:template match="dot:digraph-wrapper">
-  <!-- special case, mostly when debugging -->
-  <xsl:text>digraph </xsl:text>
-  <xsl:value-of select="@xml:id"/>
+<xsl:template match="dot:digraph">
+  <xsl:text>digraph pipeline</xsl:text>
   <xsl:text> {{&#10;</xsl:text>
   <xsl:text>compound=true{$nl}</xsl:text>
   <xsl:text>rankdir=TB{$nl}</xsl:text>
   <xsl:apply-templates/>
   <xsl:text>}}&#10;</xsl:text>
-</xsl:template>
-
-<xsl:template match="dot:digraph">
-  <!-- The digraph {} wrapper is added by the caller because
-       it may be combining several graphs into one. -->
-  <xsl:apply-templates/>
 </xsl:template>
 
 <xsl:template match="dot:subgraph[table]">

--- a/xmlcalabash/src/main/resources/com/xmlcalabash/graphviz.xsl
+++ b/xmlcalabash/src/main/resources/com/xmlcalabash/graphviz.xsl
@@ -1,0 +1,121 @@
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:dot="http://xmlcalabash.com/ns/dot"
+                xmlns:ns="http://xmlcalabash.com/ns/description"
+                xmlns:f="http://xmlcalabash.com/ns/functions"
+                xmlns:p="http://www.w3.org/ns/xproc"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                expand-text="yes"
+                version="3.0">
+
+<xsl:import href="pipelines.xsl"/>
+<xsl:import href="graphs.xsl"/>
+<xsl:import href="dot-to-text.xsl"/>
+
+<xsl:output method="text" encoding="utf-8"/>
+
+<xsl:strip-space elements="*"/>
+
+<xsl:param name="version" as="xs:string" select="'«unknown»'"/>
+
+<xsl:template match="ns:description">
+  <xsl:apply-templates select="." mode="pipelines"/>
+  <xsl:apply-templates select="." mode="graphs"/>
+
+  <xsl:result-document href="index.html" method="html" html-version="5" encoding="utf-8" indent="yes">
+    <html>
+      <head>
+        <title>Pipeline graphs</title>
+      </head>
+      <body>
+        <h1>Pipeline graphs</h1>
+        <p>
+          <xsl:text>XML Calabash version {$version} on </xsl:text>
+          <xsl:value-of select='format-dateTime(current-dateTime(),
+			        "[D01] [MNn,*-3] [Y0001] at [h01]:[m01]:[s01]")'/>
+        </p>
+
+        <xsl:variable name="trim-prefix"
+                      select="f:trim-prefix(distinct-values(ns:declare-step/@base-uri/string())) || '/'"/>
+
+        <p>Base URI: <code>{$trim-prefix}</code></p>
+
+        <table>
+          <thead>
+            <tr><th>XProc pipeline document</th><th>Pipeline</th><th>Graph</th></tr>
+          </thead>
+          <tbody>
+            <xsl:apply-templates select="ns:declare-step[1]">
+              <xsl:with-param name="trim-prefix" select="$trim-prefix"/>
+            </xsl:apply-templates>
+            <xsl:apply-templates select="ns:declare-step[position() gt 1]">
+              <xsl:sort select="@type"/>
+              <xsl:with-param name="trim-prefix" select="$trim-prefix"/>
+            </xsl:apply-templates>
+          </tbody>
+        </table>
+      </body>
+    </html>
+  </xsl:result-document>
+
+  <xsl:for-each select="ns:declare-step">
+    <xsl:text>pipelines/{@id}&#10;</xsl:text>
+  </xsl:for-each>
+
+  <xsl:for-each select="ns:graph/ns:pipeline">
+    <xsl:text>graphs/{@id}&#10;</xsl:text>
+  </xsl:for-each>
+</xsl:template>
+
+<xsl:template match="ns:declare-step">
+  <xsl:param name="trim-prefix" as="xs:string"/>
+  <tr>
+    <td>
+      <code><xsl:value-of select="substring-after(@base-uri, $trim-prefix)"/></code>
+    </td>
+    <td>
+      <a href="pipelines/{@id}.svg">{(@type, @id)[1]/string()}</a>
+    </td>
+    <td>
+      <xsl:variable name="graph" select="(following-sibling::ns:graph)[1]"/>
+      <a href="graphs/{$graph/ns:pipeline/@id}.svg">{$graph/ns:pipeline/@id/string()}</a>
+    </td>
+  </tr>
+</xsl:template>
+
+<xsl:function name="f:trim-prefix" as="xs:string">
+  <xsl:param name="files" as="xs:string*"/>
+  <xsl:choose>
+    <xsl:when test="count($files) = 1">
+      <xsl:sequence select="string-join(tokenize($files, '/')[position() lt last()], '/')"/>
+    </xsl:when>
+    <xsl:otherwise>
+      <xsl:sequence select="f:trim-prefix($files, '')"/>
+    </xsl:otherwise>
+  </xsl:choose>
+</xsl:function>
+
+<xsl:function name="f:trim-prefix" as="xs:string">
+  <xsl:param name="files" as="xs:string*"/>
+  <xsl:param name="prefix" as="xs:string"/>
+  
+  <xsl:variable name="firsts"
+                select="$files ! tokenize(., '/')[1]"/>
+
+  <xsl:choose>
+    <xsl:when test="empty($firsts)">
+      <xsl:sequence select="$prefix"/>
+    </xsl:when>
+    <xsl:when test="count(distinct-values($firsts)) = 1">
+      <xsl:variable name="rests"
+                    select="$files ! string-join(tokenize(., '/')[position() gt 1], '/')"/>
+      <xsl:variable name="new-prefix"
+                    select="if ($prefix = '') then $firsts[1] else $prefix || '/' || $firsts[1]"/>
+      <xsl:sequence select="f:trim-prefix($rests, $new-prefix)"/>
+    </xsl:when>
+    <xsl:otherwise>
+      <xsl:sequence select="$prefix"/>
+    </xsl:otherwise>
+  </xsl:choose>
+</xsl:function>
+
+</xsl:stylesheet>


### PR DESCRIPTION
This PR replaces the --description and --graph options with a single --graphs option that writes all of the descriptions to an output directory. Instead of one, potentially huge, SVG diagram of the entire set of pipelines, there are now distinct graphs for each pipeline with hyperlinks between them.