### PR TITLE
Compute a total order over subpipeline steps during graph building

### DIFF
--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/graph/Graph.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/graph/Graph.kt
@@ -4,9 +4,7 @@ import com.xmlcalabash.datamodel.*
 import com.xmlcalabash.exceptions.XProcError
 import com.xmlcalabash.namespace.NsCx
 import com.xmlcalabash.namespace.NsP
-import com.xmlcalabash.steps.internal.SelectStep
 import net.sf.saxon.s9api.XdmNode
-import java.io.PrintStream
 import java.util.*
 
 class Graph private constructor(val environment: PipelineEnvironment) {
@@ -116,6 +114,8 @@ class Graph private constructor(val environment: PipelineEnvironment) {
 
         node.decompose()
         makeConnections()
+
+        (node as CompoundModel).computeOrder()
 
         pipelineNode = node
         return node


### PR DESCRIPTION
This change replaces the, in retrospect very strange, approach previously taken where the steps were effectively unordered and at runtime each was tested to see if it could be run. Now we work out in advance a total order such that no step runs before any step that it depends on. (With some special cases to deal with the when/otherwise clauses in a choose.)