### PR TITLE
Support casting to/from text/x-java-properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ saxonVersion=12.5
 xmlResolverVersion=6.0.11
 
 xmlcalabashGroup=com.xmlcalabash
-xmlcalabashVersion=3.0.0-alpha17
+xmlcalabashVersion=3.0.0-alpha18-SNAPSHOT
 // name is defined in settings.gradle.kts
 
 builtBy=Norm Tovey-Walsh

--- a/tests/extra-suite/test-suite/tests/issue-160-001.xml
+++ b/tests/extra-suite/test-suite/tests/issue-160-001.xml
@@ -2,8 +2,17 @@
 <t:test expected="pass"
         xmlns:t="http://xproc.org/ns/testsuite/3.0">
   <t:info>
-    <t:title>issue-160--001</t:title>
+    <t:title>issue-160-001</t:title>
     <t:revision-history>
+      <t:revision>
+        <t:date>2025-01-20</t:date>
+        <t:author>
+          <t:name>Norm Tovey-Walsh</t:name>
+        </t:author>
+        <t:description xmlns="http://www.w3.org/1999/xhtml">
+          <p>Fixed typo in the test title.</p>
+        </t:description>
+      </t:revision>
       <t:revision>
         <t:date>2025-01-19</t:date>
         <t:author>

--- a/tests/extra-suite/test-suite/tests/java-properties-001.xml
+++ b/tests/extra-suite/test-suite/tests/java-properties-001.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+  <t:info>
+    <t:title>java-properties-001</t:title>
+    <t:revision-history>
+      <t:revision>
+        <t:date>2025-01-20</t:date>
+        <t:author>
+          <t:name>Norm Tovey-Walsh</t:name>
+        </t:author>
+        <t:description xmlns="http://www.w3.org/1999/xhtml">
+          <p>Created test.</p>
+        </t:description>
+      </t:revision>
+    </t:revision-history>
+  </t:info>
+  <t:description xmlns="http://www.w3.org/1999/xhtml">
+    <p>Tests that a Java properties file can be cast to XML.</p>
+  </t:description>
+<t:pipeline>
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                xmlns:ex="https://xmlcalabash.com/ns/examples"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:cx="http://xmlcalabash.com/ns/extensions"
+                exclude-inline-prefixes="ex xs cx"
+                name="main"
+                version="3.0">
+  <p:output port="result"/>
+
+  <p:cast-content-type content-type="application/xml">
+    <p:with-input>
+      <p:inline content-type="text/x-java-properties"
+># With a comment.
+version=1.0
+name=TestApp
+date=2016-11-12</p:inline>
+    </p:with-input>
+  </p:cast-content-type>
+
+</p:declare-step>
+</t:pipeline>
+  <t:schematron>
+    <s:schema queryBinding="xslt2"
+              xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:pattern>
+        <s:rule context="/">
+          <s:assert test="properties">The document root is not correct.</s:assert>
+        </s:rule>
+      </s:pattern>
+      <s:pattern>
+        <s:rule context="/properties">
+          <s:assert test="count(comment) = 1">Wrong number of comments.</s:assert>
+          <s:assert test="contains(comment, 'With a comment.')">Comment is wrong.</s:assert>
+          <s:assert test="count(entry) = 3">Wrong number of entries.</s:assert>
+          <s:assert test="entry[@key='version'] = '1.0'">Version is wrong.</s:assert>
+          <s:assert test="entry[@key='name'] = 'TestApp'">Name is wrong.</s:assert>
+          <s:assert test="entry[@key='date'] = '2016-11-12'">Date is wrong.</s:assert>
+        </s:rule>
+      </s:pattern>
+    </s:schema>
+  </t:schematron>
+</t:test>

--- a/tests/extra-suite/test-suite/tests/java-properties-002.xml
+++ b/tests/extra-suite/test-suite/tests/java-properties-002.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+  <t:info>
+    <t:title>java-properties-002</t:title>
+    <t:revision-history>
+      <t:revision>
+        <t:date>2025-01-20</t:date>
+        <t:author>
+          <t:name>Norm Tovey-Walsh</t:name>
+        </t:author>
+        <t:description xmlns="http://www.w3.org/1999/xhtml">
+          <p>Created test.</p>
+        </t:description>
+      </t:revision>
+    </t:revision-history>
+  </t:info>
+  <t:description xmlns="http://www.w3.org/1999/xhtml">
+    <p>Tests that a Java properties file can be cast to JSON.</p>
+  </t:description>
+<t:pipeline>
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                xmlns:ex="https://xmlcalabash.com/ns/examples"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:cx="http://xmlcalabash.com/ns/extensions"
+                exclude-inline-prefixes="ex xs cx"
+                name="main"
+                version="3.0">
+  <p:output port="result"/>
+
+  <p:cast-content-type content-type="application/json">
+    <p:with-input>
+      <p:inline content-type="text/x-java-properties"
+># With a comment.
+version=1.0
+name=TestApp
+date=2016-11-12</p:inline>
+    </p:with-input>
+  </p:cast-content-type>
+
+  <p:cast-content-type content-type="application/xml"/>
+
+</p:declare-step>
+</t:pipeline>
+  <t:schematron>
+    <s:schema queryBinding="xslt2"
+              xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:ns prefix="fn" uri="http://www.w3.org/2005/xpath-functions"/>
+      <s:pattern>
+        <s:rule context="/">
+          <s:assert test="fn:map">The document root is not correct.</s:assert>
+        </s:rule>
+      </s:pattern>
+      <s:pattern>
+        <s:rule context="/fn:map">
+          <s:assert test="count(fn:string) = 3">Wrong number of entries.</s:assert>
+          <s:assert test="fn:string[@key='version'] = '1.0'">Version is wrong.</s:assert>
+          <s:assert test="fn:string[@key='name'] = 'TestApp'">Name is wrong.</s:assert>
+          <s:assert test="fn:string[@key='date'] = '2016-11-12'">Date is wrong.</s:assert>
+        </s:rule>
+      </s:pattern>
+    </s:schema>
+  </t:schematron>
+</t:test>

