### PR TITLE
Tidy up some aspects of XML Schema validation

### DIFF
--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/XsltStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/XsltStep.kt
@@ -157,6 +157,12 @@ open class XsltStep(): AbstractAtomicStep() {
         val collectionFinder = config.collectionFinder
         val unparsedTextURIResolver = config.unparsedTextURIResolver
 
+        val manager = stepConfig.processor.getSchemaManager()
+        if (manager != null) {
+            manager.errorReporter = errorReporter
+            manager.schemaURIResolver = XsdResolver(stepConfig)
+        }
+
         val compiler = processor.newXsltCompiler()
         compiler.isSchemaAware = processor.isSchemaAware
         compiler.errorReporter = errorReporter
@@ -190,6 +196,10 @@ open class XsltStep(): AbstractAtomicStep() {
         }
 
         val transformer = exec.load30()
+
+        transformer.setSchemaValidationMode(ValidationMode.DEFAULT)
+        transformer.getUnderlyingController().setUnparsedTextURIResolver(unparsedTextURIResolver)
+
         transformer.resourceResolver = stepConfig.environment.documentManager
         transformer.setResultDocumentHandler(DocumentHandler())
         transformer.setStylesheetParameters(parameters)
@@ -293,9 +303,6 @@ open class XsltStep(): AbstractAtomicStep() {
                 }
             }
         }
-
-        transformer.setSchemaValidationMode(ValidationMode.DEFAULT)
-        transformer.getUnderlyingController().setUnparsedTextURIResolver(unparsedTextURIResolver)
 
         if (globalContextItem != null && globalContextItem!!.value != XdmEmptySequence.getInstance()) {
             transformer.setGlobalContextItem(globalContextItem!!.value as XdmItem)

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/validation/ValidateWithXmlSchema.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/validation/ValidateWithXmlSchema.kt
@@ -12,6 +12,7 @@ import com.xmlcalabash.runtime.parameters.RuntimeStepParameters
 import com.xmlcalabash.steps.AbstractAtomicStep
 import com.xmlcalabash.util.S9Api
 import com.xmlcalabash.util.SaxonErrorReporter
+import com.xmlcalabash.util.XsdResolver
 import net.sf.saxon.Configuration
 import net.sf.saxon.Controller
 import net.sf.saxon.lib.SchemaURIResolver
@@ -54,7 +55,7 @@ open class ValidateWithXmlSchema(): AbstractAtomicStep() {
         }
 
         manager.errorReporter = errorReporter
-        manager.schemaURIResolver = XsdResolver()
+        manager.schemaURIResolver = XsdResolver(stepConfig)
 
         validateWithSaxon(manager)
     }
@@ -234,14 +235,4 @@ open class ValidateWithXmlSchema(): AbstractAtomicStep() {
     }
 
     override fun toString(): String = "p:validate-with-xml-schema"
-
-    inner class XsdResolver(): SchemaURIResolver {
-        override fun setConfiguration(config: Configuration?) {
-            // I don't care???
-        }
-
-        override fun resolve(moduleURI: String?, baseURI: String?, locations: Array<out String>?): Array<StreamSource>? {
-            return stepConfig.environment.documentManager.resolve(moduleURI, baseURI, locations)
-        }
-    }
 }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/XsdResolver.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/XsdResolver.kt
@@ -1,0 +1,16 @@
+package com.xmlcalabash.util
+
+import com.xmlcalabash.runtime.XProcStepConfiguration
+import net.sf.saxon.Configuration
+import net.sf.saxon.lib.SchemaURIResolver
+import javax.xml.transform.stream.StreamSource
+
+class XsdResolver(val stepConfig: XProcStepConfiguration): SchemaURIResolver {
+    override fun setConfiguration(p0: Configuration?) {
+        // I don't care???
+    }
+
+    override fun resolve(moduleURI: String?, baseURI: String?, locations: Array<out String>?): Array<StreamSource>? {
+        return stepConfig.environment.documentManager.resolve(moduleURI, baseURI, locations)
+    }
+}


### PR DESCRIPTION
Make sure that the p:xslt step configures the schema manager.

(This doesn’t really fix anything in #330 because I’m not convinced the behavior described in that bug is an error. These are just some things I discovered while I was investigating.)