### PR TITLE
Reworked document resolver APIs

### DIFF
--- a/documentation/src/userguide/errors.xml
+++ b/documentation/src/userguide/errors.xml
@@ -1,0 +1,34 @@
+<chapter xmlns="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:xi='http://www.w3.org/2001/XInclude'
+         version="5.2" xml:id="errors">
+<info>
+  <?db filename="errors"?>
+  <title>Errors and error messages</title>
+</info>
+
+<para>It is an explicit goal of XML Calabash that it should produce reasonable
+and useful error messages. <link xlink:href="https://github.com/xmlcalabash/xmlcalabash3/issues">Bug
+reports</link> to the effect that “such and such an error is confusing” are
+most welcome.</para>
+
+<section>
+<title>Validation errors</title>
+
+<para>The validation steps produce error reports using the
+<link xlink:href="https://spec.xproc.org/master/head/xvrl/">Extensible
+Validation Reporting Language (XVRL)</link>. When a validation step
+fails and the error causes pipeline execution to fail, this report
+is formatted as a text document for the purpose of the error message.</para>
+
+<para>The formatting is done by this stylesheet:</para>
+
+<programlisting language='xml'
+><xi:include href="../../../xmlcalabash/src/main/resources/com/xmlcalabash/format-xvrl.xsl"
+parse="text"/></programlisting>
+
+<para>If you find XVRL reports that aren’t usefully summarized, please
+report them.</para>
+
+</section>
+</chapter>

--- a/documentation/src/userguide/userguide.xml
+++ b/documentation/src/userguide/userguide.xml
@@ -29,6 +29,7 @@
 <xi:include href="run.xml"/>
 <xi:include href="graphs.xml"/>
 <xi:include href="logging.xml"/>
+<xi:include href="errors.xml"/>
 <xi:include href="debugger.xml"/>
 <xi:include href="assertions.xml"/>
 

--- a/ext/cache/src/main/kotlin/com/xmlcalabash/ext/cache/DocumentResolverProvider.kt
+++ b/ext/cache/src/main/kotlin/com/xmlcalabash/ext/cache/DocumentResolverProvider.kt
@@ -17,6 +17,10 @@ class DocumentResolverProvider:  DocumentResolverProvider, DocumentResolver {
         var library: XProcDocument? = null
     }
 
+    override fun resolvableUris(): List<URI> {
+        return listOf(MAGIC_URI)
+    }
+
     override fun create(): DocumentResolver {
         return this
     }

--- a/ext/epubcheck/src/main/kotlin/com/xmlcalabash/ext/epubcheck/DocumentResolverProvider.kt
+++ b/ext/epubcheck/src/main/kotlin/com/xmlcalabash/ext/epubcheck/DocumentResolverProvider.kt
@@ -17,6 +17,10 @@ class DocumentResolverProvider:  DocumentResolverProvider, DocumentResolver {
         var library: XProcDocument? = null
     }
 
+    override fun resolvableUris(): List<URI> {
+        return listOf(MAGIC_URI)
+    }
+
     override fun create(): DocumentResolver {
         return this
     }

--- a/ext/metadata-extractor/src/main/kotlin/com/xmlcalabash/ext/metadataextractor/DocumentResolverProvider.kt
+++ b/ext/metadata-extractor/src/main/kotlin/com/xmlcalabash/ext/metadataextractor/DocumentResolverProvider.kt
@@ -17,6 +17,10 @@ class DocumentResolverProvider:  DocumentResolverProvider, DocumentResolver {
         var library: XProcDocument? = null
     }
 
+    override fun resolvableUris(): List<URI> {
+        return listOf(MAGIC_URI)
+    }
+
     override fun create(): DocumentResolver {
         return this
     }

--- a/ext/pipeline-messages/src/main/kotlin/com/xmlcalabash/ext/pipelinemessages/DocumentResolverProvider.kt
+++ b/ext/pipeline-messages/src/main/kotlin/com/xmlcalabash/ext/pipelinemessages/DocumentResolverProvider.kt
@@ -17,6 +17,10 @@ class DocumentResolverProvider:  DocumentResolverProvider, DocumentResolver {
         var library: XProcDocument? = null
     }
 
+    override fun resolvableUris(): List<URI> {
+        return listOf(MAGIC_URI)
+    }
+
     override fun create(): DocumentResolver {
         return this
     }

--- a/ext/polyglot/src/main/kotlin/com/xmlcalabash/ext/polyglot/DocumentResolverProvider.kt
+++ b/ext/polyglot/src/main/kotlin/com/xmlcalabash/ext/polyglot/DocumentResolverProvider.kt
@@ -17,6 +17,10 @@ class DocumentResolverProvider:  DocumentResolverProvider, DocumentResolver {
         var library: XProcDocument? = null
     }
 