--- a/tests/extra-suite/test-suite/tests/java-properties-003.xml
+++ b/tests/extra-suite/test-suite/tests/java-properties-003.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="fail" code="cxerr:XC0001"
+        xmlns:cxerr="http://xmlcalabash.com/ns/error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+  <t:info>
+    <t:title>java-properties-003</t:title>
+    <t:revision-history>
+      <t:revision>
+        <t:date>2025-01-20</t:date>
+        <t:author>
+          <t:name>Norm Tovey-Walsh</t:name>
+        </t:author>
+        <t:description xmlns="http://www.w3.org/1999/xhtml">
+          <p>Created test.</p>
+        </t:description>
+      </t:revision>
+    </t:revision-history>
+  </t:info>
+  <t:description xmlns="http://www.w3.org/1999/xhtml">
+    <p>Tests that a Java properties file can not be cast to XHTML.</p>
+  </t:description>
+<t:pipeline>
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                xmlns:ex="https://xmlcalabash.com/ns/examples"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:cx="http://xmlcalabash.com/ns/extensions"
+                exclude-inline-prefixes="ex xs cx"
+                name="main"
+                version="3.0">
+  <p:output port="result"/>
+
+  <p:cast-content-type content-type="application/xhtml+xml">
+    <p:with-input>
+      <p:inline content-type="text/x-java-properties"
+># With a comment.
+version=1.0
+name=TestApp
+date=2016-11-12</p:inline>
+    </p:with-input>
+  </p:cast-content-type>
+</p:declare-step>
+</t:pipeline>
+</t:test>

--- a/tests/extra-suite/test-suite/tests/java-properties-004.xml
+++ b/tests/extra-suite/test-suite/tests/java-properties-004.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="fail" code="cxerr:XC0001"
+        xmlns:cxerr="http://xmlcalabash.com/ns/error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+  <t:info>
+    <t:title>java-properties-004</t:title>
+    <t:revision-history>
+      <t:revision>
+        <t:date>2025-01-20</t:date>
+        <t:author>
+          <t:name>Norm Tovey-Walsh</t:name>
+        </t:author>
+        <t:description xmlns="http://www.w3.org/1999/xhtml">
+          <p>Created test.</p>
+        </t:description>
+      </t:revision>
+    </t:revision-history>
+  </t:info>
+  <t:description xmlns="http://www.w3.org/1999/xhtml">
+    <p>Tests that a Java properties file can not be cast to HTML.</p>
+  </t:description>
+<t:pipeline>
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                xmlns:ex="https://xmlcalabash.com/ns/examples"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:cx="http://xmlcalabash.com/ns/extensions"
+                exclude-inline-prefixes="ex xs cx"
+                name="main"
+                version="3.0">
+  <p:output port="result"/>
+
+  <p:cast-content-type content-type="text/html">
+    <p:with-input>
+      <p:inline content-type="text/x-java-properties"
+># With a comment.
+version=1.0
+name=TestApp
+date=2016-11-12</p:inline>
+    </p:with-input>
+  </p:cast-content-type>
+</p:declare-step>
+</t:pipeline>
+</t:test>

--- a/tests/extra-suite/test-suite/tests/java-properties-005.xml
+++ b/tests/extra-suite/test-suite/tests/java-properties-005.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="fail" code="cxerr:XC0001"
+        xmlns:cxerr="http://xmlcalabash.com/ns/error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+  <t:info>
+    <t:title>java-properties-005</t:title>
+    <t:revision-history>
+      <t:revision>
+        <t:date>2025-01-20</t:date>
+        <t:author>
+          <t:name>Norm Tovey-Walsh</t:name>
+        </t:author>
+        <t:description xmlns="http://www.w3.org/1999/xhtml">
+          <p>Created test.</p>
+        </t:description>
+      </t:revision>
+    </t:revision-history>
+  </t:info>
+  <t:description xmlns="http://www.w3.org/1999/xhtml">
+    <p>Tests that a Java properties file can not be cast to binary.</p>
+  </t:description>
+<t:pipeline>
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                xmlns:ex="https://xmlcalabash.com/ns/examples"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:cx="http://xmlcalabash.com/ns/extensions"
+                exclude-inline-prefixes="ex xs cx"
+                name="main"
+                version="3.0">
+  <p:output port="result"/>
+
+  <p:cast-content-type content-type="application/octet-stream">
+    <p:with-input>
+      <p:inline content-type="text/x-java-properties"
+># With a comment.
+version=1.0
+name=TestApp
+date=2016-11-12</p:inline>
+    </p:with-input>
+  </p:cast-content-type>
+</p:declare-step>
+</t:pipeline>
+</t:test>

