### PR TITLE
Support -s:stepType to run any known (atomic) step

### DIFF
--- a/app/src/main/kotlin/com/xmlcalabash/app/CommandLine.kt
+++ b/app/src/main/kotlin/com/xmlcalabash/app/CommandLine.kt
@@ -3,6 +3,12 @@ package com.xmlcalabash.app
 import com.xmlcalabash.api.Monitor
 import com.xmlcalabash.exceptions.XProcError
 import com.xmlcalabash.exceptions.XProcException
+import com.xmlcalabash.namespace.NsCx
+import com.xmlcalabash.namespace.NsFn
+import com.xmlcalabash.namespace.NsP
+import com.xmlcalabash.namespace.NsSaxon
+import com.xmlcalabash.namespace.NsXml
+import com.xmlcalabash.namespace.NsXs
 import com.xmlcalabash.util.AssertionsLevel
 import com.xmlcalabash.util.UriUtils
 import com.xmlcalabash.util.Verbosity
@@ -198,7 +204,7 @@ class CommandLine private constructor(val args: Array<out String>) {
         ArgumentDescription("--namespace", listOf("-ns"), ArgumentType.STRING) { it -> parseNamespace(it) },
         ArgumentDescription("--init", listOf(), ArgumentType.STRING) { it -> _initializers.add(it) },
         ArgumentDescription("--configuration", listOf("-c", "--config"), ArgumentType.EXISTING_FILE) { it -> _config = File(it) },
-        ArgumentDescription("--step", listOf(), ArgumentType.STRING) { it -> _step = it },
+        ArgumentDescription("--step", listOf("-s"), ArgumentType.STRING) { it -> _step = it },
         ArgumentDescription("--graphs", listOf(), ArgumentType.DIRECTORY) { it -> _pipelineGraphs = it },
         ArgumentDescription("--licensed", listOf(), ArgumentType.BOOLEAN, "true") { it -> _licensed = it == "true" },
         ArgumentDescription("--pipe", listOf(), ArgumentType.BOOLEAN, "true") { it -> _pipe = it == "true" },
@@ -340,6 +346,21 @@ class CommandLine private constructor(val args: Array<out String>) {
 
         if (_debug == true && (verbosity == null || verbosity!! > Verbosity.DEBUG)) {
             _verbosity = Verbosity.DEBUG
+        }
+
+        for ((prefix, namespace) in mapOf(
+            "cx" to NsCx.namespace,
+            "p" to NsP.namespace,
+            "xs" to NsXs.namespace,
+            "fn" to NsFn.namespace,
+            "map" to NsFn.mapNamespace,
+            "array" to NsFn.arrayNamespace,
+            "math" to NsFn.mathNamespace,
+            "saxon" to NsSaxon.namespace,
+            "xml" to NsXml.namespace)) {
+            if (!_namespaces.containsKey(prefix)) {
+                _namespaces[prefix] = namespace
+            }
         }
     }
 

--- a/documentation/src/userguide/run.xml
+++ b/documentation/src/userguide/run.xml
@@ -74,8 +74,6 @@ given, the <command>run</command> command is assumed.</para>
   <sbr/>
   <arg rep="norepeat" linkend="cli-graphs">--graphs:<replaceable>graph-output-directory</replaceable></arg>
   <sbr/>
-  <arg rep="norepeat" linkend="cli-step">--step:<replaceable>step-name</replaceable></arg>
-  <sbr/>
   <arg rep="norepeat" linkend="cli-verbosity">--verbosity:<replaceable>verbosity</replaceable></arg>
   <arg rep="norepeat" linkend="cli-explain">--explain</arg>
   <arg rep="norepeat" linkend="cli-visualizer">--visualizer:<replaceable>name</replaceable></arg>
@@ -90,7 +88,8 @@ given, the <command>run</command> command is assumed.</para>
   <arg rep="norepeat" linkend="cli-debug">--debugger</arg>
   <arg rep="norepeat" linkend="cli-help">--help</arg>
   <sbr/>
-  <arg choice="plain" linkend="cli-pipeline"><replaceable>pipeline.xpl</replaceable></arg>
+  <arg rep="norepeat" linkend="cli-step">--step:<replaceable>step-name</replaceable></arg>
+  <arg linkend="cli-pipeline"><replaceable>pipeline.xpl</replaceable></arg>
   <arg rep="repeat" linkend="cli-option"><replaceable>option</replaceable>=<replaceable>value</replaceable></arg>
 </cmdsynopsis>
 
@@ -204,13 +203,34 @@ if you want to save the output or enable piped mode.</para>
 <listitem>
 <para>Binds the specified <replaceable>prefix</replaceable> to the <replaceable>uri</replaceable>.
 This has no effect on the pipeline; these bindings are only used when evaluating
+the <option linkend="cli-step">--step</option> option and in
 expressions used to define <phrase linkend="cli-option">options</phrase>.
 </para>
-<para>If no namespace bindings are provided, the default bindings are 
-<code>xs</code>, <code>fn</code>, <code>map</code>, <code>array</code>, and <code>math</code>
-to their traditional XML Schema and XPath URIs. The prefix
-<code>saxon</code> is also bound to the Saxon extension namespace,
-<literal>http://saxon.sf.net/</literal>.</para>
+
+<para>The default namespace bindings on the command line are:</para>
+
+<informaltable>
+<tgroup cols="2">
+<colspec colwidth="1*"/>
+<colspec colwidth="5*"/>
+<thead>
+  <row><entry>Prefix</entry><entry>Namespace URI</entry></row>
+</thead>
+<tbody>
+  <row><entry><literal>array</literal></entry><entry><uri>http://www.w3.org/2005/xpath-functions/array</uri></entry></row>
+  <row><entry><literal>cx</literal></entry><entry><uri>http://xmlcalabash.com/ns/extensions</uri></entry></row>
+  <row><entry><literal>fn</literal></entry><entry><uri>http://www.w3.org/2005/xpath-functions</uri></entry></row>
+  <row><entry><literal>map</literal></entry><entry><uri>http://www.w3.org/2005/xpath-functions/map</uri></entry></row>
+  <row><entry><literal>math</literal></entry><entry><uri>http://www.w3.org/2005/xpath-functions/math</uri></entry></row>
+  <row><entry><literal>p</literal></entry><entry><uri>http://www.w3.org/ns/xproc</uri></entry></row>
+  <row><entry><literal>saxon</literal></entry><entry><uri>http://saxon.sf.net/</uri></entry></row>
+  <row><entry><literal>xs</literal></entry><entry><uri>http://www.w3.org/2001/XMLSchema</uri></entry></row>
+</tbody>
+</tgroup>
+</informaltable>
+
+<para>The <option>--namespace</option> option can add to, or change, these bindings.</para>
+
 </listitem>
 </varlistentry>
 
@@ -240,14 +260,6 @@ pipeline and its corresponding graph. An HTML index in the
 to view, or if links don’t work correctly, a good first step is to try a different
 browser.</para>
 </note>
-</listitem>
-</varlistentry>
-
-<varlistentry xml:id="cli-step">
-  <term><option>--step:<replaceable>step-name</replaceable></option>, identifies a step</term>
-<listitem>
-<para>If the input pipeline document is a <tag>p:library</tag>, this option identifies a step
-within that library to run.</para>
 </listitem>
 </varlistentry>
 
@@ -418,6 +430,37 @@ See <xref linkend="debugging"/>.</para>
 <para>This is equivalent to issuing the <command linkend="run-help">help</command> command.
 It’s provided as an option for convenience.
 </para>
+</listitem>
+</varlistentry>
+
+<varlistentry xml:id="cli-step">
+  <term><option>--step:<replaceable>step</replaceable></option>, identifies a step</term>
+<listitem>
+<para>The <option>--step</option> option is a little bit overloaded. Its interpretation
+depends on whether or not <link linkend="cli-pipeline">a pipeline</link> is specified.
+</para>
+
+<para>If a pipeline is specified, it must identify a <tag>p:library</tag>. The value of the
+<option>--step</option> option is interpreted as the <emphasis>name</emphasis> of a step in
+that library. The named step will be run.</para>
+
+<para>For example:</para>
+
+<screen><prompt>$ </prompt><userinput>xmlcalabash --step:helloWorld --library:examples.xpl …</userinput></screen>
+
+<para>If no pipeline is specified, the value of the <option>--step</option>
+option is interpreted as the <emphasis>type</emphasis> of a step. The (atomic)
+step with the specified type will be run. All of the inputs, outputs, and options
+specified apply to that step.</para>
+
+<para>For example:</para>
+
+<screen><prompt>$ </prompt><userinput>xmlcalabash --step:p:xslt …</userinput></screen>
+
+<para>The <literal>p</literal> and <literal>cx</literal> namespaces are bound by default.
+The <option linkend="cli-namespace">--namespace</option> option can be
+used to change the namespace bindings.</para>
+
 </listitem>
 </varlistentry>
 

--- a/ext/unique-id/src/main/resources/com/xmlcalabash/ext/unique-id.xpl
+++ b/ext/unique-id/src/main/resources/com/xmlcalabash/ext/unique-id.xpl
@@ -1,12 +1,15 @@
 <p:library xmlns:p="http://www.w3.org/ns/xproc"
+           xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
            xmlns:xs="http://www.w3.org/2001/XMLSchema"
            xmlns:cx="http://xmlcalabash.com/ns/extensions"
            version="3.0">
   <p:declare-step type="cx:unique-id">
     <p:input port="source" primary="true" content-types="xml html"/>
     <p:output port="result" content-types="text xml html"/>
-    <p:option name="match" as="xs:string" select="/*"/>  <!-- XSLTSelectionPattern -->
-    <p:option name="flavor" as="xs:string" select="'uuid'" values="('uuid','ulid','typeid')"/>
+    <p:option name="match" as="xs:string" select="'/*'"
+              e:type="XSLTSelectionPattern"/>
+    <p:option name="flavor" as="xs:string" select="'uuid'"
+              values="('uuid', 'ulid', 'typeid')"/>
     <p:option name="sequential" as="xs:boolean" select="false()"/>
     <p:option name="parameters" as="map(xs:QName,item()*)?"/> 
   </p:declare-step>

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/DeclareStepInstruction.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/DeclareStepInstruction.kt
@@ -481,6 +481,10 @@ class DeclareStepInstruction(parent: XProcInstruction?, stepConfig: InstructionC
         return input
     }
 
+    fun getOptions(): List<OptionInstruction> {
+        return children.filterIsInstance<OptionInstruction>()
+    }
+
     override fun option(name: QName): OptionInstruction {
         if (name.namespaceUri == NsP.namespace) {
             throw stepConfig.exception(XProcError.xsOptionInXProcNamespace(name))

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/StepDeclaration.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/StepDeclaration.kt
@@ -273,7 +273,7 @@ abstract class StepDeclaration(parent: XProcInstruction?, stepConfig: Instructio
         return namedPort(outputs(), name)
     }
 
-    internal open fun withInput(port: String? = null): WithInputInstruction {
+    open fun withInput(port: String? = null): WithInputInstruction {
         val withInput = WithInputInstruction(this, stepConfig)
         if (port != null) {
             withInput._port = port
@@ -282,13 +282,13 @@ abstract class StepDeclaration(parent: XProcInstruction?, stepConfig: Instructio
         return withInput
     }
 
-    internal open fun withInput(): WithInputInstruction {
+    open fun withInput(): WithInputInstruction {
         val withInput = WithInputInstruction(this, stepConfig.copy())
         _children.add(withInput)
         return withInput
     }
 
-    internal fun withOutput(): WithOutputInstruction {
+    fun withOutput(): WithOutputInstruction {
         val withOutput = WithOutputInstruction(this, stepConfig.copy())
         _children.add(withOutput)
         return withOutput

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/XProcError.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/XProcError.kt
@@ -419,6 +419,7 @@ open class XProcError protected constructor(val code: QName, val variant: Int, e
         fun xiTooLateForStaticOptions(name: QName) = internal(213, name)
         fun xiCliDuplicateNamespace(prefix: String) = internal(214, prefix)
         fun xiMergeDuplicatesError(name: String) = internal(215, name)
+        fun xiNotALibrary(uri: URI) = internal(216, uri)
 
         fun xiXvrlInvalidValue(name: QName, value: String) = internal(300, name, value)
         fun xiXvrlIllegalMessageName(name: QName) = internal(301, name)

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/parsers/xpl/XplParser.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/parsers/xpl/XplParser.kt
@@ -78,6 +78,17 @@ class XplParser internal constructor(val builder: PipelineBuilder) {
         return pipelineForContainer(stepContainer, stepName)
     }
 
+    fun parseLibrary(uri: URI): LibraryInstruction {
+        val stepContainer = parseUri(uri);
+        if (errors.isNotEmpty()) {
+            throw errors.first()
+        }
+        if (stepContainer is LibraryInstruction) {
+            return stepContainer
+        }
+        throw XProcError.xiNotALibrary(uri).exception()
+    }
+
     private fun pipelineForContainer(stepContainer: StepContainerInterface, stepName: String?): DeclareStepInstruction {
         if (stepContainer is DeclareStepInstruction) {
             return stepContainer

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/spi/DocumentResolver.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/spi/DocumentResolver.kt
@@ -7,6 +7,7 @@ import java.net.URI
 
 interface DocumentResolver {
     fun resolvableUris(): List<URI>
+    fun resolvableLibraryUris(): List<URI>
     fun configure(manager: DocumentManager)
     fun resolve(context: XProcStepConfiguration, uri: URI, current: XProcDocument?): XProcDocument?
 }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/InternalDocumentResolver.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/InternalDocumentResolver.kt
@@ -22,6 +22,10 @@ class InternalDocumentResolver(): DocumentResolver {
         return URI_MAP.keys.toList()
     }
 
+    override fun resolvableLibraryUris(): List<URI> {
+        return emptyList()
+    }
+
     override fun configure(manager: DocumentManager) {
         for ((uri, _) in URI_MAP) {
             manager.registerPrefix(uri.toString(), this)

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/NopDocumentResolverProvider.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/NopDocumentResolverProvider.kt
@@ -16,8 +16,11 @@ class NopDocumentResolverProvider: DocumentResolverProvider, DocumentResolver {
         return emptyList()
     }
 
+    override fun resolvableLibraryUris(): List<URI> {
+        return emptyList()
+    }
+
     override fun configure(manager: DocumentManager) {
-        // manager.registerPrefix("file:/Volumes/Documents/xsl/", this)
         // nop
     }
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/SimpleDocumentResolverProvider.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/SimpleDocumentResolverProvider.kt
@@ -17,6 +17,10 @@ open class SimpleDocumentResolverProvider(val magicUri: URI, val resourcePath: S
         return listOf(magicUri)
     }
 
+    override fun resolvableLibraryUris(): List<URI> {
+        return listOf(magicUri)
+    }
+
     override fun create(): DocumentResolver {
         return this
     }


### PR DESCRIPTION
Fix #236

There are a bunch of changes in here, the builder and DocumentResolverProvider APIs needed a little refactoring, and the declaration for the cx:unique-id step turned out to be incomplete. But the major functional change is that you can run any atomic step directly from the command line with -s:stepType.