### PR TITLE
Fix bugs related to [p:]message

### DIFF
--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/parsers/xpl/XplParser.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/parsers/xpl/XplParser.kt
@@ -1012,7 +1012,7 @@ class XplParser internal constructor(val builder: PipelineBuilder) {
                     else -> {
                         if ((atomic.instructionType.namespaceUri == NsP.namespace && name == Ns.message)
                             || (atomic.instructionType.namespaceUri != NsP.namespace && name == NsP.message)) {
-                            atomic.withOption(name, XProcExpression.avt(atomic.stepConfig, value))
+                            atomic.message(XProcExpression.avt(atomic.stepConfig, value))
                         } else {
                             if (name.namespaceUri != NamespaceUri.NULL) {
                                 atomic.setExtensionAttribute(name, value)

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/CompoundStepHead.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/CompoundStepHead.kt
@@ -1,5 +1,6 @@
 package com.xmlcalabash.runtime.steps
 
+import com.xmlcalabash.datamodel.DeclareStepInstruction
 import com.xmlcalabash.documents.XProcDocument
 import com.xmlcalabash.exceptions.XProcError
 import com.xmlcalabash.namespace.Ns
@@ -134,11 +135,18 @@ class CompoundStepHead(config: XProcStepConfiguration, val parent: CompoundStep,
     }
 
     override fun prepare() {
-        for ((name, details) in staticOptions) {
-            if ((parent.type.namespaceUri == NsP.namespace && name == Ns.message)
-                || (parent.type.namespaceUri != NsP.namespace && name == NsP.message)) {
-                message = details.staticValue.evaluate(stepConfig)
-            }
+        val ns = if (parent is PipelineStep && parent.stepType != null) {
+            parent.stepType!!.namespaceUri
+        } else {
+            parent.type.namespaceUri
+        }
+        val matchingName = if (ns == NsP.namespace) {
+            Ns.message
+        } else {
+            NsP.message
+        }
+        if (matchingName in staticOptions) {
+            message = staticOptions[matchingName]!!.staticValue.evaluate(stepConfig)
         }
     }
 


### PR DESCRIPTION
If a message attribute occurs on a declared step, make sure it gets output when the step is run. (The problem here was namespace confusion at runtime.)

Fix #304

The message attribute is implemented as an option (because that’s the easy way to work out the value of AVTs with variable and function references), but it isn’t an option. Don’t accept it in p:with-options.

Fix #308