### PR TITLE
Fix document base URIs with relative xml:base attributes

### DIFF
--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/ProcessMatch.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/ProcessMatch.kt
@@ -41,7 +41,7 @@ class ProcessMatch(val stepConfig: XProcStepConfiguration,
 
         // If we start a match at an element, fake a document wrapper
         if (doc.nodeKind != XdmNodeKind.DOCUMENT) {
-            startDocument(doc.baseURI)
+            startDocument(doc.parent.baseURI)
         }
 
         traverse(doc)

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/internal/SelectStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/internal/SelectStep.kt
@@ -20,11 +20,12 @@ open class SelectStep(val params: SelectStepParameters): AbstractAtomicStep() {
             }
 
             val result = params.select.evaluate(params.select.stepConfig)
+
             for (doc in S9Api.makeDocuments(params.select.stepConfig, result)) {
                 receiver.output("result", doc)
             }
         }
     }
 
-    override fun toString(): String = "cx:selector"
+    override fun toString(): String = "cx:select"
 }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/S9Api.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/S9Api.kt
@@ -183,13 +183,21 @@ class S9Api {
                             throw XProcError.xdInvalidSelection(value.nodeName).exception()
                         }
 
+                        // Special case for a document element with a relative base URI. Make sure that the base
+                        // URI that will get computed for the document element will be correct.
+                        val baseUri = if (value.getAttributeValue(NsXml.base) != null && !URI(value.getAttributeValue(NsXml.base)).isAbsolute) {
+                            value.parent.baseURI
+                        } else {
+                            value.baseURI
+                        }
+
                         val props = DocumentProperties()
-                        if (value.baseURI != null) {
-                            props[Ns.baseUri] = value.baseURI
+                        if (baseUri != null) {
+                            props[Ns.baseUri] = baseUri
                         }
 
                         val builder = SaxonTreeBuilder(stepConfig.processor)
-                        builder.startDocument(value.baseURI)
+                        builder.startDocument(baseUri)
                         builder.addSubtree(value)
                         builder.endDocument()
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/XmlViewportComposer.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/XmlViewportComposer.kt
@@ -89,7 +89,16 @@ class XmlViewportComposer(val stepConfig: XProcStepConfiguration, val match: Str
 
         override fun startElement(node: XdmNode, attributes: AttributeMap): Boolean {
             val builder = SaxonTreeBuilder(stepConfig)
-            builder.startDocument(node.baseURI)
+
+            // Special case for a document element with a relative base URI. Make sure that the base
+            // URI that will get computed for the document element will be correct.
+            val baseUri = if (node.getAttributeValue(NsXml.base) != null && !URI(node.getAttributeValue(NsXml.base)).isAbsolute) {
+                node.parent.baseURI
+            } else {
+                node.baseURI
+            }
+
+            builder.startDocument(baseUri)
             builder.addSubtree(node)
             builder.endDocument()
             viewportItems.add(XmlViewportItem(stepConfig, builder.result))


### PR DESCRIPTION
See https://lists.w3.org/Archives/Public/xproc-dev/2025Feb/0013.html

Basically, if you use select or match to select portions of a document, the processor has to make sure that a relative xml:base attribute on the document element will be resolved correctly.