### PR TITLE
Improve error messages

### DIFF
--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/XQueryStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/XQueryStep.kt
@@ -99,7 +99,11 @@ open class XQueryStep(): AbstractAtomicStep() {
         val exec = try {
             var xquery = query.value.underlyingValue.stringValue
             if (query.contentClassification == MediaClassification.XML) {
-                val root = S9Api.documentElement(query.value as XdmNode)
+                val root = try {
+                    S9Api.documentElement(query.value as XdmNode)
+                } catch (ex: IllegalArgumentException) {
+                    throw stepConfig.exception(XProcError.xdStepFailed("XQuery query input is ${query.contentType}, but ${ex.message}"), ex)
+                }
                 if (root.nodeName != NsC.query) {
                     val baos = ByteArrayOutputStream()
                     val writer = DocumentWriter(query, baos)

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/S9Api.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/S9Api.kt
@@ -25,14 +25,14 @@ class S9Api {
             for (child in node.axisIterator(Axis.CHILD)) {
                 if (child.nodeKind == XdmNodeKind.ELEMENT) {
                     if (root != null) {
-                        throw RuntimeException("Multiple root nodes")
+                        throw IllegalArgumentException("XML document has multiple top-level elements")
                     }
                     root = child
                 }
             }
 
             if (root == null) {
-                throw RuntimeException("No root")
+                throw IllegalArgumentException("XML document has no document element")
             }
 
             return root

--- a/xmlcalabash/src/main/resources/com/xmlcalabash/explain-errors.txt
+++ b/xmlcalabash/src/main/resources/com/xmlcalabash/explain-errors.txt
@@ -93,7 +93,7 @@ It is a dynamic error if any attribute value does not satisfy the type required
 for that attribute.
 
 XD0030
-Step failed: “$1”.
+Step failed: $1.
 It is a dynamic error if a step is unable or incapable of performing its function.
 
 XD0036/1


### PR DESCRIPTION
Give better error message for an XML document with no root element.

In the case of XQuery, do even better still if the problem is that the query is XML but the input is just a text node.

See also, https://github.com/xproc/3.0-steps/issues/658