### PR TITLE
Correctly handle “\” in p:urify filepaths on Windows

### DIFF
--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/Urify.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/Urify.kt
@@ -208,7 +208,7 @@ class Urify(filepath: String, basedir: String?) {
         } else if (windows && wfMatch != null) {
             val fpfile = wfMatch.groupValues[1]
             val fpdrive = wfMatch.groupValues[2]
-            val fppath = wfMatch.groupValues[3]
+            val fppath = wfMatch.groupValues[3].replace("\\", "/")
             _scheme = "file"
             _explicit = fpfile.lowercase().startsWith("file:")
             _driveLetter = fpdrive


### PR DESCRIPTION
Fix #281

Remarkably, none of the p:urify tests in the test-suite actually used “C:\…” filepaths, they all used “C:/…” filepaths. I’ve added a dozen or so tests to correct that.

This may also resolve #282, even though I couldn’t reproduce it.