+    override fun resolvableUris(): List<URI> {
+        return listOf(MAGIC_URI)
+    }
+
     override fun create(): DocumentResolver {
         return this
     }

--- a/ext/unique-id/src/main/kotlin/com/xmlcalabash/ext/uniqueid/DocumentResolverProvider.kt
+++ b/ext/unique-id/src/main/kotlin/com/xmlcalabash/ext/uniqueid/DocumentResolverProvider.kt
@@ -1,12 +1,12 @@
 package com.xmlcalabash.ext.uniqueid
 
-import com.xmlcalabash.io.MediaType
 import com.xmlcalabash.documents.XProcDocument
 import com.xmlcalabash.io.DocumentLoader
 import com.xmlcalabash.io.DocumentManager
+import com.xmlcalabash.io.MediaType
+import com.xmlcalabash.runtime.XProcStepConfiguration
 import com.xmlcalabash.spi.DocumentResolver
 import com.xmlcalabash.spi.DocumentResolverProvider
-import com.xmlcalabash.runtime.XProcStepConfiguration
 import java.io.IOException
 import java.net.URI
 
@@ -15,6 +15,10 @@ class DocumentResolverProvider:  DocumentResolverProvider, DocumentResolver {
         val MAGIC_URI = URI("https://xmlcalabash.com/ext/library/unique-id.xpl")
         val RESOURCE_PATH = "/com/xmlcalabash/ext/unique-id.xpl"
         var library: XProcDocument? = null
+    }
+
+    override fun resolvableUris(): List<URI> {
+        return listOf(MAGIC_URI)
     }
 
     override fun create(): DocumentResolver {

--- a/ext/xpath/src/main/kotlin/com/xmlcalabash/ext/xpath/DocumentResolverProvider.kt
+++ b/ext/xpath/src/main/kotlin/com/xmlcalabash/ext/xpath/DocumentResolverProvider.kt
@@ -17,6 +17,10 @@ class DocumentResolverProvider:  DocumentResolverProvider, DocumentResolver {
         var library: XProcDocument? = null
     }
 
+    override fun resolvableUris(): List<URI> {
+        return listOf(MAGIC_URI)
+    }
+
     override fun create(): DocumentResolver {
         return this
     }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/config/CommonEnvironment.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/config/CommonEnvironment.kt
@@ -17,6 +17,7 @@ import com.xmlcalabash.util.DefaultMessageReporter
 import com.xmlcalabash.api.MessageReporter
 import com.xmlcalabash.io.MessagePrinter
 import com.xmlcalabash.util.DefaultMessagePrinter
+import com.xmlcalabash.util.InternalDocumentResolver
 import net.sf.saxon.lib.Initializer
 import net.sf.saxon.s9api.QName
 import org.apache.logging.log4j.kotlin.logger
@@ -101,12 +102,25 @@ class CommonEnvironment(private val xmlCalabash: XmlCalabash) {
 
         for (provider in AtomicStepServiceProvider.providers()) {
             val manager = provider.create();
-            knownAtomicSteps.addAll(manager.stepTypes())
+            for (stepType in manager.stepTypes()) {
+                logger.debug { "Added available step type '$stepType'" }
+                knownAtomicSteps.add(stepType)
+            }
             stepManagers.add(manager)
         }
 
+        val internalManager = InternalDocumentResolver()
+        for (uri in internalManager.resolvableUris()) {
+            logger.debug { "Added resolvable URI: ${uri}" }
+        }
+        internalManager.configure(_documentManager)
+
         for (provider in DocumentResolverServiceProvider.providers()) {
-            provider.create().configure(_documentManager)
+            val manager = provider.create();
+            for (uri in manager.resolvableUris()) {
+                logger.debug { "Added resolvable URI: ${uri}" }
+            }
+            manager.configure(_documentManager)
         }
     }
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/DefaultErrorExplanation.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/DefaultErrorExplanation.kt
@@ -9,6 +9,7 @@ import com.xmlcalabash.namespace.Ns
 import com.xmlcalabash.namespace.NsCx
 import com.xmlcalabash.namespace.NsErr
 import com.xmlcalabash.namespace.NsXvrl
+import com.xmlcalabash.util.InternalDocumentResolver
 import com.xmlcalabash.util.MediaClassification
 import com.xmlcalabash.util.S9Api
 import net.sf.saxon.s9api.*
@@ -301,7 +302,11 @@ class DefaultErrorExplanation(): ErrorExplanation {
             environment!!.messageReporter().debug { "${node}" }
         }
 
-        val stylesheet = "/com/xmlcalabash/format-xvrl.xsl"
+        // This is a slightly odd context, we don't have access to a step configuration
+        // so we can't call on the document manager to load the stylesheet. But we
+        // can make sure we get the same one...
+        val stylesheet = InternalDocumentResolver.URI_MAP[InternalDocumentResolver.XVRL_TO_TEXT]!!
+
         var styleStream = DefaultErrorExplanation::class.java.getResourceAsStream(stylesheet)
         var styleSource = SAXSource(InputSource(styleStream))
         styleSource.systemId = "/com/xmlcalabash/format-report.xsl"

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/spi/DocumentResolver.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/spi/DocumentResolver.kt
@@ -6,6 +6,7 @@ import com.xmlcalabash.runtime.XProcStepConfiguration
 import java.net.URI
 
 interface DocumentResolver {
+    fun resolvableUris(): List<URI>
     fun configure(manager: DocumentManager)
     fun resolve(context: XProcStepConfiguration, uri: URI, current: XProcDocument?): XProcDocument?
 }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/InternalDocumentResolver.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/InternalDocumentResolver.kt
@@ -1,0 +1,55 @@
+package com.xmlcalabash.util
+
+import com.xmlcalabash.documents.XProcDocument
+import com.xmlcalabash.io.DocumentLoader
+import com.xmlcalabash.io.DocumentManager
+import com.xmlcalabash.io.MediaType
+import com.xmlcalabash.runtime.XProcStepConfiguration
+import com.xmlcalabash.spi.DocumentResolver
+import java.io.IOException
+import java.net.URI
+
+class InternalDocumentResolver(): DocumentResolver {
+    companion object {
+        val XVRL_TO_TEXT = URI("https://xmlcalabash.com/stylesheet/xvrl-to-text.xsl")
+        val URI_MAP = mapOf(
+            XVRL_TO_TEXT to "/com/xmlcalabash/format-xvrl.xsl"
+        )
+        private val document_map = mutableMapOf<URI, XProcDocument>()
+    }
+
+    override fun resolvableUris(): List<URI> {
+        return URI_MAP.keys.toList()
+    }
+
+    override fun configure(manager: DocumentManager) {
+        for ((uri, _) in URI_MAP) {
+            manager.registerPrefix(uri.toString(), this)
+        }
+    }
+
+    override fun resolve(context: XProcStepConfiguration, uri: URI, current: XProcDocument?): XProcDocument? {
+        if (current != null) {
+            return current // WAT?
+        }
+
+        if (uri !in URI_MAP) {
+            return null // WAT?
+        }
+
+        synchronized(Companion) {
+            if (uri in document_map) {
+                return document_map[uri]!!
+            }
+
+            val path = URI_MAP[uri]!!
+            val loader = DocumentLoader(context, uri)
+            val stream = InternalDocumentResolver::class.java.getResourceAsStream(path)
+                ?: throw IOException("Failed to find ${path} as a resource")
+            val document = loader.load(uri, stream, MediaType.XML)
+            stream.close()
+            document_map[uri] = document
+            return document
+        }
+    }
+}

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/NopDocumentResolverProvider.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/NopDocumentResolverProvider.kt
@@ -12,6 +12,10 @@ class NopDocumentResolverProvider: DocumentResolverProvider, DocumentResolver {
         return this
     }
 
+    override fun resolvableUris(): List<URI> {
+        return emptyList()
+    }
+
     override fun configure(manager: DocumentManager) {
         // manager.registerPrefix("file:/Volumes/Documents/xsl/", this)
         // nop

--- a/xmlcalabash/src/main/resources/com/xmlcalabash/format-xvrl.xsl
+++ b/xmlcalabash/src/main/resources/com/xmlcalabash/format-xvrl.xsl
@@ -40,7 +40,9 @@
   <xsl:choose>
     <xsl:when test=". castable as xs:dateTime">
       <xsl:variable name="dt"
-                    select="format-dateTime(xs:dateTime(.), '[D01] [MNn,*-3] [Y0001] at [h01]:[m01]:[s01]Z')"/>
+                    select="format-dateTime(xs:dateTime(.),
+                              '[D01] [MNn,*-3] [Y0001] '
+                              || 'at [h01]:[m01]:[s01]Z')"/>
       <xsl:choose>
         <xsl:when test="../../self::xvrl:reports">
           <xsl:text>XVRL Reports on {$dt}</xsl:text>
@@ -99,7 +101,8 @@
       <xsl:text>  {xvrl:message/node()}</xsl:text>
     </xsl:when>
     <xsl:otherwise>
-      <xsl:text>  {xvrl:message/node() ! serialize(., map{'method':'xml', 'indent':true()})}</xsl:text>
+      <xsl:text>  {xvrl:message/node()
+        ! serialize(., map{'method':'xml', 'indent':true()})}</xsl:text>
     </xsl:otherwise>
   </xsl:choose>
   <xsl:text>{$nl}</xsl:text>


### PR DESCRIPTION
1. Added a method to get the URIs of documents so resolved
2. Updated the default error formatter to use the published XSLT
3. Added the XVRL-to-text XSLT transformation to the userguide in a new *Errors and error messages* chapter.