--- a/tests/extra-suite/test-suite/tests/java-properties-006.xml
+++ b/tests/extra-suite/test-suite/tests/java-properties-006.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="fail" code="cxerr:XC0001"
+        xmlns:cxerr="http://xmlcalabash.com/ns/error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+  <t:info>
+    <t:title>java-properties-006</t:title>
+    <t:revision-history>
+      <t:revision>
+        <t:date>2025-01-20</t:date>
+        <t:author>
+          <t:name>Norm Tovey-Walsh</t:name>
+        </t:author>
+        <t:description xmlns="http://www.w3.org/1999/xhtml">
+          <p>Created test.</p>
+        </t:description>
+      </t:revision>
+    </t:revision-history>
+  </t:info>
+  <t:description xmlns="http://www.w3.org/1999/xhtml">
+    <p>Tests that a Java properties file can not be cast to image/jpeg.</p>
+  </t:description>
+<t:pipeline>
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                xmlns:ex="https://xmlcalabash.com/ns/examples"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:cx="http://xmlcalabash.com/ns/extensions"
+                exclude-inline-prefixes="ex xs cx"
+                name="main"
+                version="3.0">
+  <p:output port="result"/>
+
+  <p:cast-content-type content-type="image/jpeg">
+    <p:with-input>
+      <p:inline content-type="text/x-java-properties"
+># With a comment.
+version=1.0
+name=TestApp
+date=2016-11-12</p:inline>
+    </p:with-input>
+  </p:cast-content-type>
+</p:declare-step>
+</t:pipeline>
+</t:test>

--- a/tests/extra-suite/test-suite/tests/java-properties-007.xml
+++ b/tests/extra-suite/test-suite/tests/java-properties-007.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+  <t:info>
+    <t:title>java-properties-007</t:title>
+    <t:revision-history>
+      <t:revision>
+        <t:date>2025-01-20</t:date>
+        <t:author>
+          <t:name>Norm Tovey-Walsh</t:name>
+        </t:author>
+        <t:description xmlns="http://www.w3.org/1999/xhtml">
+          <p>Created test.</p>
+        </t:description>
+      </t:revision>
+    </t:revision-history>
+  </t:info>
+  <t:description xmlns="http://www.w3.org/1999/xhtml">
+    <p>Tests that a Java properties file can be cast to YAML (same as JSON).</p>
+  </t:description>
+<t:pipeline>
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                xmlns:ex="https://xmlcalabash.com/ns/examples"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:cx="http://xmlcalabash.com/ns/extensions"
+                exclude-inline-prefixes="ex xs cx"
+                name="main"
+                version="3.0">
+  <p:output port="result"/>
+
+  <p:cast-content-type content-type="application/x-yaml">
+    <p:with-input>
+      <p:inline content-type="text/x-java-properties"
+># With a comment.
+version=1.0
+name=TestApp
+date=2016-11-12</p:inline>
+    </p:with-input>
+  </p:cast-content-type>
+
+  <p:cast-content-type content-type="application/xml"/>
+
+</p:declare-step>
+</t:pipeline>
+  <t:schematron>
+    <s:schema queryBinding="xslt2"
+              xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:ns prefix="fn" uri="http://www.w3.org/2005/xpath-functions"/>
+      <s:pattern>
+        <s:rule context="/">
+          <s:assert test="fn:map">The document root is not correct.</s:assert>
+        </s:rule>
+      </s:pattern>
+      <s:pattern>
+        <s:rule context="/fn:map">
+          <s:assert test="count(fn:string) = 3">Wrong number of entries.</s:assert>
+          <s:assert test="fn:string[@key='version'] = '1.0'">Version is wrong.</s:assert>
+          <s:assert test="fn:string[@key='name'] = 'TestApp'">Name is wrong.</s:assert>
+          <s:assert test="fn:string[@key='date'] = '2016-11-12'">Date is wrong.</s:assert>
+        </s:rule>
+      </s:pattern>
+    </s:schema>
+  </t:schematron>
+</t:test>

