### PR TITLE
Tidy up the pipeline/graph visualization output

### DIFF
--- a/app/src/main/kotlin/com/xmlcalabash/app/XmlCalabashCli.kt
+++ b/app/src/main/kotlin/com/xmlcalabash/app/XmlCalabashCli.kt
@@ -243,7 +243,7 @@ class XmlCalabashCli private constructor() {
                         stream.close()
                     }
 
-                    VisualizerOutput.svg(description, commandLine.pipelineGraphs!!, config.graphviz!!.absolutePath)
+                    VisualizerOutput.svg(description, commandLine.pipelineGraphs!!, config.graphviz!!.absolutePath, commandLine.debug == true)
                 }
             }
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/PipelineVisualization.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/PipelineVisualization.kt
@@ -120,6 +120,7 @@ class PipelineVisualization private constructor(private val instruction: XProcIn
             "type" to step.instructionType.toString(),
             "expression" to expr,
             "as" to step.expression.asType.underlyingSequenceType.toString(),
+            "option-name" to step.externalName?.toString()
         )
 
         if (step.expression.values.isNotEmpty()) {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/graph/GraphVisualization.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/graph/GraphVisualization.kt
@@ -1,5 +1,6 @@
 package com.xmlcalabash.graph
 
+import com.xmlcalabash.datamodel.AtomicExpressionStepInstruction
 import com.xmlcalabash.datamodel.DeclareStepInstruction
 import com.xmlcalabash.datamodel.InstructionConfiguration
 import com.xmlcalabash.namespace.NsCx
@@ -234,10 +235,17 @@ class GraphVisualization private constructor(val graph: Graph) {
 
     open inner class AtomicNode(model: Model): ModelNode(model) {
         override fun describe(builder: SaxonTreeBuilder) {
+            val optName = if (model.step is AtomicExpressionStepInstruction) {
+                model.step.externalName?.toString()
+            } else {
+                null
+            }
+
             builder.addStartElement(NsDescription.atomic, stepConfig.stringAttributeMap(mapOf(
                 "id" to id,
                 "tag" to model.step.instructionType.toString(),
-                "name" to model.step.name)))
+                "name" to model.step.name,
+                "option-name" to optName)))
             connections(builder)
             builder.addEndElement()
         }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/namespace/Ns.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/namespace/Ns.kt
