### PR TITLE
Initial implementation of the cx:xmlunit extension step

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -143,6 +143,7 @@ jobs:
             ext/diagramming/build/distributions/diagramming-${{ env.CI_TAG }}.zip
             ext/railroad/build/distributions/railroad-${{ env.CI_TAG }}.zip
             ext/rdf/build/distributions/rdf-${{ env.CI_TAG }}.zip
+            ext/xmlunit/build/distributions/xmlunit-${{ env.CI_TAG }}.zip
 
       # N.B. This is **only** publishing the SNAPSHOT builds on the main branch
       - name: Publish to Sonatype

--- a/documentation/src/reference/extension-steps/cx-xmlunit.xml
+++ b/documentation/src/reference/extension-steps/cx-xmlunit.xml
@@ -1,0 +1,85 @@
+<refentry xmlns:p="http://www.w3.org/ns/xproc"
+          xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
+          xmlns:xi="http://www.w3.org/2001/XInclude"
+          xmlns:xlink="http://www.w3.org/1999/xlink"
+          xmlns:cx="http://xmlcalabash.com/ns/extensions"
+          xmlns:cxerr="http://xmlcalabash.com/ns/error"
+          xmlns="http://docbook.org/ns/docbook"
+          xml:id="cx-xmlunit">
+<?db filename="cx-xmlunit"?>
+   <refnamediv>
+      <refname>cx:xmlunit</refname>
+      <refpurpose>Performs comparisons with xmlunit</refpurpose>
+   </refnamediv>
+   <refsynopsisdiv>
+
+<refsection role="introduction">
+<title>Introduction</title>
+<para>The <tag>cx:xmlunit</tag> step compares two XML (or HTML) documents with
+<link xlink:href="https://www.xmlunit.org/">XMLUnit</link>.</para>
+</refsection>
+
+<refsection role="step-declaration">
+<title>Step declaration</title>
+     <xi:include href="../../../../ext/xmlunit/src/main/resources/com/xmlcalabash/ext/xmlunit.xpl"
+                 xpointer="xpath(/*/*[@type='cx:xmlunit'])"/>
+</refsection>
+
+<refsection role="errors">
+<title>Errors</title>
+<para>Errors from the entry body are summarized here.</para>
+</refsection>
+</refsynopsisdiv>
+
+<refsection>
+<title>Description</title>
+
+<para>The <tag>cx:xmlunit</tag> step compares two XML (or HTML) documents for similarity or
+identity with XMLUnit version <?version DEPENDENCY_xmlunit?>. XMLUnit is very flexible, the
+<tag>cx:xmlunit</tag> step attempts to support many of the options, but there are some
+gaps.</para>
+
+<para>After the comparison, the source document appears (unchanged) on the
+<port>result</port> port. A report of the differences appears on the
+<port>report</port> port. For every difference, there are two <tag>xvrl:detection</tag>
+elements, one for the source document and one for the alternate.
+<error code="cxerr:XC0014">It
+is a <glossterm>dynamic error</glossterm> if the documents are different
+and the <option>fail-if-not-equal</option> option is true.</error></para>
+
+<para><error code="cxerr:XC0015">It
+is a <glossterm>dynamic error</glossterm> if the <option>attributes-list</option>
+option is not a list of QNames.</error>
+<error code="cxerr:XC0016">It
+is a <glossterm>dynamic error</glossterm> if the <option>attributes-list</option>
+option is not empty and the <option>element-selector</option> option is not
+“<literal>by-name-and-attributes</literal>”.</error></para>
+
+<para>In an effort to make the step more flexible, the
+<option>element-selector-class</option> can be used to provide the name
+of a class that implements the XMLUnit <interfacename>ElementSelector</interfacename> interface.
+If specified, that class will be instantiated (with a zero-argument constructor) and used
+to select elements. 
+<error code="cxerr:XC0017">It
+is a <glossterm>dynamic error</glossterm> if the <option>element-selector</option>
+and <option>element-selector-class</option> options are both provided.</error>
+<error code="cxerr:XC0018">It
+is a <glossterm>dynamic error</glossterm> if the <option>element-selector-class</option>
+cannot be instantiated.</error> You must provide the class on the class path.</para>
+
+<para>The <option>node-matcher-class</option> provides the name of a class that
+implements the <interfacename>NodeMatcher</interfacename> interface.
+If specified, that class will be instantiated (with a zero-argument constructor) and used
+to match nodes.
+<error code="cxerr:XC0020">It
+is a <glossterm>dynamic error</glossterm> if the <option>element-selector</option>
+and <option>node-matcher-class</option> options are both provided.</error>
+<error code="cxerr:XC0021">It
+is a <glossterm>dynamic error</glossterm> if the <option>node-matcher-class</option>
+cannot be instantiated.</error></para>
+
+</refsection>
+
+</refentry>
+
+

