### PR TITLE
Check for required inputs and options before running a pipeline

### DIFF
--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/VariableBindingContainer.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/VariableBindingContainer.kt
@@ -1,10 +1,8 @@
 package com.xmlcalabash.datamodel
 
-import com.xmlcalabash.runtime.XProcStepConfiguration
 import com.xmlcalabash.exceptions.XProcError
 import net.sf.saxon.s9api.QName
 import net.sf.saxon.s9api.SequenceType
-import net.sf.saxon.s9api.XdmValue
 
 abstract class VariableBindingContainer(
     parent: XProcInstruction,

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/XProcError.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/XProcError.kt
@@ -144,7 +144,8 @@ open class XProcError protected constructor(val code: QName, val variant: Int, v
 
         fun xdSequenceForbidden() = dynamic(Pair(1,1))
         fun xdEmptySequenceForbidden() = dynamic(Pair(1,2))
-        fun xdInputSequenceForbidden(port: String) = dynamic(6, port)
+        fun xdInputSequenceForbidden(port: String) = dynamic(Pair(6, 1), port)
+        fun xdInputRequiredOnPort(port: String) = dynamic(Pair(6, 2), port)
         fun xdOutputSequenceForbidden(port: String) = dynamic(7, port)
         fun xdViewportOnAttribute(expr: String) = dynamic(10, expr)
         fun xdDoesNotExist(path: String, message: String) = dynamic(Pair(11, 1), path, message)

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/graph/ModelOption.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/graph/ModelOption.kt
@@ -10,7 +10,7 @@ import net.sf.saxon.s9api.QName
 import net.sf.saxon.s9api.SequenceType
 import net.sf.saxon.s9api.XdmAtomicValue
 
-class ModelOption private constructor(val parent: Model, val name: QName) {
+class ModelOption private constructor(val parent: Model, val name: QName, val required: Boolean) {
     private var _static = false
     val static: Boolean
         get() = _static
@@ -27,7 +27,7 @@ class ModelOption private constructor(val parent: Model, val name: QName) {
     val values: List<XdmAtomicValue>
         get() = _values
 
-    constructor(parent: Model, option: OptionInstruction): this(parent, option.name) {
+    constructor(parent: Model, option: OptionInstruction): this(parent, option.name, option.required == true) {
         _static = option.static
         _asType = option.asType!!
         _values = option.values
@@ -36,7 +36,7 @@ class ModelOption private constructor(val parent: Model, val name: QName) {
         }
     }
 
-    constructor(parent: Model, option: WithOptionInstruction): this(parent, option.name) {
+    constructor(parent: Model, option: WithOptionInstruction): this(parent, option.name, false) {
         _static = false
         _asType = option.asType!!
         _values = option.optionValues
@@ -45,7 +45,7 @@ class ModelOption private constructor(val parent: Model, val name: QName) {
         }
     }
 
-    constructor(parent: Model, option: StaticOptionDetails): this(parent, option.name) {
+    constructor(parent: Model, option: StaticOptionDetails): this(parent, option.name, false) {
         _static = true
         _asType = option.asType
         _values = option.values

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/api/RuntimeOption.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/api/RuntimeOption.kt
@@ -6,5 +6,5 @@ import net.sf.saxon.s9api.QName
 import net.sf.saxon.s9api.SequenceType
 import net.sf.saxon.s9api.XdmAtomicValue
 
-class RuntimeOption(val name: QName, val asType: SequenceType, val values: List<XdmAtomicValue>, val static: Boolean, val staticValue: XProcExpression? = null) {
+class RuntimeOption(val name: QName, val required: Boolean, val asType: SequenceType, val values: List<XdmAtomicValue>, val static: Boolean, val staticValue: XProcExpression? = null) {
 }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/model/AtomicBuiltinStepModel.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/model/AtomicBuiltinStepModel.kt
@@ -61,7 +61,8 @@ open class AtomicBuiltinStepModel(runtime: XProcRuntime, val model: AtomicModel)
                 for (name in step.expression.variableRefs) {
                     if (name in step.inscopeVariables) {
                         val expr = step.inscopeVariables[name]!!
-                        inscopeOptions[name] = RuntimeOption(name, expr.asType ?: SequenceType.ANY, emptyList(), false, expr.select!!)
+                        val required = expr is OptionInstruction && expr.required == true
+                        inscopeOptions[name] = RuntimeOption(name, required, expr.asType ?: SequenceType.ANY, emptyList(), false, expr.select!!)
                     }
                 }
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/model/StepModel.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/model/StepModel.kt
@@ -58,7 +58,7 @@ abstract class StepModel(val runtime: XProcRuntime, model: Model) {
             // Don't report [p:]messages as options
             if ((type.namespaceUri == NsP.namespace && name != Ns.message)
                 || (type.namespaceUri != NsP.namespace && name != NsP.message)) {
-                roptions[name] = RuntimeOption(name, option.asType, option.values, option.static, option.staticValue)
+                roptions[name] = RuntimeOption(name, option.required, option.asType, option.values, option.static, option.staticValue)
             }
         }
         options = roptions.toMap()

--- a/xmlcalabash/src/main/resources/com/xmlcalabash/explain-errors.txt
+++ b/xmlcalabash/src/main/resources/com/xmlcalabash/explain-errors.txt
@@ -11,8 +11,13 @@ There must be a context item for this expression.
 It is a dynamic error if an XPath expression makes reference to the context
 item, size, or position when the context item is undefined.
 
-XD0006
+XD0006/1
 A sequence of inputs is not allowed on the “$1” port.
+If sequence is not specified, or has the value false, then it is a dynamic error
+unless exactly one document appears on the declared port.
+
+XD0006/2
+An input must be provided for the “$1” port.
 If sequence is not specified, or has the value false, then it is a dynamic error
 unless exactly one document appears on the declared port.
 


### PR DESCRIPTION
When a top-level pipeline is run, check that required options and required
inputs have been provided. (Checking for required inputs here is an opportunity
to improve the error message.)