### PR TITLE
Resolve the Saxon configuration file against the base URI

### DIFF
--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/config/ConfigurationLoader.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/config/ConfigurationLoader.kt
@@ -122,7 +122,8 @@ class ConfigurationLoader private constructor(private val config: XmlCalabashCon
     private fun parse(root: XdmNode): XmlCalabashConfiguration {
         val saxonConfig = root.getAttributeValue(_saxonConfiguration)
         if (saxonConfig != null) {
-            config.saxonConfigurationFile = File(saxonConfig)
+            val uri = root.baseURI!!.resolve(saxonConfig)
+            config.saxonConfigurationFile = File(uri.path)
             if (!config.saxonConfigurationFile!!.exists()) {
                 throw XProcError.xiConfigurationInvalid(configFile, "file does not exist: ${saxonConfig}").exception()
             }


### PR DESCRIPTION
Fix #232

The value of the `saxon-configuration` file was used directly; it should be resolved against the base URI of the configuration element.