@@ -41,6 +41,7 @@ object Ns {
     val cwd = QName("cwd")
     val date = QName("date")
     val dtdValidate = QName("dtd-validate")
+    val debug = QName("debug")
     val deepEqual = QName("deep-equal")
     val deflate = QName("deflate")
     val defaultVersion = QName("default-version")

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/VisualizerOutput.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/VisualizerOutput.kt
@@ -32,7 +32,7 @@ class VisualizerOutput {
             writer.write()
         }
 
-        fun svg(node: XdmNode, outdir: String, graphviz: String) {
+        fun svg(node: XdmNode, outdir: String, graphviz: String, debug: Boolean = false) {
             val stylesheet = "/com/xmlcalabash/graphviz.xsl"
             var styleStream = VisualizerOutput::class.java.getResourceAsStream(stylesheet)
             var styleSource = SAXSource(InputSource(styleStream))
@@ -46,6 +46,10 @@ class VisualizerOutput {
 
             var transformer = xsltExec.load30()
             transformer.setStylesheetParameters(mapOf(Ns.version to XdmAtomicValue(XmlCalabashBuildConfig.VERSION)))
+            if (debug) {
+                transformer.setStylesheetParameters(mapOf(Ns.debug to XdmAtomicValue("1")))
+            }
+
             transformer.globalContextItem = node
             transformer.baseOutputURI = "${outputBaseURI}"
             val xmlResult = XdmDestination()

--- a/xmlcalabash/src/main/resources/com/xmlcalabash/graphs.xsl
+++ b/xmlcalabash/src/main/resources/com/xmlcalabash/graphs.xsl
@@ -25,7 +25,7 @@
       <xsl:apply-templates select="$labeled/g:graph"/>
     </xsl:variable>
 
-    <xsl:if test="$debug != 0">
+    <xsl:if test="$debug != '0'">
       <xsl:result-document href="graphs/{g:pipeline/@id}.xml" method="xml" indent="yes">
         <xsl:sequence select="$dotxml"/>
       </xsl:result-document>
@@ -215,10 +215,21 @@
         <xsl:if test="$xref">
           <xsl:attribute name="href" select="$xref"/>
         </xsl:if>
-        <xsl:if test="@tag">
-          <xsl:text>{string(@tag)}</xsl:text>
-          <br/>
-        </xsl:if>
+
+        <xsl:choose>
+          <xsl:when test="@option-name">
+            <xsl:text>${@option-name/string()}</xsl:text>
+            <br/>
+          </xsl:when>
+          <xsl:when test="@tag">
+            <xsl:text>{@tag/string()}</xsl:text>
+            <br/>
+          </xsl:when>
+          <xsl:otherwise>
+            <!-- nop -->
+          </xsl:otherwise>
+        </xsl:choose>
+
         <xsl:if test="true() or self::g:subpipeline or not(starts-with($label, '!'))">
           <xsl:choose>
             <xsl:when test="$xref and starts-with($xref, '#')">

--- a/xmlcalabash/src/main/resources/com/xmlcalabash/graphviz.xsl
+++ b/xmlcalabash/src/main/resources/com/xmlcalabash/graphviz.xsl
@@ -172,7 +172,7 @@ a, a:visited {
       <code><xsl:value-of select="substring-after(@base-uri, $trim-prefix)"/></code>
     </td>
     <td>
-      <a href="pipelines/{@id}.svg">{(@type, @id)[1]/string()}</a>
+      <a href="pipelines/{@id}.svg">{(@type/string(), "«anonymous»")[1]}</a>
     </td>
     <td>
       <xsl:variable name="graph" select="(following-sibling::ns:graph)[1]"/>

--- a/xmlcalabash/src/main/resources/com/xmlcalabash/pipelines.xsl
+++ b/xmlcalabash/src/main/resources/com/xmlcalabash/pipelines.xsl
@@ -9,7 +9,7 @@
 
 <xsl:strip-space elements="*"/>
 
-<xsl:param name="debug" select="1"/>
+<xsl:param name="debug" select="'0'"/>
 
 <xsl:key name="step" match="ns:atomic-step|ns:compound-step|ns:declare-step" use="@name"/>
 
@@ -28,7 +28,7 @@
       <xsl:apply-templates select="$pipeline"/>
     </xsl:variable>
 
-    <xsl:if test="$debug != 0">
+    <xsl:if test="$debug != '0'">
       <xsl:result-document href="pipelines/{@id}.xml" method="xml" indent="yes">
         <xsl:sequence select="$dotxml"/>
       </xsl:result-document>
@@ -234,14 +234,19 @@
             <xsl:attribute name="href" select="$pipeline/@id || '.svg'"/>
           </xsl:if>
 
+          <xsl:variable name="display-name" as="xs:string"
+                        select="if (@option-name)
+                                then '$' || @option-name
+                                else @type"/>
+
           <xsl:choose>
             <xsl:when test="$pipeline">
               <font color="#0000ff">
-                <xsl:text>{@type/string()}</xsl:text>
+                <xsl:text>{$display-name}</xsl:text>
               </font>
             </xsl:when>
             <xsl:otherwise>
-              <xsl:text>{@type/string()}</xsl:text>
+              <xsl:text>{$display-name}</xsl:text>
             </xsl:otherwise>
           </xsl:choose>
 


### PR DESCRIPTION
Output option names for options, use the command line --debug flag to control debugging output. Use «anonymous» instead of the arbitrary step ID for the root pipeline if it has no declared type.