--- a/tests/extra-suite/test-suite/tests/java-properties-008.xml
+++ b/tests/extra-suite/test-suite/tests/java-properties-008.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+  <t:info>
+    <t:title>java-properties-008</t:title>
+    <t:revision-history>
+      <t:revision>
+        <t:date>2025-01-20</t:date>
+        <t:author>
+          <t:name>Norm Tovey-Walsh</t:name>
+        </t:author>
+        <t:description xmlns="http://www.w3.org/1999/xhtml">
+          <p>Created test.</p>
+        </t:description>
+      </t:revision>
+    </t:revision-history>
+  </t:info>
+  <t:description xmlns="http://www.w3.org/1999/xhtml">
+    <p>Tests that XML can be cast to Java properties.</p>
+  </t:description>
+<t:pipeline>
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                xmlns:ex="https://xmlcalabash.com/ns/examples"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:cx="http://xmlcalabash.com/ns/extensions"
+                exclude-inline-prefixes="ex xs cx"
+                name="main"
+                version="3.0">
+  <p:output port="result"/>
+
+  <p:cast-content-type content-type="text/x-java-properties">
+    <p:with-input>
+      <properties>
+        <comment> Hello, world.</comment>
+        <entry key="first">One</entry>
+        <entry key="second">One</entry>
+        <entry key="second">Two</entry>
+        <entry key="three">“Several”
+lines‽</entry>
+      </properties>
+    </p:with-input>
+  </p:cast-content-type>
+
+  <p:wrap-sequence wrapper="props"/>
+
+</p:declare-step>
+</t:pipeline>
+  <t:schematron>
+    <s:schema queryBinding="xslt2"
+              xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:pattern>
+        <s:rule context="/">
+          <s:assert test="props">The document root is not correct.</s:assert>
+        </s:rule>
+      </s:pattern>
+      <s:pattern>
+        <s:rule context="/props">
+          <s:assert test="contains(., '# Hello, world')">Comment is missing.</s:assert>
+          <s:assert test="contains(., '&#10;first=One&#10;')">first is missing.</s:assert>
+          <s:assert test="contains(., '&#10;second=Two&#10;')">second is missing.</s:assert>
+          <s:assert test="contains(., '&#10;three=\u201CSeveral\u201D\nlines\u203D&#10;')"
+                    >third is missing.</s:assert>
+        </s:rule>
+      </s:pattern>
+    </s:schema>
+  </t:schematron>
+</t:test>

--- a/tests/extra-suite/test-suite/tests/java-properties-009.xml
+++ b/tests/extra-suite/test-suite/tests/java-properties-009.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+  <t:info>
+    <t:title>java-properties-009</t:title>
+    <t:revision-history>
+      <t:revision>
+        <t:date>2025-01-20</t:date>
+        <t:author>
+          <t:name>Norm Tovey-Walsh</t:name>
+        </t:author>
+        <t:description xmlns="http://www.w3.org/1999/xhtml">
+          <p>Created test.</p>
+        </t:description>
+      </t:revision>
+    </t:revision-history>
+  </t:info>
+  <t:description xmlns="http://www.w3.org/1999/xhtml">
+    <p>Tests that a map can be cast to Java properties.</p>
+  </t:description>
+<t:pipeline>
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                xmlns:ex="https://xmlcalabash.com/ns/examples"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:cx="http://xmlcalabash.com/ns/extensions"
+                exclude-inline-prefixes="ex xs cx"
+                name="main"
+                version="3.0">
+  <p:output port="result"/>
+
+  <p:cast-content-type content-type="text/x-java-properties">
+    <p:with-input expand-text="false">
+      <p:inline content-type="application/json">
+        { "first": "One",
+          "second": "Two",
+          "third": null,
+          "fourth": 3.14 }</p:inline>
+    </p:with-input>
+  </p:cast-content-type>
+
+  <p:wrap-sequence wrapper="props"/>
+
+</p:declare-step>
+</t:pipeline>
+  <t:schematron>
+    <s:schema queryBinding="xslt2"
+              xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:pattern>
+        <s:rule context="/">
+          <s:assert test="props">The document root is not correct.</s:assert>
+        </s:rule>
+      </s:pattern>
+      <s:pattern>
+        <s:rule context="/props">
+          <s:assert test="contains(., 'first=One&#10;')">first is missing.</s:assert>
+          <s:assert test="contains(., 'second=Two&#10;')">second is missing.</s:assert>
+          <s:assert test="contains(., 'third=&#10;')">third is missing.</s:assert>
+          <s:assert test="contains(., 'fourth=3.14&#10;')">fourth is missing.</s:assert>
+        </s:rule>
+      </s:pattern>
+    </s:schema>
+  </t:schematron>
+</t:test>

--- a/tests/extra-suite/test-suite/tests/java-properties-010.xml
+++ b/tests/extra-suite/test-suite/tests/java-properties-010.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test  expected="fail" code="cxerr:XC0001"
+        xmlns:cxerr="http://xmlcalabash.com/ns/error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+  <t:info>
+    <t:title>java-properties-010</t:title>
+    <t:revision-history>
+      <t:revision>
+        <t:date>2025-01-20</t:date>
+        <t:author>
+          <t:name>Norm Tovey-Walsh</t:name>
+        </t:author>
+        <t:description xmlns="http://www.w3.org/1999/xhtml">
+          <p>Created test.</p>
+        </t:description>
+      </t:revision>
+    </t:revision-history>
+  </t:info>
+  <t:description xmlns="http://www.w3.org/1999/xhtml">
+    <p>Tests that an atomic cannot be cast to Java properties.</p>
+  </t:description>
+<t:pipeline>
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                xmlns:ex="https://xmlcalabash.com/ns/examples"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:cx="http://xmlcalabash.com/ns/extensions"
+                exclude-inline-prefixes="ex xs cx"
+                name="main"
+                version="3.0">
+  <p:output port="result"/>
+
+  <p:cast-content-type content-type="text/x-java-properties">
+    <p:with-input expand-text="false">
+      <p:inline content-type="application/json">17</p:inline>
+    </p:with-input>
+  </p:cast-content-type>
+</p:declare-step>
+</t:pipeline>
+</t:test>

