### PR TITLE
Adjust the ContentTypeConverter interface

### DIFF
--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/io/DocumentConverter.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/io/DocumentConverter.kt
@@ -68,10 +68,8 @@ class DocumentConverter(val stepConfig: XProcStepConfiguration,
         }
 
         for (converter in converters!!) {
-            for (conversion in converter.conversions()) {
-                if (conversion.first == doc.contentType && conversion.second == contentType) {
-                    return converter.convert(stepConfig, doc, contentType, serializationParameters)
-                }
+            if (doc.contentType != null && converter.canConvert(doc.contentType!!, contentType)) {
+                return converter.convert(stepConfig, doc, contentType, serializationParameters)
             }
         }
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/spi/ContentTypeConverter.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/spi/ContentTypeConverter.kt
@@ -7,6 +7,6 @@ import net.sf.saxon.s9api.QName
 import net.sf.saxon.s9api.XdmValue
 
 interface ContentTypeConverter {
-    fun conversions(): List<Pair<MediaType, MediaType>>
+    fun canConvert(from: MediaType, to: MediaType): Boolean
     fun convert(stepConfig: XProcStepConfiguration, doc: XProcDocument, convertTo: MediaType, serialization: Map<QName, XdmValue>): XProcDocument
 }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/NopContentTypeConverter.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/NopContentTypeConverter.kt
@@ -8,8 +8,8 @@ import net.sf.saxon.s9api.QName
 import net.sf.saxon.s9api.XdmValue
 
 class NopContentTypeConverter(): ContentTypeConverter {
-    override fun conversions(): List<Pair<MediaType, MediaType>> {
-        return emptyList()
+    override fun canConvert(from: MediaType, to: MediaType): Boolean {
+        return false
     }
 
     override fun convert(


### PR DESCRIPTION
Rather than returning a list of conversion pairs, have a method that returns true if a particular conversion is possible.