### PR TITLE
Use a Windows encoding on Windows; format SequenceType correctly

### DIFF
--- a/app/src/main/kotlin/com/xmlcalabash/app/XmlCalabashCli.kt
+++ b/app/src/main/kotlin/com/xmlcalabash/app/XmlCalabashCli.kt
@@ -21,6 +21,7 @@ import com.xmlcalabash.namespace.NsFn
 import com.xmlcalabash.namespace.NsXs
 import com.xmlcalabash.runtime.api.RuntimeOption
 import com.xmlcalabash.runtime.api.RuntimePort
+import com.xmlcalabash.util.DefaultMessagePrinter
 import com.xmlcalabash.util.DefaultXmlCalabashConfiguration
 import com.xmlcalabash.util.FileUtils
 import com.xmlcalabash.util.UriUtils
@@ -67,7 +68,9 @@ class XmlCalabashCli private constructor() {
     private var sawStdout = false
 
     private fun run(args: Array<out String>) {
-        var errorExplanation: ErrorExplanation = DefaultErrorExplanation()
+        val messagePrinter = DefaultMessagePrinter(XmlCalabashConfiguration.DEFAULT_CONSOLE_ENCODING)
+        var errorExplanation: ErrorExplanation = DefaultErrorExplanation(messagePrinter)
+
         val inputManifold = mutableMapOf<String, RuntimePort>()
         val outputManifold = mutableMapOf<String, RuntimePort>()
         val optionManifold = mutableMapOf<QName, RuntimeOption>()
@@ -392,7 +395,7 @@ class XmlCalabashCli private constructor() {
             xmlCalabash.println("Error: help is not available.")
             return
         }
-        val reader = BufferedReader(InputStreamReader(stream))
+        val reader = BufferedReader(InputStreamReader(stream, Charsets.UTF_8))
         for (line in reader.lines()) {
             xmlCalabash.println(line)
         }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/config/CommonEnvironment.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/config/CommonEnvironment.kt
@@ -71,7 +71,8 @@ class CommonEnvironment(private val xmlCalabash: XmlCalabash) {
     }
 
     private var _documentManager: DocumentManager = DocumentManager()
-    private var _errorExplanation: ErrorExplanation = DefaultErrorExplanation()
+    private var _messagePrinter: MessagePrinter = xmlCalabash.xmlCalabashConfig.messagePrinter
+    private var _errorExplanation: ErrorExplanation = DefaultErrorExplanation(_messagePrinter)
     private var _messageReporter: (() -> MessageReporter)? = null
     private var _mimeTypes = MimetypesFileTypeMap()
     private var _proxies = mutableMapOf<String, String>()
@@ -141,6 +142,7 @@ class CommonEnvironment(private val xmlCalabash: XmlCalabash) {
         set(value) {
             _errorExplanation = value
         }
+    val messagePrinter = _messagePrinter
     var messageReporter: () -> MessageReporter
         get() {
             if (_messageReporter == null) {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/config/XmlCalabashConfiguration.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/config/XmlCalabashConfiguration.kt
@@ -9,14 +9,18 @@ import com.xmlcalabash.util.DefaultMessagePrinter
 import com.xmlcalabash.util.Verbosity
 import com.xmlcalabash.visualizers.Silent
 import net.sf.saxon.Configuration
-import net.sf.saxon.om.NamespaceUri
 import net.sf.saxon.s9api.QName
 import java.io.File
 import java.net.URI
 
 abstract class XmlCalabashConfiguration {
     companion object {
-        val DEFAULT_CONSOLE_ENCODING = "utf-8"
+        val OS = System.getProperty("os.name") ?: "unknown"
+        val DEFAULT_CONSOLE_ENCODING = if (OS.startsWith("Windows")) {
+            "windows-1252"
+        } else {
+            "utf-8"
+        }
     }
 
     abstract fun saxonConfigurer(saxon: Configuration)

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/StaticOptionDetails.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/StaticOptionDetails.kt
@@ -2,6 +2,7 @@ package com.xmlcalabash.datamodel
 
 import com.xmlcalabash.runtime.XProcStepConfiguration
 import com.xmlcalabash.exceptions.XProcError
+import com.xmlcalabash.util.TypeUtils
 import net.sf.saxon.s9api.QName
 import net.sf.saxon.s9api.SequenceType
 import net.sf.saxon.s9api.XdmAtomicValue
@@ -14,12 +15,12 @@ class StaticOptionDetails(val stepConfig: XProcStepConfiguration, val name: QNam
 
     internal fun override(value: XdmValue) {
         if (!asType.matches(value)) {
-            throw stepConfig.exception(XProcError.xsValueDoesNotSatisfyType(value.toString(), asType.toString()))
+            throw stepConfig.exception(XProcError.xsValueDoesNotSatisfyType(value.toString(), TypeUtils.sequenceTypeToString(asType)))
         }
 
         if (values.isNotEmpty()) {
             if (value !is XdmAtomicValue) {
-                throw stepConfig.exception(XProcError.xsValueDoesNotSatisfyType(value.toString(), asType.toString()))
+                throw stepConfig.exception(XProcError.xsValueDoesNotSatisfyType(value.toString(), TypeUtils.sequenceTypeToString(asType)))
             }
             if (!values.contains(value)) {
                 throw stepConfig.exception(XProcError.xsValueDoesNotSatisfyType(value.toString(), values.toString()))

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/debugger/CliDebugger.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/debugger/CliDebugger.kt
@@ -940,7 +940,7 @@ class CliDebugger(val runtime: XProcRuntime): Monitor {
     private fun init() {
         val invisibleXml = InvisibleXml()
         val stream = CliDebugger::class.java.getResourceAsStream("/com/xmlcalabash/debugger.ixml")
-        parser = invisibleXml.getParser(stream, "https://xmlcalabash.com/grammar/debugger.ixml")
+        parser = invisibleXml.getParser(stream, "https://xmlcalabash.com/grammar/debugger.ixml", "utf-8")
 
         for (graph in runtime.graphList) {
             for (model in graph.models) {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/DefaultErrorExplanation.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/DefaultErrorExplanation.kt
@@ -5,6 +5,7 @@ import com.xmlcalabash.datamodel.Location
 import com.xmlcalabash.documents.XProcBinaryDocument
 import com.xmlcalabash.documents.XProcDocument
 import com.xmlcalabash.io.DocumentWriter
+import com.xmlcalabash.io.MessagePrinter
 import com.xmlcalabash.namespace.Ns
 import com.xmlcalabash.namespace.NsCx
 import com.xmlcalabash.namespace.NsErr
@@ -21,7 +22,7 @@ import java.io.InputStreamReader
 import java.nio.charset.StandardCharsets
 import javax.xml.transform.sax.SAXSource
 
-class DefaultErrorExplanation(): ErrorExplanation {
+class DefaultErrorExplanation(val printer: MessagePrinter): ErrorExplanation {
     private var environment: CommonEnvironment? = null
 
     companion object {
@@ -99,7 +100,7 @@ class DefaultErrorExplanation(): ErrorExplanation {
     }
 
     override fun report(error: XProcError) {
-        System.err.println(message(error, true))
+        printer.println(message(error, true))
     }
 
     override fun explanation(error: XProcError): String {
@@ -108,7 +109,7 @@ class DefaultErrorExplanation(): ErrorExplanation {
     }
 
     override fun reportExplanation(error: XProcError) {
-        System.err.println(explanation(error))
+        printer.println(explanation(error))
     }
 
     private fun template(code: QName, variant: Int, count: Int): ErrorExplanationTemplate {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/XProcPipeline.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/XProcPipeline.kt
@@ -15,6 +15,7 @@ import com.xmlcalabash.tracing.TraceListener
 import com.xmlcalabash.util.DefaultOutputReceiver
 import com.xmlcalabash.util.AssertionsLevel
 import com.xmlcalabash.util.AssertionsMonitor
+import com.xmlcalabash.util.TypeUtils
 import com.xmlcalabash.visualizers.Silent
 import net.sf.saxon.s9api.QName
 import java.io.FileOutputStream
@@ -96,7 +97,7 @@ class XProcPipeline internal constructor(runtime: XProcRuntime, pipeline: Compou
         try {
             config.checkType(name, value.value, option.asType, config.inscopeNamespaces, option.values)
         } catch (_: Exception) {
-            throw XProcError.xdBadType(value.value.toString(), option.asType.toString()).exception()
+            throw XProcError.xdBadType(value.value.toString(), TypeUtils.sequenceTypeToString(option.asType)).exception()
         }
 
         for (step in runnable.runnables.filterIsInstance<AtomicOptionStep>()) {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/TypeUtils.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/TypeUtils.kt
@@ -24,6 +24,12 @@ class TypeUtils(val stepConfig: XProcStepConfiguration) {
         private val parsedXsTypes = mutableMapOf<String, SequenceType>()
         private var vara = QName("a")
         private var varb = QName("b")
+
+        fun sequenceTypeToString(asType: SequenceType): String {
+            val baseType = asType.itemType.typeName
+            val occur = asType.occurrenceIndicator.toString()
+            return "${baseType}${occur}"
+        }
     }
 
     val inscopeNamespaces = stepConfig.inscopeNamespaces


### PR DESCRIPTION
Fix #266

The documentation claimed that the default encoding on Windows was Windows-1252. It lied. That’s fixed now and I tidied up the formatting of SequenceTypes.