--- a/tests/extra-suite/test-suite/tests/java-properties-011.xml
+++ b/tests/extra-suite/test-suite/tests/java-properties-011.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test  expected="fail" code="cxerr:XC0001"
+        xmlns:cxerr="http://xmlcalabash.com/ns/error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+  <t:info>
+    <t:title>java-properties-011</t:title>
+    <t:revision-history>
+      <t:revision>
+        <t:date>2025-01-20</t:date>
+        <t:author>
+          <t:name>Norm Tovey-Walsh</t:name>
+        </t:author>
+        <t:description xmlns="http://www.w3.org/1999/xhtml">
+          <p>Created test.</p>
+        </t:description>
+      </t:revision>
+    </t:revision-history>
+  </t:info>
+  <t:description xmlns="http://www.w3.org/1999/xhtml">
+    <p>Tests that an atomic cannot be cast to Java properties.</p>
+  </t:description>
+<t:pipeline>
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                xmlns:ex="https://xmlcalabash.com/ns/examples"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:cx="http://xmlcalabash.com/ns/extensions"
+                exclude-inline-prefixes="ex xs cx"
+                name="main"
+                version="3.0">
+  <p:output port="result"/>
+
+  <p:cast-content-type content-type="text/x-java-properties">
+    <p:with-input expand-text="false">
+      <p:inline content-type="application/json">[1,2,3]</p:inline>
+    </p:with-input>
+  </p:cast-content-type>
+</p:declare-step>
+</t:pipeline>
+</t:test>

--- a/tests/extra-suite/test-suite/tests/java-properties-012.xml
+++ b/tests/extra-suite/test-suite/tests/java-properties-012.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test  expected="fail" code="cxerr:XC0001"
+        xmlns:cxerr="http://xmlcalabash.com/ns/error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+  <t:info>
+    <t:title>java-properties-012</t:title>
+    <t:revision-history>
+      <t:revision>
+        <t:date>2025-01-20</t:date>
+        <t:author>
+          <t:name>Norm Tovey-Walsh</t:name>
+        </t:author>
+        <t:description xmlns="http://www.w3.org/1999/xhtml">
+          <p>Created test.</p>
+        </t:description>
+      </t:revision>
+    </t:revision-history>
+  </t:info>
+  <t:description xmlns="http://www.w3.org/1999/xhtml">
+    <p>Tests that an atomic cannot be cast to Java properties.</p>
+  </t:description>
+<t:pipeline>
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                xmlns:ex="https://xmlcalabash.com/ns/examples"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:cx="http://xmlcalabash.com/ns/extensions"
+                exclude-inline-prefixes="ex xs cx"
+                name="main"
+                version="3.0">
+  <p:output port="result"/>
+
+  <p:cast-content-type content-type="text/x-java-properties">
+    <p:with-input>
+      <p:inline content-type="application/xhtml+xml"><body/></p:inline>
+    </p:with-input>
+  </p:cast-content-type>
+</p:declare-step>
+</t:pipeline>
+</t:test>

--- a/tests/extra-suite/test-suite/tests/java-properties-013.xml
+++ b/tests/extra-suite/test-suite/tests/java-properties-013.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test  expected="fail" code="cxerr:XC0001"
+        xmlns:cxerr="http://xmlcalabash.com/ns/error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+  <t:info>
+    <t:title>java-properties-013</t:title>
+    <t:revision-history>
+      <t:revision>
+        <t:date>2025-01-20</t:date>
+        <t:author>
+          <t:name>Norm Tovey-Walsh</t:name>
+        </t:author>
+        <t:description xmlns="http://www.w3.org/1999/xhtml">
+          <p>Created test.</p>
+        </t:description>
+      </t:revision>
+    </t:revision-history>
+  </t:info>
+  <t:description xmlns="http://www.w3.org/1999/xhtml">
+    <p>Tests that an atomic cannot be cast to Java properties.</p>
+  </t:description>
+<t:pipeline>
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                xmlns:ex="https://xmlcalabash.com/ns/examples"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:cx="http://xmlcalabash.com/ns/extensions"
+                exclude-inline-prefixes="ex xs cx"
+                name="main"
+                version="3.0">
+  <p:output port="result"/>
+
+  <p:cast-content-type content-type="text/x-java-properties">
+    <p:with-input>
+      <p:inline content-type="text/html"><body/></p:inline>
+    </p:with-input>
+  </p:cast-content-type>
+</p:declare-step>
+</t:pipeline>
+</t:test>

--- a/tests/extra-suite/test-suite/tests/java-properties-014.xml
+++ b/tests/extra-suite/test-suite/tests/java-properties-014.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test  expected="fail" code="cxerr:XC0001"
+        xmlns:cxerr="http://xmlcalabash.com/ns/error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+  <t:info>
+    <t:title>java-properties-013</t:title>
+    <t:revision-history>
+      <t:revision>
+        <t:date>2025-01-20</t:date>
+        <t:author>
+          <t:name>Norm Tovey-Walsh</t:name>
+        </t:author>
+        <t:description xmlns="http://www.w3.org/1999/xhtml">
+          <p>Created test.</p>
+        </t:description>
+      </t:revision>
+    </t:revision-history>
+  </t:info>
+  <t:description xmlns="http://www.w3.org/1999/xhtml">
+    <p>Tests that an atomic cannot be cast to Java properties.</p>
+  </t:description>
+<t:pipeline>
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                xmlns:ex="https://xmlcalabash.com/ns/examples"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:cx="http://xmlcalabash.com/ns/extensions"
+                exclude-inline-prefixes="ex xs cx"
+                name="main"
+                version="3.0">
+  <p:output port="result"/>
+
+  <p:cast-content-type content-type="text/x-java-properties">
+    <p:with-input>
+      <p:inline encoding="base64" content-type="application/octet-stream">U1BPT04K</p:inline>
+    </p:with-input>
+  </p:cast-content-type>
+</p:declare-step>
+</t:pipeline>
+</t:test>

