### PR TITLE
Bundle CoffeeSacks in the application; automatically register it

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,6 +32,7 @@ val waitForUpdateRelease by configurations.dependencyScope("waitforUpdateRelease
 val collectionManagerRelease by configurations.dependencyScope("collectionManagerRelease")
 
 val dep_slf4j = project.findProperty("slf4j").toString()
+val dep_nineml = project.findProperty("nineml").toString()
 
 dependencies {
   xmlcalabashRelease(project(mapOf("path" to ":xmlcalabash",
@@ -85,6 +86,7 @@ dependencies {
   implementation(project(":ext:xmlunit"))
   implementation(project(":ext:xpath"))
 
+  implementation("org.nineml:coffeesacks:${dep_nineml}")
   implementation("org.slf4j:slf4j-api:${dep_slf4j}")
 }
 


### PR DESCRIPTION
When XML Calabash starts, if the user hasn’t specified the CoffeeSacks registration class on the command line with --init, automatically attempt to register it. On the off chance that CoffeeSacks isn’t on the class path, ignore any errors that occur in this case.

Fix #319