### PR TITLE
Don’t construct a new Saxon configuration for every step

### DIFF
--- a/ext/pipeline-messages/src/main/kotlin/com/xmlcalabash/ext/pipelinemessages/PipelineMessagesStep.kt
+++ b/ext/pipeline-messages/src/main/kotlin/com/xmlcalabash/ext/pipelinemessages/PipelineMessagesStep.kt
@@ -52,7 +52,7 @@ class PipelineMessagesStep(): AbstractAtomicStep() {
                 attributes[name] = value
             }
             attributes[Ns.level] = "${message.level}"
-            attributes[Ns.message] = message.message()
+            attributes[Ns.message] = message.message
             attributes[Ns.date] = "${message.timestamp}"
 
             builder.addStartElement(NsCx.message, stepConfig.attributeMap(attributes))

--- a/test-driver/src/main/kotlin/com/xmlcalabash/testdriver/TestCase.kt
+++ b/test-driver/src/main/kotlin/com/xmlcalabash/testdriver/TestCase.kt
@@ -347,7 +347,7 @@ class TestCase(val suite: TestSuite, val testFile: File) {
         for (message in messages) {
             builder.addStartElement(NsCx.message, attributeMap(mapOf(
                 Ns.level to "${message.level}",
-                Ns.message to message.message(),
+                Ns.message to message.message,
                 Ns.date to "${message.timestamp}"
             )))
             builder.addEndElement()

--- a/tests/extra-suite/test-suite/tests/issue-160-001.xml
+++ b/tests/extra-suite/test-suite/tests/issue-160-001.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+  <t:info>
+    <t:title>issue-160--001</t:title>
+    <t:revision-history>
+      <t:revision>
+        <t:date>2025-01-19</t:date>
+        <t:author>
+          <t:name>Norm Tovey-Walsh</t:name>
+        </t:author>
+        <t:description xmlns="http://www.w3.org/1999/xhtml">
+          <p>Created test.</p>
+        </t:description>
+      </t:revision>
+    </t:revision-history>
+  </t:info>
+  <t:description xmlns="http://www.w3.org/1999/xhtml">
+    <p>Tests that a variable defined as a function can be evaluated later on.</p>
+  </t:description>
+<t:pipeline>
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                xmlns:ex="https://xmlcalabash.com/ns/examples"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:cx="http://xmlcalabash.com/ns/extensions"
+                exclude-inline-prefixes="ex xs cx"
+                name="main"
+                version="3.0">
+  <p:import href="https://xmlcalabash.com/ext/library/pipeline-messages.xpl"/>
+  <p:output port="result"/>
+
+  <p:variable name="ex:document-info" as="function(*)" 
+              select="function($d as item()) as xs:string
+                      { p:document-property($d, 'content-type')
+                        || ' at ' || p:document-property($d, 'base-uri') }"/>
+
+  <p:identity>
+    <p:with-input><doc/></p:with-input>
+  </p:identity>
+
+  <p:identity name="id" message="Seeing { $ex:document-info(.) }"/>
+
+  <cx:pipeline-messages p:depends="id" level="info" clear="true"/>
+</p:declare-step>
+</t:pipeline>
+  <t:schematron>
+    <s:schema queryBinding="xslt2"
+              xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:ns prefix="cx" uri="http://xmlcalabash.com/ns/extensions"/>
+      <s:pattern>
+        <s:rule context="/">
+          <s:assert test="cx:messages">The document root is not correct.</s:assert>
+        </s:rule>
+      </s:pattern>
+      <s:pattern>
+        <s:rule context="/cx:messages">
+          <s:assert test="cx:message[@level='INFO' and contains(@message, 'Seeing application/xml')]"
+                    >Did not find user message.</s:assert>
+        </s:rule>
+      </s:pattern>
+    </s:schema>
+  </t:schematron>
+</t:test>

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/graph/Model.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/graph/Model.kt
@@ -4,7 +4,8 @@ import com.xmlcalabash.datamodel.StepDeclaration
 import net.sf.saxon.s9api.QName
 
 abstract class Model(val graph: Graph, val parent: Model?, val step: StepDeclaration, val id: String) {
-    internal val saxonConfig = step.stepConfig.saxonConfig.newConfiguration(graph.environment)
+    // Issue #160, don't create a new Saxon configuration here
+    internal val saxonConfig = step.stepConfig.saxonConfig
     internal val inputs = mutableMapOf<String, ModelPort>()
     internal val outputs = mutableMapOf<String, ModelPort>()
     internal val options = mutableMapOf<QName, ModelOption>()

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/XProcRuntime.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/XProcRuntime.kt
@@ -39,7 +39,8 @@ class XProcRuntime private constructor(internal val start: DeclareStepInstructio
     val environment = config.environment
 
     fun stepConfiguration(instructionConfig: InstructionConfiguration): XProcStepConfiguration {
-        val impl = XProcStepConfigurationImpl(config.environment, instructionConfig.saxonConfig.newConfiguration(), instructionConfig.location)
+        // Issue #160, don't create a new Saxon configuration here
+        val impl = XProcStepConfigurationImpl(config.environment, instructionConfig.saxonConfig, instructionConfig.location)
         impl.putAllNamespaces(instructionConfig.inscopeNamespaces)
         impl.putAllStepTypes(instructionConfig.inscopeStepTypes)
         impl.stepName = instructionConfig.stepName

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/BufferingMessageReporter.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/BufferingMessageReporter.kt
@@ -33,7 +33,12 @@ class BufferingMessageReporter(val maxsize: Int, nextReporter: MessageReporter):
         }
     }
 
-    class Message(val level: Verbosity, extra: Map<QName, String>, val message: () -> String) {
+    class Message(val level: Verbosity, extra: Map<QName, String>, val messageFunction: () -> String) {
+        val message = try {
+            messageFunction()
+        } catch (ex: Exception) {
+            "(Attempting to evaluate message raised error: ${ex})"
+        }
         val attributes = mutableMapOf<QName, String>()
         val timestamp = LocalDateTime.now()
         init {


### PR DESCRIPTION
The code was over-zealous when constructing step configurations. It created a new Saxon Configuration for every step. That’s not necessary; it’s only necessary that each p:library and p:declare-step (and their descndants) have a new configuration. Configurations are required at that level because any use of p:import-functions has to be isolated.

Fix #160 