### PR TITLE
Don’t swallow the underlying exception when updating locations

### DIFF
--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/AbstractStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/AbstractStep.kt
@@ -168,9 +168,9 @@ abstract class AbstractStep(val stepConfig: XProcStepConfiguration, step: StepMo
                 else -> {
                     val msg = ex.message ?: ""
                     if (msg.contains("cannot be cast")) {
-                        throw stepConfig.exception(XProcError.xdBadType(msg).updateAt(type,name))
+                        throw stepConfig.exception(XProcError.xdBadType(msg).updateAt(type,name), ex)
                     }
-                    throw stepConfig.exception(XProcError.xdStepFailed(msg).updateAt(type, name))
+                    throw stepConfig.exception(XProcError.xdStepFailed(msg).updateAt(type, name), ex)
                 }
             }
         }


### PR DESCRIPTION
The general error handler in AbstractStep was wrapping an unexpected exception in an XProcException but failing to provide the underlying exception as the cause. This made the debugging output a little useless.

See #282 
