### PR TITLE
Use the correct context for select expressions

### DIFF
--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/XProcSelectExpression.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/XProcSelectExpression.kt
@@ -35,7 +35,7 @@ class XProcSelectExpression private constructor(stepConfig: XProcStepConfigurati
             compiler.baseURI = uri
         }
 
-        for ((prefix, uri) in config.inscopeNamespaces) {
+        for ((prefix, uri) in stepConfig.inscopeNamespaces) {
             compiler.declareNamespace(prefix, uri.toString())
         }
         for (name in variableRefs) {


### PR DESCRIPTION
The namespace context for an expression has to be the context where it was declared. But I have an ugly feeling that there was another bug in this area that motivated a related change. But I can't find a test that demonstrates that, so...my bad.