--- a/documentation/src/reference/extension-steps/reference.xml
+++ b/documentation/src/reference/extension-steps/reference.xml
@@ -23,6 +23,7 @@
 <xi:include href="cx-until.xml"/>
 <xi:include href="cx-wait-for-update.xml"/>
 <xi:include href="cx-while.xml"/>
+<xi:include href="cx-xmlunit.xml"/>
 <xi:include href="cx-xpath.xml"/>
 
 </part>

--- a/ext/xmlunit/README.md
+++ b/ext/xmlunit/README.md
@@ -1,0 +1,26 @@
+#  XML Unit extension step
+
+These are extension steps for [XML Calabash 3.x](https://github.com/xmlcalabash/xmlcalabash3).
+
+To use these steps, you must add them to your XML Calabash configuration. They doesn’t
+have any standalone functionality.
+
+## Install with Maven
+
+Alpha versions of XML Calabash and this step are published to the Maven
+[SNAPSHOT](https://help.sonatype.com/en/maven-repositories.html) repository,
+https://oss.sonatype.org/content/repositories/snapshots/
+
+Add `com.xmlcalabash:xmlcalabash:<version>` and
+`com.xmlcalabash:xmlunit:<version>` to your project.
+
+# Install “by hand”
+
+To install this package by hand, download the distribution
+[from GitHub](https://github.com/xmlcalabash/xmlcalabash3/releases) and
+unzip it somewhere. When you run XML Calabash, make sure that
+all of the jar files in the `extra` directory are included on your classpath.
+
+One way to do this is to copy all of them into the `extra` directory
+in the XML Calabash release. The scripts included in the release will
+then load them automatically.

--- a/ext/xmlunit/build.gradle.kts
+++ b/ext/xmlunit/build.gradle.kts
@@ -1,0 +1,141 @@
+import com.xmlcalabash.build.XmlCalabashBuildExtension
+
+plugins {
+  id("buildlogic.kotlin-library-conventions")
+  id("com.xmlcalabash.build.xmlcalabash-build")
+  `maven-publish`
+}
+
+val xmlcalabash by configurations.creating {}
+
+configurations.forEach {
+  it.exclude("net.sf.saxon.Saxon-HE")
+}
+
+val dep_xmlunit = project.findProperty("xmlunit").toString()
+
+dependencies {
+  implementation(project(":xmlcalabash"))
+  implementation("org.xmlunit:xmlunit-core:${dep_xmlunit}")
+
+  xmlcalabash(project(":xmlcalabash"))
+}
+
+val xmlbuild = the<XmlCalabashBuildExtension>()
+
+tasks.jar {
+  archiveFileName.set(xmlbuild.jarArchiveFilename())
+}
+
+val sourcesJar by tasks.registering(Jar::class) {
+  archiveClassifier = "sources"
+  from(sourceSets.main.get().allSource)
+}
+
+tasks.register("stage-release") {
+  dependsOn("jar")
+
+  doLast {
+    mkdir(layout.buildDirectory.dir("stage"))
+    mkdir(layout.buildDirectory.dir("stage/extra"))
+    copy {
+      from(layout.buildDirectory.dir("libs"))
+      into(layout.buildDirectory.dir("stage/extra"))
+    }
+  }
+
+  doLast {
+    xmlbuild.distClasspath(configurations["xmlcalabash"], configurations["distributionClasspath"])
+        .forEach { path ->
+          copy {
+            from(path)
+            into(layout.buildDirectory.dir("stage/extra"))
+            exclude("META-INF/**")
+            exclude("com/**")
+          }                      
+        }
+  }
+
+  doLast {
+    copy {
+      from(layout.projectDirectory.dir("src/main/docs"))
+      into(layout.buildDirectory.dir("stage"))
+      filter { line ->
+        line.replace("@@VERSION@@", xmlbuild.version.get())
+      }
+    }
+  }
+
+  doLast {
+    copy {
+      from(layout.projectDirectory)
+      into(layout.buildDirectory.dir("stage"))
+      include("README.md")
+      filter { line ->
+        line.replace("XML Unit extension step",
+                     "XML Unit extension step version ${xmlbuild.version.get()}")
+            .replace("<version>", xmlbuild.version.get())
+      }
+    }
+  }
+}
+
+tasks.register<Zip>("release") {
+  dependsOn("stage-release")
+  from(layout.buildDirectory.dir("stage"))
+  into("${xmlbuild.name.get()}-${xmlbuild.version.get()}/")
+  archiveFileName = "${xmlbuild.name.get()}-${xmlbuild.version.get()}.zip"
+}
+
+publishing {
+  repositories {
+    maven {
+      credentials {
+        username = project.findProperty("sonatypeUsername").toString()
+        password = project.findProperty("sonatypePassword").toString()
+      }
+      url = if (xmlbuild.version.get().contains("SNAPSHOT")) {
+        uri("https://oss.sonatype.org/content/repositories/snapshots/")
+      } else {
+        uri("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
+      }
+    }
+  }
+
+  publications {
+    create<MavenPublication>("mavenXmlCalabash") {
+      pom {
+        groupId = project.findProperty("xmlcalabashGroup").toString()
+        version = project.findProperty("xmlcalabashVersion").toString()
+        name = "XML Calabash XML Unit Step"
+        packaging = "jar"
+        description = "XML Unit step for XML Calabash 3.x"
+        url = "https://github.com/xmlcalabash/xmlcalabash3"
+
+        scm {
+          url = "scm:git@github.com:xmlcalabash/xmlcalabash3.git"
+          connection = "scm:git@github.com:xmlcalabash/xmlcalabash3.git"
+          developerConnection = "scm:git@github.com:xmlcalabash/xmlcalabash3.git"
+        }
+
+        licenses {
+          license {
+            name = "MIT License"
+            url = "http://www.opensource.org/licenses/mit-license.php"
+            distribution = "repo"
+          }
+        }
+
+        developers {
+          developer {
+            id = "ndw"
+            name = "Norm Tovey-Walsh"
+          }
+        }
+      }
+
+      from(components["java"])
+      artifact(sourcesJar.get())
+    }
+  }
+}

--- a/ext/xmlunit/src/main/kotlin/com/xmlcalabash/ext/xmlunit/ExampleElementSelector.kt
+++ b/ext/xmlunit/src/main/kotlin/com/xmlcalabash/ext/xmlunit/ExampleElementSelector.kt
@@ -1,0 +1,15 @@
+package com.xmlcalabash.ext.xmlunit
+
+import org.w3c.dom.Element
+import org.xmlunit.diff.ElementSelector
+import org.xmlunit.util.Nodes
+
+class ExampleElementSelector: ElementSelector {
+    override fun canBeCompared(controlElement: Element?, testElement: Element?): Boolean {
+        if (controlElement == null || testElement == null) {
+            return false // can't actually happen, but keep the API happy
+        }
+
+        return Nodes.getQName(controlElement) == Nodes.getQName(testElement)
+    }
+}

--- a/ext/xmlunit/src/main/kotlin/com/xmlcalabash/ext/xmlunit/ExampleNodeMatcher.kt
+++ b/ext/xmlunit/src/main/kotlin/com/xmlcalabash/ext/xmlunit/ExampleNodeMatcher.kt
@@ -1,0 +1,16 @@
+package com.xmlcalabash.ext.xmlunit
+
+import org.w3c.dom.Node
+import org.xmlunit.diff.DefaultNodeMatcher
+import org.xmlunit.diff.NodeMatcher
+
+class ExampleNodeMatcher(): NodeMatcher {
+    val matcher = DefaultNodeMatcher()
+
+    override fun match(
+        controlNodes: Iterable<Node?>?,
+        testNodes: Iterable<Node?>?
+    ): Iterable<Map.Entry<Node?, Node?>?>? {
+        return matcher.match(controlNodes, testNodes)
+    }
+}

--- a/ext/xmlunit/src/main/kotlin/com/xmlcalabash/ext/xmlunit/XmlUnitDocumentResolverProvider.kt
+++ b/ext/xmlunit/src/main/kotlin/com/xmlcalabash/ext/xmlunit/XmlUnitDocumentResolverProvider.kt
@@ -1,0 +1,8 @@
+package com.xmlcalabash.ext.xmlunit
+
+import com.xmlcalabash.util.SimpleDocumentResolverProvider
+import java.net.URI
+
+class XmlUnitDocumentResolverProvider: SimpleDocumentResolverProvider(
+    URI("https://xmlcalabash.com/ext/library/xmlunit.xpl"),
+    "/com/xmlcalabash/ext/xmlunit.xpl")

--- a/ext/xmlunit/src/main/kotlin/com/xmlcalabash/ext/xmlunit/XmlUnitStep.kt
+++ b/ext/xmlunit/src/main/kotlin/com/xmlcalabash/ext/xmlunit/XmlUnitStep.kt
@@ -1,0 +1,206 @@
+package com.xmlcalabash.ext.xmlunit
+
+import com.xmlcalabash.XmlCalabashBuildConfig
+import com.xmlcalabash.documents.XProcDocument
+import com.xmlcalabash.exceptions.XProcError
+import com.xmlcalabash.io.MediaType
+import com.xmlcalabash.namespace.*
+import com.xmlcalabash.steps.AbstractAtomicStep
+import com.xmlcalabash.util.MarkdownConfigurer
+import com.xmlcalabash.xvrl.XvrlLocation
+import com.xmlcalabash.xvrl.XvrlReport
+import com.xmlcalabash.xvrl.XvrlReportMetadata
+import net.sf.saxon.dom.DocumentOverNodeInfo
+import net.sf.saxon.s9api.*
+import net.sf.saxon.value.QNameValue
+import org.w3c.dom.Document
+import org.xmlunit.builder.DiffBuilder
+import org.xmlunit.builder.Input
+import org.xmlunit.diff.Comparison
+import org.xmlunit.diff.ComparisonListener
+import org.xmlunit.diff.ComparisonResult
+import org.xmlunit.diff.DefaultNodeMatcher
+import org.xmlunit.diff.Difference
+import org.xmlunit.diff.ElementSelector
+import org.xmlunit.diff.ElementSelectors
+import org.xmlunit.diff.NodeMatcher
+
+class XmlUnitStep(): AbstractAtomicStep() {
+    companion object {
+        private val _ignoreComments = QName("ignore-comments")
+        private val _ignoreWhitespace = QName("ignore-whitespace")
+        private val _normalizeWhitespace = QName("normalize-whitespace")
+        private val _checkFor = QName("check-for")
+        private val _elementSelector = QName("element-selector")
+        private val _attributeList = QName("attribute-list")
+        private val _nodeMatcherClass = QName("node-matcher-class")
+        private val _elementSelectorClass = QName("element-selector-class")
+    }
+    lateinit var source: XProcDocument
+    lateinit var alternate: XProcDocument
+
+    override fun run() {
+        super.run()
+
+        source = queues["source"]!!.first()
+        alternate = queues["alternate"]!!.first()
+
+        val reportFormat = stringBinding(Ns.reportFormat) ?: "xvrl"
+        val ignoreComments = booleanBinding(_ignoreComments) == true
+        val ignoreWhitespace = booleanBinding(_ignoreWhitespace) == true
+        val normalizeWhitespace = booleanBinding(_normalizeWhitespace) == true
+        val failIfNotEqual = booleanBinding(Ns.failIfNotEqual) == true
+        val checkFor = stringBinding(_checkFor)
+        val elementSelector = stringBinding(_elementSelector)
+        val nodeMatcherClass = stringBinding(_nodeMatcherClass)
+        val elementSelectorClass = stringBinding(_elementSelectorClass)
+
+        if (reportFormat != "xvrl") {
+            throw stepConfig.exception(XProcError.xcUnsupportedReportFormat(reportFormat))
+        }
+
+        val attributeList = mutableListOf<javax.xml.namespace.QName>()
+        if (_attributeList in options) {
+            val value = options[_attributeList]!!.value
+            for (item in value.iterator()) {
+                if (item.underlyingValue is QNameValue) {
+                    val qnameValue = item.underlyingValue as QNameValue
+                    attributeList.add(javax.xml.namespace.QName(qnameValue.namespaceURI.toString(), qnameValue.localName, qnameValue.prefix))
+                } else {
+                    throw stepConfig.exception(XProcError.xcxXmlUnitBadAttributeList(item.toString()))
+                }
+            }
+        }
+        if (attributeList.isNotEmpty() && elementSelector != "by-name-and-attributes") {
+            throw stepConfig.exception(XProcError.xcxXmlUnitAttributesSelector())
+        }
+
+        val elementSelectorImpl = if (elementSelectorClass != null) {
+            if (elementSelector != null) {
+                throw stepConfig.exception(XProcError.xcxXmlUnitElementSelectorAndClass())
+            } else {
+                val klass = Class.forName(elementSelectorClass)
+                try {
+                    klass.getConstructor().newInstance() as ElementSelector
+                } catch (ex: Exception) {
+                    throw stepConfig.exception(XProcError.xcxXmlUnitNotAnElementSelector(elementSelectorClass), ex)
+                }
+            }
+        } else {
+            when (elementSelector) {
+                null, "by-name" -> ElementSelectors.byName
+                "by-name-and-text" -> ElementSelectors.byNameAndText
+                "by-name-and-all-attributes" -> ElementSelectors.byNameAndAllAttributes
+                "by-name-and-attributes" -> {
+                    val namelist = attributeList.toTypedArray()
+                    ElementSelectors.byNameAndAttributes(*namelist)
+                }
+                else -> throw stepConfig.exception(XProcError.xcxXmlUnitUnexpectedElementSelector(elementSelector))
+            }
+        }
+
+        val nodeMatcherImpl = if (nodeMatcherClass != null) {
+            if (elementSelector != null) {
+                throw stepConfig.exception(XProcError.xcxXmlUnitElementSelectorAndNodeMatcher())
+            }
+            val klass = Class.forName(nodeMatcherClass)
+            try {
+                klass.getConstructor().newInstance() as NodeMatcher
+            } catch (ex: Exception) {
+                throw stepConfig.exception(XProcError.xcxXmlUnitNotANodeMatcher(nodeMatcherClass), ex)
+            }
+        } else {
+            DefaultNodeMatcher(elementSelectorImpl)
+        }
+
+        val sourceDoc = DocumentOverNodeInfo.wrap((source.value as XdmNode).underlyingNode) as Document
+        val altDoc = DocumentOverNodeInfo.wrap((alternate.value as XdmNode).underlyingNode) as Document
+
+        val control = Input.fromDocument(sourceDoc).build()
+        val test = Input.fromDocument(altDoc).build()
+
+        var diffBuilder = DiffBuilder.compare(control).withTest(test)
+        if (checkFor == "similarity") {
+            diffBuilder = diffBuilder.checkForSimilar()
+        } else {
+            diffBuilder = diffBuilder.checkForIdentical()
+        }
+        diffBuilder = diffBuilder.withNodeMatcher(nodeMatcherImpl)
+
+        if (ignoreComments) {
+            diffBuilder = diffBuilder.ignoreComments()
+        }
+
+        if (ignoreWhitespace) {
+            diffBuilder = diffBuilder.ignoreWhitespace()
+        }
+
+        if (normalizeWhitespace) {
+            diffBuilder = diffBuilder.normalizeWhitespace()
+        }
+
+        val diff = diffBuilder.build()
+
+        val diffmeta = mutableMapOf<QName, String>()
+        diffmeta[cx(_ignoreComments)] = "${ignoreComments}"
+        diffmeta[cx(_ignoreWhitespace)] = "${ignoreWhitespace}"
+        diffmeta[cx(_normalizeWhitespace)] = "${normalizeWhitespace}"
+        diffmeta[cx(_checkFor)] = "${checkFor}"
+        diffmeta[cx(_elementSelector)] = elementSelectorClass ?: elementSelector ?: "by-name"
+        nodeMatcherClass?.let { diffmeta[cx(_nodeMatcherClass)] = it }
+
+        if (attributeList.isNotEmpty()) {
+            val sb = StringBuilder()
+            for (attr in attributeList) {
+                sb.append(attr.toString()).append(" ")
+            }
+            diffmeta[cx(_attributeList)] = sb.toString().trim()
+        }
+
+        val report = XvrlReport.newInstance(stepConfig, diffmeta)
+        report.metadata.validator("xmlunit", XmlCalabashBuildConfig.DEPENDENCIES["xmlunit"] ?: "unknown")
+
+        for (comp in diff.differences) {
+            details(source, report, comp, comp.comparison.controlDetails)
+            details(alternate, report, comp, comp.comparison.testDetails)
+        }
+
+        val reportDoc = XProcDocument.ofXml(report.asXml(stepConfig.baseUri), stepConfig, MediaType.XML)
+
+        if (failIfNotEqual && diff.hasDifferences()) {
+            throw stepConfig.exception(XProcError.xcxXmlUnitComparisonFailed(reportDoc))
+        }
+
+        receiver.output("result", source)
+        receiver.output("report", reportDoc)
+    }
+
+    private fun details(doc: XProcDocument, report: XvrlReport, diff: Difference, details: Comparison.Detail) {
+        val severity = when (diff.result) {
+            ComparisonResult.EQUAL -> "info"
+            ComparisonResult.SIMILAR -> "warning"
+            else -> "error"
+        }
+
+        val loc = XvrlLocation.newInstance(stepConfig, doc.baseURI)
+        if (details.xPath != null) {
+            loc.xpath = details.xPath
+        }
+
+        val message = diff.toString()
+        val pos = message.indexOf(" - comparing")
+        val detection = if (pos >= 0) {
+            report.detection(severity, null, message.substring(0, pos))
+        } else {
+            report.detection(severity, null, message)
+        }
+
+        detection.location = loc
+    }
+
+    private fun cx(name: QName): QName {
+        return QName(NsCx.namespace, "cx:${name.localName}")
+    }
+
+    override fun toString(): String = "cx:xmlunit"
+}

--- a/ext/xmlunit/src/main/kotlin/com/xmlcalabash/ext/xmlunit/XmlUnitStepProvider.kt
+++ b/ext/xmlunit/src/main/kotlin/com/xmlcalabash/ext/xmlunit/XmlUnitStepProvider.kt
@@ -1,0 +1,9 @@
+package com.xmlcalabash.ext.xmlunit
+
+import com.xmlcalabash.namespace.NsCx
+import com.xmlcalabash.util.SimpleStepProvider
+import net.sf.saxon.s9api.QName
+
+class XmlUnitStepProvider: SimpleStepProvider(
+    QName(NsCx.namespace, "cx:xmlunit"),
+    { -> XmlUnitStep() })

--- a/ext/xmlunit/src/main/resources/META-INF/services/com.xmlcalabash.spi.AtomicStepProvider
+++ b/ext/xmlunit/src/main/resources/META-INF/services/com.xmlcalabash.spi.AtomicStepProvider
@@ -1,0 +1,1 @@
+com.xmlcalabash.ext.xmlunit.XmlUnitStepProvider

--- a/ext/xmlunit/src/main/resources/META-INF/services/com.xmlcalabash.spi.DocumentResolverProvider
+++ b/ext/xmlunit/src/main/resources/META-INF/services/com.xmlcalabash.spi.DocumentResolverProvider
@@ -1,0 +1,1 @@
+com.xmlcalabash.ext.xmlunit.XmlUnitDocumentResolverProvider

--- a/ext/xmlunit/src/main/resources/com/xmlcalabash/ext/xmlunit.xpl
+++ b/ext/xmlunit/src/main/resources/com/xmlcalabash/ext/xmlunit.xpl
@@ -1,0 +1,27 @@
+<p:library xmlns:p="http://www.w3.org/ns/xproc"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
+           xmlns:cx="http://xmlcalabash.com/ns/extensions"
+           version="3.0">
+
+<p:declare-step type="cx:xmlunit">
+  <p:input port="source" content-types="xml html"/>
+  <p:input port="alternate" content-types="xml html"/>
+  <p:output port="result" primary="true"/>
+  <p:output port="report" sequence="true"/>
+  <p:option name="check-for" as="xs:string?" values="('identity', 'similarity')"/>
+  <p:option name="element-selector" as="xs:string?" select="()"
+            values="('by-name', 'by-name-and-text', 'by-name-and-all-attributes',
+                     'by-name-and-attributes')"/>
+  <p:option name="attribute-list" as="xs:QName*"/>
+  <p:option name="report-format" select="'xvrl'" as="xs:string"/>
+  <p:option name="ignore-comments" select="false()" as="xs:boolean"/>
+  <p:option name="ignore-whitespace" select="false()" as="xs:boolean"/>
+  <p:option name="normalize-whitespace" select="false()" as="xs:boolean"/>  
+  <p:option name="fail-if-not-equal" as="xs:boolean" select="true()"/>
+
+  <p:option name="node-matcher-class" as="xs:string?"/>
+  <p:option name="element-selector-class" as="xs:string?"/>
+</p:declare-step>
+
+</p:library>

--- a/gradle.properties
+++ b/gradle.properties
@@ -43,3 +43,4 @@ jena=5.3.0
 semargl=0.7
 ditaa=0.9
 rr=2.1
+xmlunit=2.10.0

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,6 +15,5 @@ include("xmlcalabash", "app", "test-driver",
         "ext:polyglot", "ext:xpath", "ext:wait-for-update",
         "ext:diagramming", "ext:collection-manager",
         "template:kotlin", "template:java",
-        "ext:rdf",
-        "ext:railroad"
+        "ext:rdf", "ext:railroad", "ext:xmlunit"
     )

--- a/test-driver/build.gradle.kts
+++ b/test-driver/build.gradle.kts
@@ -42,6 +42,7 @@ dependencies {
   implementation(files("build/classes/kotlin/main"))
   implementation(project(":ext:railroad"))
   implementation(project(":ext:rdf"))
+  implementation(project(":ext:xmlunit"))
 
   transformation ("net.sf.saxon:Saxon-HE:${saxonVersion}")
 }

--- a/tests/extra-suite/test-suite/tests/xmlunit-001.xml
+++ b/tests/extra-suite/test-suite/tests/xmlunit-001.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+  <t:info>
+    <t:title>xmlunit-001</t:title>
+    <t:revision-history>
+      <t:revision>
+        <t:date>2025-02-21</t:date>
+        <t:author>
+          <t:name>Norm Tovey-Walsh</t:name>
+        </t:author>
+        <t:description xmlns="http://www.w3.org/1999/xhtml">
+          <p>Created test.</p>
+        </t:description>
+      </t:revision>
+    </t:revision-history>
+  </t:info>
+  <t:description xmlns="http://www.w3.org/1999/xhtml">
+    <p>Tests that identity comparison succeeds.</p>
+  </t:description>
+  <t:pipeline>
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                xmlns:cx="http://xmlcalabash.com/ns/extensions"
+                name="main" version="3.0">
+  <p:import href="https://xmlcalabash.com/ext/library/xmlunit.xpl"/>
+  <p:output port="result" sequence="true"/>
+
+  <cx:xmlunit>
+    <p:with-input port="source">
+      <flowers>
+	<flower>Roses</flower>
+	<flower>Daisy</flower>
+	<flower>Crocus</flower>
+      </flowers>
+    </p:with-input>
+    <p:with-input port="alternate">
+      <flowers>
+	<flower>Roses</flower>
+	<flower>Daisy</flower>
+	<flower>Crocus</flower>
+      </flowers>
+    </p:with-input>
+  </cx:xmlunit>
+</p:declare-step>
+  </t:pipeline>
+  <t:schematron>
+    <s:schema queryBinding="xslt2"
+              xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:pattern>
+        <s:rule context="/">
+          <s:assert test="flowers">The output is wrong.</s:assert>
+        </s:rule>
+      </s:pattern>
+    </s:schema>
+  </t:schematron>
+</t:test>

--- a/tests/extra-suite/test-suite/tests/xmlunit-002.xml
+++ b/tests/extra-suite/test-suite/tests/xmlunit-002.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="fail" code="cxerr:XC0014"
+        xmlns:cxerr="http://xmlcalabash.com/ns/error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+  <t:info>
+    <t:title>xmlunit-002</t:title>
+    <t:revision-history>
+      <t:revision>
+        <t:date>2025-02-21</t:date>
+        <t:author>
+          <t:name>Norm Tovey-Walsh</t:name>
+        </t:author>
+        <t:description xmlns="http://www.w3.org/1999/xhtml">
+          <p>Created test.</p>
+        </t:description>
+      </t:revision>
+    </t:revision-history>
+  </t:info>
+  <t:description xmlns="http://www.w3.org/1999/xhtml">
+    <p>Tests that identity comparison fails.</p>
+  </t:description>
+  <t:pipeline>
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                xmlns:cx="http://xmlcalabash.com/ns/extensions"
+                name="main" version="3.0">
+  <p:import href="https://xmlcalabash.com/ext/library/xmlunit.xpl"/>
+  <p:output port="result" sequence="true"/>
+
+  <cx:xmlunit>
+    <p:with-input port="source">
+      <flowers>
+	<flower>Daisy</flower>
+	<flower>Roses</flower>
+	<flower>Crocus</flower>
+      </flowers>
+    </p:with-input>
+    <p:with-input port="alternate">
+      <flowers>
+	<flower>Roses</flower>
+	<flower>Daisy</flower>
+	<flower>Crocus</flower>
+      </flowers>
+    </p:with-input>
+  </cx:xmlunit>
+</p:declare-step>
+  </t:pipeline>
+</t:test>

--- a/tests/extra-suite/test-suite/tests/xmlunit-003.xml
+++ b/tests/extra-suite/test-suite/tests/xmlunit-003.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass"
+        xmlns:cxerr="http://xmlcalabash.com/ns/error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+  <t:info>
+    <t:title>xmlunit-003</t:title>
+    <t:revision-history>
+      <t:revision>
+        <t:date>2025-02-21</t:date>
+        <t:author>
+          <t:name>Norm Tovey-Walsh</t:name>
+        </t:author>
+        <t:description xmlns="http://www.w3.org/1999/xhtml">
+          <p>Created test.</p>
+        </t:description>
+      </t:revision>
+    </t:revision-history>
+  </t:info>
+  <t:description xmlns="http://www.w3.org/1999/xhtml">
+    <p>Tests that documents can be similar.</p>
+  </t:description>
+  <t:pipeline>
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                xmlns:cx="http://xmlcalabash.com/ns/extensions"
+                name="main" version="3.0">
+  <p:import href="https://xmlcalabash.com/ext/library/xmlunit.xpl"/>
+  <p:output port="result" sequence="true"/>
+
+  <cx:xmlunit check-for="similarity" element-selector="by-name-and-text">
+    <p:with-input port="source">
+      <flowers>
+	<flower>Daisy</flower>
+	<flower>Roses</flower>
+	<flower>Crocus</flower>
+      </flowers>
+    </p:with-input>
+    <p:with-input port="alternate">
+      <flowers>
+	<flower>Roses</flower>
+	<flower>Daisy</flower>
+	<flower>Crocus</flower>
+      </flowers>
+    </p:with-input>
+  </cx:xmlunit>
+</p:declare-step>
+  </t:pipeline>
+  <t:schematron>
+    <s:schema queryBinding="xslt2"
+              xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:pattern>
+        <s:rule context="/">
+          <s:assert test="flowers">The output is wrong.</s:assert>
+        </s:rule>
+      </s:pattern>
+    </s:schema>
+  </t:schematron>
+</t:test>

--- a/tests/extra-suite/test-suite/tests/xmlunit-004.xml
+++ b/tests/extra-suite/test-suite/tests/xmlunit-004.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass"
+        xmlns:cxerr="http://xmlcalabash.com/ns/error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+  <t:info>
+    <t:title>xmlunit-004</t:title>
+    <t:revision-history>
+      <t:revision>
+        <t:date>2025-02-21</t:date>
+        <t:author>
+          <t:name>Norm Tovey-Walsh</t:name>
+        </t:author>
+        <t:description xmlns="http://www.w3.org/1999/xhtml">
+          <p>Created test.</p>
+        </t:description>
+      </t:revision>
+    </t:revision-history>
+  </t:info>
+  <t:description xmlns="http://www.w3.org/1999/xhtml">
+    <p>Tests that differences are reported.</p>
+  </t:description>
+  <t:pipeline>
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                xmlns:cx="http://xmlcalabash.com/ns/extensions"
+                name="main" version="3.0">
+  <p:import href="https://xmlcalabash.com/ext/library/xmlunit.xpl"/>
+  <p:output port="result" sequence="true" pipe="report"/>
+
+  <cx:xmlunit check-for="identity" fail-if-not-equal="false">
+    <p:with-input port="source">
+      <flowers>
+	<flower>Daisy</flower>
+	<flower>Roses</flower>
+	<flower>Crocus</flower>
+      </flowers>
+    </p:with-input>
+    <p:with-input port="alternate">
+      <flowers>
+	<flower>Roses</flower>
+	<flower>Daisy</flower>
+	<flower>Crocus</flower>
+      </flowers>
+    </p:with-input>
+  </cx:xmlunit>
+</p:declare-step>
+  </t:pipeline>
+  <t:schematron>
+    <s:schema queryBinding="xslt2"
+              xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:ns prefix="xvrl" uri="http://www.xproc.org/ns/xvrl"/>
+      <s:pattern>
+        <s:rule context="/">
+          <s:assert test="xvrl:report">The output is not an XVRL report.</s:assert>
+          <s:assert test="xvrl:report/xvrl:metadata/xvrl:validator/@name = 'xmlunit'"
+                    >The validator is incorrect.</s:assert>
+          <s:assert test="xvrl:report/xvrl:digest/@error-count = 4"
+                    >The error count is incorrect.</s:assert>
+        </s:rule>
+      </s:pattern>
+    </s:schema>
+  </t:schematron>
+</t:test>

--- a/xmlcalabash/build.gradle.kts
+++ b/xmlcalabash/build.gradle.kts
@@ -152,11 +152,12 @@ buildConfig {
                   "tukaaniXz",
                   "uuidCreator",
                   "xercesImpl",
-                  "xmlResolver"
+                  "xmlResolver",
+                  "xmlunit"
   ).forEach { dep ->
     sb.append("  \"").append(dep).append("\" to ")
     sb.append("\"").append(project.findProperty(dep).toString()).append("\"")
-    if (dep != "xmlResolver") {
+    if (dep != "xmlunit") {
       sb.append(",")
     }
     sb.append("\n")

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/XProcError.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/XProcError.kt
@@ -376,6 +376,15 @@ open class XProcError protected constructor(val code: QName, val variant: Int, e
         fun xcxUnsupportedContentType(contentType: MediaType) = xstep(12, contentType)
         fun xcxUnrecognizedRdfContentType(contentType: MediaType) = xstep(13, contentType)
 
+        fun xcxXmlUnitComparisonFailed(xvrl:XProcDocument) = xstep(14, xvrl)
+        fun xcxXmlUnitBadAttributeList(bad: String) = xstep(15)
+        fun xcxXmlUnitAttributesSelector() = xstep(16)
+        fun xcxXmlUnitElementSelectorAndClass() = xstep(17)
+        fun xcxXmlUnitNotAnElementSelector(klass: String) = xstep(18, klass)
+        fun xcxXmlUnitUnexpectedElementSelector(name: String) = xstep(19, name)
+        fun xcxXmlUnitElementSelectorAndNodeMatcher() = xstep(20)
+        fun xcxXmlUnitNotANodeMatcher(klass: String) = xstep(21, klass)
+
         fun xiNoSuchOutputPort(port: String)= internal(1, port)
         fun xiImpossibleNodeType(type: XdmNodeKind) = internal(2, type)
         fun xiThreadInterrupted() = internal(3)

--- a/xmlcalabash/src/main/resources/com/xmlcalabash/explain-errors.txt
+++ b/xmlcalabash/src/main/resources/com/xmlcalabash/explain-errors.txt
@@ -1409,6 +1409,30 @@ cxerr:XC0013
 Unrecognized RDF content type: $1
 Only recognized content types can be parsed as RDF.
 
+cxerr:XC0014
+Comparison failed: XMLUnit found differences.
+
+cxerr:XC0015
+An attribute-list must be a list of QNames: “$1” not allowed.
+
+cxerr:XC0016
+Only element selector by-name-and-attributes has attribute-list.
+
+cxerr:XC0017
+The element-selector and element-selector-class options are mutually exclusive.
+
+cxerr:XC0018
+Failed to instantiate “$1” as an ElementSelector.
+
+cxerr:XC0019
+Unexpected element-selector: “$1”.
+
+cxerr:XC0020
+The element-selector and node-matcher-class options are mutually exclusive.
+
+cxerr:XC0021
+Failed to instantiate “$1” as a NodeMatcher.
+
 cxerr:XI0001
 Pipeline has no “$1” output port.
 Cannot save the output from a port that doesn’t exist.


### PR DESCRIPTION
This implements document comparisons with XMLUnit. It doesn’t support everything that XMLUnit can do, but it supports many of the options.