--- a/tests/extra-suite/test-suite/tests/java-properties-015.xml
+++ b/tests/extra-suite/test-suite/tests/java-properties-015.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test  expected="fail" code="cxerr:XC0001"
+        xmlns:cxerr="http://xmlcalabash.com/ns/error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+  <t:info>
+    <t:title>java-properties-013</t:title>
+    <t:revision-history>
+      <t:revision>
+        <t:date>2025-01-20</t:date>
+        <t:author>
+          <t:name>Norm Tovey-Walsh</t:name>
+        </t:author>
+        <t:description xmlns="http://www.w3.org/1999/xhtml">
+          <p>Created test.</p>
+        </t:description>
+      </t:revision>
+    </t:revision-history>
+  </t:info>
+  <t:description xmlns="http://www.w3.org/1999/xhtml">
+    <p>Tests that an atomic cannot be cast to Java properties.</p>
+  </t:description>
+<t:pipeline>
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                xmlns:ex="https://xmlcalabash.com/ns/examples"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:cx="http://xmlcalabash.com/ns/extensions"
+                exclude-inline-prefixes="ex xs cx"
+                name="main"
+                version="3.0">
+  <p:output port="result"/>
+
+  <p:cast-content-type content-type="text/x-java-properties">
+    <p:with-input>
+      <p:inline encoding="base64" content-type="image/gif">R0lGODlhMAAxAPcAAP///wAAAP7+/v39/fz8/Pv7+/r6+vn5+fj4+Pf39/b29vX19fT09PPz8/Ly8vHx
+8fDw8O/v7+7u7u3t7ezs7Ovr6+rq6unp6ejo6Ofn5+bm5uXl5eTk5OPj4+Li4uHh4eDg4N/f397e3t3d
+3dzc3Nvb29ra2tnZ2djY2NfX19bW1tXV1dTU1NPT09HR0dDQ0M/Pz87Ozs3NzczMzMvLy8rKysnJycjI
+yMfHx8bGxsXFxcTExMPDw8LCwsHBwcDAwL+/v76+vr29vbu7u7q6urm5ubi4uLe3t7a2trW1tbS0tLOz
+s7KysrGxsbCwsK+vr66urq2traysrKurq6qqqqmpqaioqKenp6ampqWlpaSkpKOjo6GhoaCgoJ+fn56e
+np2dnZycnJubm5qampmZmZiYmJeXl5WVlZSUlJKSkpGRkZCQkI+Pj46Ojo2NjYyMjIuLi4qKiomJiYiI
+iIaGhoSEhIODg4KCgoGBgX9/f35+fn19fXx8fHt7e3p6enl5eXh4eHd3d3Z2dnV1dXR0dHNzc3JycnFx
+cXBwcG9vb25ubm1tbWxsbGtra2pqamlpaWhoaGdnZ2ZmZmVlZWRkZGNjY2JiYmFhYWBgYF9fX15eXlxc
+XFtbW1paWllZWVhYWFdXV1ZWVlVVVVRUVFNTU1JSUlFRUVBQUE9PT05OTk1NTUxMTEtLS0pKSklJSUhI
+SEdHR0ZGRkVFRURERENDQ0JCQkFBQUBAQD8/Pz4+Pj09PTw8PDs7Ozo6Ojk5OTg4ODc3NzY2NjU1NTQ0
+NDMzMzIyMjExMTAwMC8vLy4uLi0tLSwsLCsrKyoqKikpKSgoKCcnJyYmJiUlJSQkJCMjIyIiIiEhISAg
+IB8fHx4eHh0dHRwcHBsbGxoaGhgYGBcXFxYWFhUVFRQUFBMTExISEhERERAQEA8PDw4ODg0NDQwMDAsL
+CwoKCgkJCQgICAcHBwYGBgUFBQQEBAMDAwICAgEBAf///wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+ACH5BAUAAPYALAAAAAAwADEAAAj/AO0JHEiwYEEIM7xYSSFAgA5I0jbJoCBHFKAvJwxq3KhRgSBSIGiE
+W4Yp1DIfjM7VenUrVx0yvCY54EizoAMrl2x9AABARzVTtP7wFAZN06IFPAEgQkehZk0Tu4wZ2wWhjDUA
+j5gd81EAgA9typYAOOQHwIdzqKAAIeDUoAVpPHvBs4GgCQBbzhYBAFT21zoUAMwFCLWpFq1d3FIJaEvw
+kiEVNwQEIJS0wCpqAOZ8AvAnQBmeiaJFYtWqQIFpmxifEOQpkqEf6bDokAUAyqYTKJhRAGAAgBd3ytDw
+VCTMmBQAFIJVK+MUhLRqqwapEtLEBwAuEX4EUATAjYikMrjx/zIGiec4UDwLsTP0iUhNM0kIwXOkiwyA
+EC4eoDigIwGAPRSEMMoJABBjCiHZ4ACAK0YAgEM6k5RiSioq0CRGFgCk4s0ogABgRgArJLHbA4Eg42EA
+GNZhlhMAzNAGT2iYA8kvKJQQyUYChNEMLhAAYI01pNiARTy3DEOIEpgk40ojs+DiySGxdJBUGTYkdUMo
+VgDQgi8bYbEKLgHQAsATiOy1zRk1eNJNNIJswYQPG9jzgiXC3CKGColwR8EiBDYgAACV3LIRLC8IUMU1
+jvCEQB2dWCAQBjNpVIAMkmCzDgwAlBHAMyvwhEUAfmgkQCxMiNEFAEWgQMEhuDTBmEAzcP/CUy4BnMJT
+CMuck4VGKERzSA4b9JaBMdt08epAUexARgCP8IQDOAHAkoBBCZxiyyo0AIDLLa5g88KxAxFASwB28LSF
+OerkgoBGPLxghS+SdMDIMDwoAC5BCqjixweTBKCLKOtqpIULcQRQBRLciHGvQQe0oYs61qgRsEYVCLKB
+Hh76MsDCG0HQgFMxMALAD5lszDHHBUBwRCBqnMyRBUFkcYcgstBREAKhHGOHI7iY4DJBAuTASjsBwLPM
+KbfYTFACceQgRQyghPGzQDd8E8A5acRJkxCGvLFGIiVMbUQAAcRBEwQyDIEDEoy4AQggOuxwgsn3YuFM
+AE4QhMAAEUD/McAAa8SBQwQAOBACBxkwwJMDSHgxMWM6JDNZQSMYccQcPUCBhQ0qjADCBDwVIMEKOfxg
+hBlgHHtCMc68s0BBBzAgQAMl5IFCBgQkBUABCzAQAQg1UJHIIK8SkEklAShhkAQycNADA0Ec4kUYVeQg
+Qgw33JBEE0GI8UgpErzKRh/TWLNYQRYAoYIQGNjzADG6uGIJMfOsQ045AXiDii/TMmaCJWsIQA4MAoAG
+bCAEBRgIICTRBU6QLQD0qEc90nGLIhyLE1pghzTORxAG6MAeITDCQJQgCj68IwDrIBvRxjGLDrzqC38o
+RABcpREGrGAEMRgIBkLhiQCgIx1XQ0cA/6zxiQkwZgKy2EL+DGAQATTBUSNg4kD6EIp4oGMd8HCHPIY4
+igswJhFjYEUAoKAREIChBAogAlsGMoVQPMOHWyRbNkZRgbbQABJXCAA3DiCpjakhCAWRQChKEQB2BKAe
+ZBOHKl5XEwKg4gnbSF5NMvCxgpTBE+eARzwO6UNdQMApYmhDZ/a4EQJsjCcGQQEoxuUOTqZjFUakiQQM
+8QWy5c0gEIAAAUAAAI4IYhLqIBsi15GKD9QkDFxARQBUsUaCGAAG3wqCCzeCAlbQCh4PfMYMOAIBU6gi
+FAHIhs8K8gARICAKRpBDAjlih16kgx7zIBs41sARD3RjFq00FkE2xv8BFtgDBqYIG00eAAxjBCCO8nhG
++zTiiUJkwh3h8IJAILAYCYgBATtYAwwYAwRfGJQeZGOHJhhgEEwIogG9SAY0AOk+e2AABTSQAwnG8EnG
+uIEWyyAbPejxjmJIQQMKWAAPapEKEPAiANgQgj0KkIADqKABlHAIHu41CExIg2zzoIc61sGObHCDHucI
+RE7dAQeBJEALAICDB54AhKUuDA+r0AYiD/kOdKhDHvNghyGv0YaBCGAHVzCBE0TASI7pYBXeiGM81JEO
+drRDgt7YAkEsAAJCPOAAhT3ZAsgAjHXUQx71gCfZkuECghAAAikIwdQKQoAdLCIa3diGN1IRBLoICWQA
+zWRMQAAAOw==</p:inline>
+    </p:with-input>
+  </p:cast-content-type>
+</p:declare-step>
+</t:pipeline>
+</t:test>

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/XProcError.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/XProcError.kt
@@ -28,6 +28,10 @@ open class XProcError protected constructor(val code: QName, val variant: Int, v
             return NsErr.xi(code)
         }
 
