### PR TITLE
Make sure that secondary input ports are bound correctly

### DIFF
--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/WithInputInstruction.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/WithInputInstruction.kt
@@ -18,7 +18,12 @@ open class WithInputInstruction(parent: XProcInstruction, stepConfig: Instructio
         // elaboration might add a connection
         val connected = children.isNotEmpty() || href != null || pipe != null
 
-        if (!connected && primary != false) {
+        var connectDrp = !connected && primary == true
+        if (!connectDrp && !connected && parent != null) {
+            connectDrp = parent!!.instructionType in listOf(NsP.forEach, NsP.viewport)
+        }
+
+        if (!connected && connectDrp) {
             if (stepConfig.drp != null) {
                 pipe()
             } else {


### PR DESCRIPTION
Fix #325

A secondary input *is not* bound to the default readable port if there’s no explicit connection for it. Instead, it’s bound to the input port’s default connection. (This was, mostly, the discinction between `primary != null` and `primary != false`)