### PR TITLE
Make sure that options passed to a subpipeline are reset in a loop

### DIFF
--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/CompoundStepHead.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/CompoundStepHead.kt
@@ -266,6 +266,7 @@ class CompoundStepHead(config: XProcStepConfiguration, val parent: CompoundStep,
         openPorts.addAll(params.inputs.keys)
         _cache.clear()
         inputCount.clear()
+        _options.clear()
         showMessage = true
     }
 


### PR DESCRIPTION
Fix #215

It’s a little hard to believe this hasn’t been found sooner. A compound step in a loop wasn’t resetting the options passed to it when the loop restarted. So they accumulated.