+        private fun xstepError(code: Int): QName {
+            return NsErr.xxc(code)
+        }
+
         private fun static(code: Pair<Int, Int>, vararg details: Any): XProcError {
             val ecode = staticError(code.first)
             return XProcError(ecode, code.second, Location.NULL, Location.NULL, *details)
@@ -55,6 +59,13 @@ open class XProcError protected constructor(val code: QName, val variant: Int, v
         }
 
         fun internal(code: Int, vararg details: Any): XProcError = internal(Pair(code, 1), *details)
+
+        private fun xstep(code: Pair<Int,Int>, vararg details: Any): XProcError {
+            val ecode = xstepError(code.first)
+            return XProcError(ecode, code.second, Location.NULL, Location.NULL, *details)
+        }
+
+        fun xstep(code: Int, vararg details: Any): XProcError = xstep(Pair(code, 1), *details)
 
         // ====================================================================================
 
@@ -347,6 +358,9 @@ open class XProcError protected constructor(val code: QName, val variant: Int, v
         fun xcAtMostOneGrammar() = step(211)
         fun xcInvalidIxmlGrammar() = step(212)
 
+        fun xiCastUnsupported(message: String) = xstep(1, message)
+        fun xiCastInputIncorrect(message: String) = xstep(2, message)
+
         fun xiNoSuchOutputPort(port: String)= internal(1, port)
         fun xiImpossibleNodeType(type: XdmNodeKind) = internal(2, type)
         fun xiThreadInterrupted() = internal(3)
@@ -367,7 +381,6 @@ open class XProcError protected constructor(val code: QName, val variant: Int, v
         fun xiCannotFindGraphviz(value: String) = internal(31, value)
         fun xiCannotExecuteGraphviz(value: String) = internal(32, value)
         fun xiUnwritableOutputFile(filename: String) = internal(33, filename)
-        fun xiNoRunnableSteps() = internal(35)
         fun xiNotASpecialType(type: String) = internal(36, type)
         fun xiDocumentInCache(href: URI) = internal(37, href)
         fun xiDocumentNotInCache(href: URI) = internal(38, href)

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/io/MediaType.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/io/MediaType.kt
@@ -36,6 +36,7 @@ class MediaType private constructor(val mediaType: String, val mediaSubtype: Str
         val ARJ = MediaType("application", "x-arj")
         val CPIO = MediaType("application", "x-cpio")
         val SEVENZ = MediaType("application", "x-7z-compressed")
+        val JAVA_PROPERTIES = MediaType("text", "x-java-properties")
 
         private val extensionMap = HashMap<MediaType, String>()
 
@@ -119,9 +120,9 @@ class MediaType private constructor(val mediaType: String, val mediaSubtype: Str
         )
 
         val classifications = listOf<Pair<MediaClassification, List<MediaType>>> (
-            Pair(MediaClassification.XML, MATCH_XML),
             Pair(MediaClassification.XHTML, listOf(XHTML)),
             Pair(MediaClassification.HTML, MATCH_HTML),
+            Pair(MediaClassification.XML, MATCH_XML),
             Pair(MediaClassification.JSON, MATCH_JSON),
             Pair(MediaClassification.YAML, MATCH_YAML),
             Pair(MediaClassification.TOML, MATCH_TOML),

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/namespace/NsErr.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/namespace/NsErr.kt
@@ -10,6 +10,7 @@ object NsErr {
     private val dynamicErrors = mutableMapOf<Int, QName>()
     private val stepErrors = mutableMapOf<Int, QName>()
     private val internalErrors = mutableMapOf<Int, QName>()
+    private val xstepErrors = mutableMapOf<Int, QName>()
 
     val threadInterrupted = xi(3)
     val assertionFailed = xi(41)
@@ -38,6 +39,15 @@ object NsErr {
         }
         val err = QName(NsCx.errorNamespace, "cxerr:XI${code.toString().padStart(4, '0')}")
         internalErrors[code] = err
+        return err
+    }
+
+    fun xxc(code: Int): QName {
+        if (code in xstepErrors) {
+            return xstepErrors[code]!!
+        }
+        val err = QName(NsCx.errorNamespace, "cxerr:XC${code.toString().padStart(4, '0')}")
+        xstepErrors[code] = err
         return err
     }
 

--- a/xmlcalabash/src/main/resources/com/xmlcalabash/explain-errors.txt
+++ b/xmlcalabash/src/main/resources/com/xmlcalabash/explain-errors.txt
@@ -1354,6 +1354,10 @@ XC0212
 Invalid Invisible XML grammar.
 It is a dynamic error if the grammar provided is not a valid Invisible XML grammar.
 
+cxerr:XC0001
+Cannot cast: $1.
+The requested content-type cast is not supported.
+
 cxerr:XI0001
 Pipeline has no “$1” output port.
 Cannot save the output from a port that doesn’t exist.

--- a/xmlcalabash/src/main/resources/com/xmlcalabash/properties.rnc
+++ b/xmlcalabash/src/main/resources/com/xmlcalabash/properties.rnc
@@ -1,0 +1,30 @@
+# https://docs.oracle.com/javase/8/docs/api/java/util/Properties.html
+#
+# Defines a DTD for properties files:
+#
+# <!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
+# <!-- DTD for properties -->
+# <!ELEMENT properties ( comment?, entry* ) >
+# <!ATTLIST properties version CDATA #FIXED "1.0">
+# <!ELEMENT comment (#PCDATA) >
+# <!ELEMENT entry (#PCDATA) >
+# <!ATTLIST entry key CDATA #REQUIRED>
+#
+
+start = properties
+
+properties =
+    element properties {
+        attribute version { "1.0" }?,
+        comment?,
+        entry*
+    }
+
+comment =
+    element comment { text }
+
+entry =
+    element entry {
+        attribute key { text },
+        text
+    }


### PR DESCRIPTION
This is an alternative to the XML Calabash 1.0 step that read a Java properties file.