### PR TITLE
Improve testing for invalid URIs

### DIFF
--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/internal/InlineStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/internal/InlineStep.kt
@@ -16,6 +16,8 @@ import com.xmlcalabash.util.S9Api
 import com.xmlcalabash.util.SaxonTreeBuilder
 import net.sf.saxon.s9api.*
 import java.io.ByteArrayInputStream
+import java.net.URI
+import java.net.URISyntaxException
 import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets
 import java.util.*
@@ -91,7 +93,20 @@ open class InlineStep(val params: InlineStepParameters): AbstractAtomicStep() {
             }
         }
 
-        if (!props.has(Ns.baseUri)) {
+        if (props.has(Ns.baseUri)) {
+            val pbaseUri = props[Ns.baseUri]
+            if (pbaseUri != null && pbaseUri != XdmEmptySequence.getInstance()) {
+                val uristr = pbaseUri.underlyingValue.stringValue
+                try {
+                    val uri = URI(uristr)
+                    if (!uri.isAbsolute) {
+                        throw stepConfig.exception(XProcError.xdInvalidUri(uristr))
+                    }
+                } catch (ex: URISyntaxException) {
+                    throw stepConfig.exception(XProcError.xdInvalidUri(uristr))
+                }
+            }
+        } else {
             props[Ns.baseUri] = xml.baseURI
         }
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/S9Api.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/S9Api.kt
@@ -16,6 +16,7 @@ import org.xml.sax.InputSource
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.net.URI
+import java.net.URISyntaxException
 import java.nio.charset.StandardCharsets
 
 class S9Api {
@@ -107,7 +108,11 @@ class S9Api {
             if (baseUri == null) {
                 return xml
             }
-            return adjustBaseUri(xml, URI(baseUri.toString()))
+            try {
+                return adjustBaseUri(xml, URI(baseUri.toString()))
+            } catch (ex: URISyntaxException) {
+                throw XProcError.xdInvalidUri(baseUri.toString()).exception(ex)
+            }
         }
 
         fun adjustBaseUri(xml: XdmNode, baseUri: URI?): XdmNode {


### PR DESCRIPTION
This PR fixes some failures caused by revised test suite tests. The base URI specified in document-properties must be valid and absolute.