### PR TITLE
Experimental implementation of implicit validation of primary inputs

### DIFF
--- a/documentation/src/userguide/config.xml
+++ b/documentation/src/userguide/config.xml
@@ -56,7 +56,7 @@ The command-line setting takes precedence.</para>
 linkend="cli-verbosity">on the command line</link>. The command-line setting takes precedence.</para>
 </listitem>
 </varlistentry>
-<varlistentry><term><tag class="attribute">piped-io</tag></term>
+<varlistentry><term><tag class="attribute">piped-io</tag> (boolean)</term>
 <listitem>
 <para>If <tag class="attribute">piped-io</tag> is <literal>true</literal>, XML Calabash
 will behave like a Unix pipeline. If there is no binding for the primary input port, it will
@@ -71,7 +71,7 @@ on the primary input port. It will be parsed as XML if the primary input port do
 specify any content types.</para>
 </listitem>
 </varlistentry>
-<varlistentry><term><tag class="attribute">console-output-encoding</tag></term>
+<varlistentry><term><tag class="attribute">console-output-encoding</tag> (string)</term>
 <listitem>
 <para>When XML Calabash writes to the console, it attempts to make sure that
 the output is consistent with the <tag class="attribute">console-output-encoding</tag>.
@@ -81,12 +81,60 @@ by default, on other platforms it is
 <link xlink:href="https://en.wikipedia.org/wiki/UTF-8">UTF-8</link> by default.</para>
 </listitem>
 </varlistentry>
+
+<varlistentry><term><tag class="attribute">validation-mode</tag> (“lax” or “strict”)</term>
+<listitem>
+<para>Specifies a validation mode for <link linkend="implicit-validation">implicit validation</link>.
+This can also be specified
+<link linkend="cli-validation-mode">on the command line</link>.
+The command-line setting takes precedence.</para>
+</listitem>
+</varlistentry>
+<varlistentry><term><tag class="attribute">use-location-hints</tag> (boolean)</term>
+<listitem>
+<para>If true, <link linkend="implicit-validation">implicit validation</link> will
+use location hints to locate schemas.
+This can also be specified
+<link linkend="cli-use-location-hints">on the command line</link>.
+The command-line setting takes precedence.</para>
+</listitem>
+</varlistentry>
+<varlistentry><term><tag class="attribute">try-namespaces</tag> (boolean)</term>
+<listitem>
+<para>If true, <link linkend="implicit-validation">implicit validation</link> will
+attempt to retrieve the schema using the namespace URI.
+This can also be specified
+<link linkend="cli-try-namespaces">on the command line</link>.
+The command-line setting takes precedence.</para>
+</listitem>
+</varlistentry>
 </variablelist>
 
 <para>For simplicity, the content model of <tag>cc:xml-calabash</tag> allows every element to
 occur an arbitrary number of times. Where an element defines a single, global setting, the last
 value in document order applies.</para>
 
+</section>
+
+<section xml:id="cc.catalog">
+<info>
+<?db filename="cc-catalog"?>
+<title>cc:catalog</title>
+</info>
+
+<para>Adds the specified catalog to the list of XML Catalogs used during resource
+resolution.</para>
+
+<rng-pattern schema="../../build/xml-calabash.rng"
+             name="cc.catalog"/>
+
+<variablelist>
+<varlistentry><term><tag class="attribute">href</tag> (URI)</term>
+<listitem>
+<para>Location of the catalog file.</para>
+</listitem>
+</varlistentry>
+</variablelist>
 </section>
 
 <section xml:id="cc.graphviz">
@@ -108,7 +156,6 @@ executable. Making SVG diagrams of pipelines or graphs requires Graphviz.</para>
 </listitem>
 </varlistentry>
 </variablelist>
-
 </section>
 
 <section xml:id="cc.inline">
@@ -497,7 +544,32 @@ the documents produced during execution are recorded. (Defaults to false.)</para
 </variablelist>
 
 <para>Irrelevant at the moment. XML Calabash is currently single-threaded.</para>
+</section>
 
+<section xml:id="cc.xml-schema">
+<info>
+<?db filename="cc-xml-schema"?>
+<title>cc:xml-schema</title>
+</info>
+
+<para>Adds the specified XML Schema to the global validation context.</para>
+
+<rng-pattern schema="../../build/xml-calabash.rng"
+             name="cc.xmlSchema"/>
+
+<variablelist>
+<varlistentry><term><tag class="attribute">href</tag> (URI)</term>
+<listitem>
+<para>Location of the schema file.</para>
+</listitem>
+</varlistentry>
+</variablelist>
+
+<para>Alternatively, the XML Schema document (or documents) can be children of
+the <tag>cc:xml-schema</tag> element. The RELAX NG grammar for configuration
+files will allow any element as a child of <tag>cc:xml-schema</tag>, but in practice
+only <tag>xsd:schema</tag> elements are allowed.
+</para>
 </section>
 
 <section xml:id="cc.any-name">

--- a/documentation/src/userguide/run.xml
+++ b/documentation/src/userguide/run.xml
@@ -85,7 +85,12 @@ given, the <command>run</command> command is assumed.</para>
   <sbr/>
   <arg rep="norepeat" linkend="cli-licensed">--licensed</arg>
   <arg rep="norepeat" linkend="cli-debug">--debug</arg>
-  <arg rep="norepeat" linkend="cli-debug">--debugger</arg>
+  <arg rep="norepeat" linkend="cli-debugger">--debugger</arg>
+  <arg rep="repeat" linkend="cli-catalog">--catalog:<replaceable>catalog-file-uri</replaceable></arg>
+  <arg rep="repeat" linkend="cli-xml-schema">--xml-schema:<replaceable>xml-schema-file-uri</replaceable></arg>
+  <arg rep="norepeat" linkend="cli-validation-mode">--validation-mode:<replaceable>mode</replaceable></arg>
+  <arg rep="norepeat" linkend="cli-try-namespaces">--try-namespaces</arg>
+  <arg rep="norepeat" linkend="cli-use-location-hints">--use-location-hints</arg>
   <arg rep="norepeat" linkend="cli-help">--help</arg>
   <sbr/>
   <arg rep="norepeat" linkend="cli-step">--step:<replaceable>step-name</replaceable></arg>
@@ -423,7 +428,42 @@ You can configure it in the usual ways.</para>
 See <xref linkend="debugging"/>.</para>
 </listitem>
 </varlistentry>
-
+<varlistentry xml:id="cli-catalog">
+  <term><option>--catalog:<replaceable>catalog-file-uri</replaceable></option></term>
+<listitem>
+<para>Adds the specified catalog to the list of XML Catalogs that are used 
+during resource resolution.</para>
+</listitem>
+</varlistentry>
+<varlistentry xml:id="cli-xml-schema">
+  <term><option>--xml-schema:<replaceable>xml-schema-file-uri</replaceable></option></term>
+<listitem>
+<para>Adds the specified XML Schema to the validation context. This schema will
+be available in both <link linkend="implicit-validation">implicit validation</link> and
+when the <tag>p:validate-with-xml-schema</tag> step is used.</para>
+</listitem>
+</varlistentry>
+<varlistentry xml:id="cli-validation-mode">
+  <term><option>--validation-mode:<replaceable>mode</replaceable></option></term>
+<listitem>
+<para>This option enables <link linkend="implicit-validation">implicit validation</link>.
+The mode must be either “lax” or “strict”.</para>
+</listitem>
+</varlistentry>
+<varlistentry xml:id="cli-try-namespaces">
+  <term><option>----try-namespaces</option></term>
+<listitem>
+<para>This option enables attempting to retrieve a schema using its namespace URI
+during <link linkend="implicit-validation">implicit validation</link>.</para>
+</listitem>
+</varlistentry>
+<varlistentry xml:id="cli-use-location-hints">
+  <term><option>--use-location-hints</option></term>
+<listitem>
+<para>This option enables attempting to retrieve a schema using location hints
+during <link linkend="implicit-validation">implicit validation</link>.</para>
+</listitem>
+</varlistentry>
 <varlistentry xml:id="cli-help">
   <term><option>--help</option></term>
 <listitem>

--- a/documentation/src/userguide/tracing.xml
+++ b/documentation/src/userguide/tracing.xml
@@ -88,6 +88,22 @@ type <tag>p:declare-step</tag>. That represents the invocation of their subpipel
 It may also include documents.</para>
 
 </section>
+
+<section xml:id="t.resource">
+<title>Resources</title>
+
+<rng-pattern schema="../../build/trace.rng"
+             name="t.resource"/>
+
+<para>The <tag>t:resource</tag> element records resources loaded by the pipeline.
+The <tag class="attribute">uri</tag> attribute is the resource loaded; if the
+<tag class="attribute">href</tag> attribute is present, that’s the originally 
+requested URI. If <tag class="attribute">resolved</tag> is true, the resource
+was resolved locally. If <tag class="attribute">cached</tag> is true, the resource
+was found in the cache.
+</para>
+</section>
+
 <section xml:id="t.document">
 <title>Documents</title>
 

--- a/documentation/src/userguide/userguide.xml
+++ b/documentation/src/userguide/userguide.xml
@@ -27,6 +27,7 @@
 -->
 <xi:include href="install.xml"/>
 <xi:include href="run.xml"/>
+<xi:include href="validation.xml"/>
 <xi:include href="graphs.xml"/>
 <xi:include href="logging.xml"/>
 <xi:include href="errors.xml"/>

--- a/documentation/src/userguide/validation.xml
+++ b/documentation/src/userguide/validation.xml
@@ -1,0 +1,120 @@
+<chapter xmlns="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:xi='http://www.w3.org/2001/XInclude'
+         version="5.2" xml:id="implicit-validation">
+<info>
+  <?db filename="validation"?>
+  <title>Implicit validation</title>
+</info>
+
+<important>
+<para>This is an experimental feature. The design may change in subsequent releases.</para>
+</important>
+
+<para>The XProc validation steps (<tag>p:validate-with-nvdl</tag>,
+<tag>p:validate-with-relax-ng</tag>,
+<tag>p:validate-with-schematron</tag>,
+<tag>p:validate-with-xml-schema</tag>,
+<tag>p:validate-with-json-schema</tag>,
+and <tag>validate-with-dtd</tag>) provide flexible, robust options for
+validation. But in the XPath data model, XML Schema validation has a special
+significance because it can effect the types of elements and attributes in XML documents.</para>
+
+<para>If you are using Saxon EE, you can enable implicit validation of inputs.
+This is not as flexible as using the <tag>p:validate-with-xml-schema</tag> step, but
+it offers a level of convenience.</para>
+
+<note>
+<para>This is an implementation-defined extension. Pipelines that rely on
+implicit validation may not run, or may produce unexpected results, when another
+XProc processor is used.</para>
+</note>
+
+<para>When implicit validation is enabled, it applies to one or more steps. When
+implicit validation is in force for a step, all the XML documents that appear on
+the step’s primary input port will be XML Schema validated. The step will throw
+an exception if validation fails.</para>
+
+<para>Implicit validation doesn’t apply to non-primary input ports. If
+validation applied to all ports, then you’d have to have an XML Schema for XSLT
+stylesheets to use the <tag>p:xslt</tag> step, and a schema for any document
+fragments that you were inserting with <tag>p:insert</tag>, etc.</para>
+
+<para>You can validate non-primary inputs with an explicit validation step or by
+passing them through the primary input port of some other step, such as
+<tag>p:identity</tag>.</para>
+
+
+<para>There’s only one, global context for schemas and catalogs. You can’t
+load different schemas for the same namespace in different steps, nor can you
+have a catalog that applies to only some steps.</para>
+
+<section>
+<title>From the configuration file</title>
+
+<para>Setting the
+<tag class="attribute" linkend="cc.xml-calabash">cc:validation-mode</tag> in the
+configuration file applies implicit validation to all steps. The validation
+mode can be either strict or lax.</para>
+
+<para>If <tag class="attribute" linkend="cc.xml-calabash">cc:try-namespaces</tag> is
+true, implicit validation will attempt to locate a schema using the namespace URI.
+(If a schema is not already loaded.)</para>
+
+<para>If <tag class="attribute" linkend="cc.xml-calabash">cc:use-location-hints</tag> is
+true, implicit validation will attempt to locate a schema using schema location hints
+in the source document. (If a schema is not already loaded.)</para>
+
+<para>Additional schema documents can be loaded directly from the configuration
+file with <tag linkend="cc.xml-schema">cc:xml-schema</tag> elements.</para>
+
+<para>Additional catalogs, consulted when trying the namespace URI to locate a
+schema, can be added directly from the configuration file with
+<tag linkend="cc.catalog">cc:catalog</tag> elements.</para>
+
+</section>
+
+<section>
+<title>From the command line</title>
+
+<para>Options specified on the command line take precedence over any values
+specified in the configuration file.</para>
+
+<para>Using the
+<option linkend="cli-validation-mode">--validation-mode</option> option
+applies implicit validation to all steps. The validation
+mode can be either strict or lax.</para>
+
+<para>If <option linkend="cli-try-namespaces">--try-namespaces</option> is
+specified, implicit validation will attempt to locate a schema using the namespace URI.
+(If a schema is not already loaded.)</para>
+
+<para>If <option linkend="cli-use-location-hints">--use-location-hints</option> is
+specified, implicit validation will attempt to locate a schema using schema location hints
+in the source document. (If a schema is not already loaded.)</para>
+
+<para>Additional schema documents can be loaded from the command
+line with the <option linkend="cli-xml-schema">--xml-schema</option> option.</para>
+
+<para>Additional catalogs, consulted when trying the namespace URI to locate a
+schema, can be loaded from the command line with the
+<option linkend="cli-catalog">--catalog</option> option.</para>
+
+</section>
+
+<section>
+<title>From a pipeline</title>
+
+<para>Putting the <tag class="attribute">cx:validation-mode</tag> attribute on
+a step enables implicit validation for that step. Specified on <tag>p:declare-step</tag>,
+it applies to all instances of that step type.</para>
+
+<para>A pipeline can include <tag>cx:use-catalog</tag> and <tag>cx:import-schema</tag>
+directives in a <tag>p:pipeinfo</tag> to load additional catalogs or schemas.</para>
+
+<para>All of the catalogs and schemas declared in any step type that could be
+called are loaded before execution begins.</para>
+
+</section>
+
+</chapter>

--- a/tests/extra-suite/test-suite/documents/document.xsd
+++ b/tests/extra-suite/test-suite/documents/document.xsd
@@ -1,0 +1,49 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	   elementFormDefault="qualified">
+  <xs:element name="doc">
+    <xs:complexType>
+      <xs:sequence>
+	<xs:element minOccurs="0" ref="title"/>
+	<xs:element minOccurs="0" maxOccurs="unbounded" ref="p"/>
+	<xs:element minOccurs="0" maxOccurs="unbounded" ref="div"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="title" type="xs:string"/>
+  <xs:element name="div">
+    <xs:complexType>
+      <xs:sequence>
+	<xs:element minOccurs="0" ref="title"/>
+	<xs:element minOccurs="0" maxOccurs="unbounded" ref="p"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="p">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+	<xs:element ref="a"/>
+	<xs:element ref="img"/>
+	<xs:element ref="uri"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="a">
+    <xs:complexType>
+      <xs:simpleContent>
+	<xs:extension base="xs:string">
+	  <xs:attribute name="href" type="xs:anyURI"/>
+	</xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="img">
+    <xs:complexType>
+      <xs:complexContent>
+	<xs:restriction base="xs:anyType">
+	  <xs:attribute name="src" type="xs:anyURI"/>
+	</xs:restriction>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="uri" type="xs:anyURI"/>
+</xs:schema>

--- a/tests/extra-suite/test-suite/documents/simple-catalog.xml
+++ b/tests/extra-suite/test-suite/documents/simple-catalog.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" prefer="public">
+
+  <uri name="https://www.xmlcalabash.com/ns/simple"
+       uri="simple.xsd"/>
+
+</catalog>

--- a/tests/extra-suite/test-suite/documents/simple.xml
+++ b/tests/extra-suite/test-suite/documents/simple.xml
@@ -1,0 +1,6 @@
+<simple xmlns="https://www.xmlcalabash.com/ns/simple"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://www.xmlcalabash.com/ns/simple simple.xsd">
+  <title>Document title</title>
+  <p>Some text.</p>
+</simple>

--- a/tests/extra-suite/test-suite/documents/simple.xsd
+++ b/tests/extra-suite/test-suite/documents/simple.xsd
@@ -1,0 +1,52 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:s="https://www.xmlcalabash.com/ns/simple"
+           targetNamespace="https://www.xmlcalabash.com/ns/simple"
+	   elementFormDefault="qualified">
+  <xs:element name="simple">
+    <xs:complexType>
+      <xs:sequence>
+	<xs:element minOccurs="0" ref="s:title"/>
+	<xs:element minOccurs="0" maxOccurs="unbounded" ref="s:p"/>
+	<xs:element minOccurs="0" maxOccurs="unbounded" ref="s:div"/>
+      </xs:sequence>
+      <xs:attribute name="status" type="xs:string" default="draft"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="title" type="xs:string"/>
+  <xs:element name="div">
+    <xs:complexType>
+      <xs:sequence>
+	<xs:element minOccurs="0" ref="s:title"/>
+	<xs:element minOccurs="0" maxOccurs="unbounded" ref="s:p"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="p">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+	<xs:element ref="s:a"/>
+	<xs:element ref="s:img"/>
+	<xs:element ref="s:uri"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="a">
+    <xs:complexType>
+      <xs:simpleContent>
+	<xs:extension base="xs:string">
+	  <xs:attribute name="href" type="xs:anyURI"/>
+	</xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="img">
+    <xs:complexType>
+      <xs:complexContent>
+	<xs:restriction base="xs:anyType">
+	  <xs:attribute name="src" type="xs:anyURI"/>
+	</xs:restriction>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="uri" type="xs:anyURI"/>
+</xs:schema>

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/config/XmlCalabashConfiguration.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/config/XmlCalabashConfiguration.kt
@@ -8,8 +8,9 @@ import com.xmlcalabash.util.AssertionsLevel
 import com.xmlcalabash.util.DefaultMessagePrinter
 import com.xmlcalabash.util.Verbosity
 import com.xmlcalabash.visualizers.Silent
-import net.sf.saxon.Configuration
 import net.sf.saxon.s9api.QName
+import net.sf.saxon.s9api.ValidationMode
+import net.sf.saxon.s9api.XdmNode
 import java.io.File
 import java.net.URI
 
@@ -31,6 +32,11 @@ abstract class XmlCalabashConfiguration {
     var saxonConfigurationProperties: Map<String,String> = emptyMap()
     var uniqueInlineUris: Boolean = true
     var licensed: Boolean = true // If a licensed configuration can't be loaded, an unlicensed one will be...
+    val xmlSchemaDocuments = mutableListOf<XdmNode>()
+    var validationMode = ValidationMode.DEFAULT
+    var tryNamespaces = false
+    var useLocationHints = false
+    val xmlCatalogs = mutableListOf<URI>()
     var proxies: Map<String, String> = emptyMap()
     var inlineTrimWhitespace: Boolean = false
     var mpt: Double = 0.99999998

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/DeclareStepInstruction.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/DeclareStepInstruction.kt
@@ -2,6 +2,7 @@ package com.xmlcalabash.datamodel
 
 import com.xmlcalabash.exceptions.XProcError
 import com.xmlcalabash.io.MediaType
+import com.xmlcalabash.namespace.NsCx
 import com.xmlcalabash.namespace.NsP
 import com.xmlcalabash.runtime.XProcPipeline
 import com.xmlcalabash.runtime.XProcRuntime
@@ -9,6 +10,7 @@ import com.xmlcalabash.util.AssertionsLevel
 import com.xmlcalabash.util.AssertionsMonitor
 import net.sf.saxon.om.NamespaceUri
 import net.sf.saxon.s9api.QName
+import net.sf.saxon.s9api.ValidationMode
 import net.sf.saxon.s9api.XdmNode
 import java.net.URI
 
@@ -263,6 +265,14 @@ class DeclareStepInstruction(parent: XProcInstruction?, stepConfig: InstructionC
                     throw stepConfig.exception(XProcError.xsUnsupportedVersion(version!!.toString()))
                 }
             }
+        }
+
+        stepConfig.validationMode = stepConfig.xmlCalabash.xmlCalabashConfig.validationMode
+        when (extensionAttributes[NsCx.validationMode]) {
+            null -> Unit
+            "strict" -> stepConfig.validationMode = ValidationMode.STRICT
+            "lax" -> stepConfig.validationMode = ValidationMode.LAX
+            else -> throw stepConfig.exception(XProcError.xiUnsupportedValidationMode(extensionAttributes[NsCx.validationMode]!!))
         }
 
         if (isAtomic) {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/InstructionConfiguration.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/InstructionConfiguration.kt
@@ -1,15 +1,11 @@
 package com.xmlcalabash.datamodel
 
-import com.xmlcalabash.runtime.XProcStepConfiguration
 import com.xmlcalabash.documents.DocumentProperties
 import com.xmlcalabash.documents.XProcDocument
 import com.xmlcalabash.io.MediaType
+import com.xmlcalabash.runtime.XProcStepConfiguration
 import net.sf.saxon.om.NamespaceUri
-import net.sf.saxon.s9api.QName
-import net.sf.saxon.s9api.SequenceType
-import net.sf.saxon.s9api.XdmAtomicValue
-import net.sf.saxon.s9api.XdmNode
-import net.sf.saxon.s9api.XdmValue
+import net.sf.saxon.s9api.*
 import java.net.URI
 
 interface InstructionConfiguration: XProcStepConfiguration {
@@ -34,7 +30,6 @@ interface InstructionConfiguration: XProcStepConfiguration {
 
     fun updateWith(node: XdmNode)
     fun updateWith(baseUri: URI)
-    //fun updateNamespaces(nsmap: Map<String, NamespaceUri>)
 
     fun fromUri(href: URI, properties: DocumentProperties, parameters: Map<QName, XdmValue>): XProcDocument
     fun fromString(xml: String, properties: DocumentProperties, parameters: Map<QName, XdmValue>): XProcDocument

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/StepDeclaration.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/StepDeclaration.kt
@@ -2,10 +2,14 @@ package com.xmlcalabash.datamodel
 
 import com.xmlcalabash.exceptions.XProcError
 import com.xmlcalabash.exceptions.XProcException
+import com.xmlcalabash.namespace.NsCx
+import com.xmlcalabash.namespace.NsP
+import com.xmlcalabash.runtime.XProcStepConfigurationImpl
 import com.xmlcalabash.util.AssertionsLevel
 import com.xmlcalabash.util.AssertionsMonitor
 import com.xmlcalabash.util.DurationUtils
 import net.sf.saxon.s9api.QName
+import net.sf.saxon.s9api.ValidationMode
 import java.time.Duration
 
 abstract class StepDeclaration(parent: XProcInstruction?, stepConfig: InstructionConfiguration, instructionType: QName): XProcInstruction(parent, stepConfig, instructionType) {
@@ -84,6 +88,14 @@ abstract class StepDeclaration(parent: XProcInstruction?, stepConfig: Instructio
 
         if (stepConfig.xmlCalabash.xmlCalabashConfig.assertions != AssertionsLevel.IGNORE) {
             AssertionsMonitor.parseStepAssertions(this)
+        }
+
+        stepConfig.validationMode = stepConfig.xmlCalabash.xmlCalabashConfig.validationMode
+        when (extensionAttributes[NsCx.validationMode]) {
+            null -> Unit
+            "strict" -> stepConfig.validationMode = ValidationMode.STRICT
+            "lax" -> stepConfig.validationMode = ValidationMode.LAX
+            else -> throw stepConfig.exception(XProcError.xiUnsupportedValidationMode(extensionAttributes[NsCx.validationMode]!!))
         }
     }
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/XProcInstruction.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/XProcInstruction.kt
@@ -61,14 +61,6 @@ abstract class XProcInstruction internal constructor(initialParent: XProcInstruc
     val inscopeNamespaces: Map<String, NamespaceUri>
         get() = stepConfig.inscopeNamespaces
 
-    /*
-    val inscopeStepNames: Map<String, StepDeclaration>
-        get() = stepConfig.inscopeStepNames
-
-    val inscopeStepTypes: Map<QName, DeclareStepInstruction>
-        get() = stepConfig.inscopeStepTypes
-     */
-
     val inscopeVariables: Map<QName, VariableBindingContainer>
         get() = stepConfig.inscopeVariables
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/XProcError.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/XProcError.kt
@@ -425,6 +425,12 @@ open class XProcError protected constructor(val code: QName, val variant: Int, e
         fun xiPipeinfoMustBePipeinfo(root: QName) = internal(Pair(45, 2), root)
         fun xiXPathVersionNotSupported(version: String) = internal(46, version)
         fun xiTooManySources(count: Int) = internal(47, count)
+        fun xiNotAnXmlSchema(name: QName) = internal(48, name)
+        fun xiXmlSchemaContentOrHref() = internal(49)
+        fun xiNonWhitespaceTextInSchema() = internal(50)
+        fun xiDocumentReturnedMultipart() = internal(51)
+        fun xiUnsupportedValidationMode(mode: String) = internal(52, mode)
+        fun xiConfigurationCatalogElementMustBeEmpty() = internal(53)
 
         fun xiCliInvalidValue(option: String, value: String) = internal(200, option, value)
         fun xiCliValueRequired(option: String) = internal(202, option)

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/namespace/Ns.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/namespace/Ns.kt
@@ -189,4 +189,8 @@ object Ns {
     val trace = QName("trace")
     val timing = QName("timing")
     val verbose = QName("verbose")
+    val validationMode = QName("validatation-mode")
+    val tryNamespaces = QName("try-namespaces")
+    val useLocationHints = QName("use-location-hints")
+    val targetNamespace = QName("targetNamespace") // N.B. targetNamespace not target-namespace
 }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/namespace/NsCx.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/namespace/NsCx.kt
@@ -109,4 +109,7 @@ object NsCx {
     val statusChangeTime = QName(namespace, "cx:status-change-time")
     val windowsAttributes = QName(namespace, "cx:windows-attributes")
     val hostOs = QName(namespace, "cx:host-os")
+    val validationMode = QName(namespace, "cx:validation-mode")
+    val useCatalog = QName(namespace, "cx:use-catalog")
+    val importSchema = QName(namespace, "cx:import-schema")
 }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/namespace/NsXs.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/namespace/NsXs.kt
@@ -7,6 +7,7 @@ import net.sf.saxon.s9api.QName
 object NsXs {
     val namespace: NamespaceUri = NamespaceUri.of("http://www.w3.org/2001/XMLSchema")
 
+    val schema = QName(namespace, "xs:schema")
     val ENTITY = QName(namespace, "xs:ENTITY")
     val ID = QName(namespace, "xs:ID")
     val IDREF = QName(namespace, "xs:IDREF")

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/XProcStepConfiguration.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/XProcStepConfiguration.kt
@@ -15,6 +15,7 @@ import net.sf.saxon.s9api.*
 interface XProcStepConfiguration: DocumentContext {
     val environment: PipelineEnvironment
     val saxonConfig: SaxonConfiguration
+    var validationMode: ValidationMode
 
     val inscopeStepTypes: Map<QName, DeclareStepInstruction>
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/XProcStepConfigurationImpl.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/XProcStepConfigurationImpl.kt
@@ -33,6 +33,8 @@ open class XProcStepConfigurationImpl internal constructor(
     override val processor: Processor
         get() = saxonConfig.processor
 
+    override var validationMode = ValidationMode.DEFAULT
+
     protected val _inscopeNamespaces = mutableMapOf<String, NamespaceUri>()
     protected val _inscopeStepTypes = mutableMapOf<QName, DeclareStepInstruction>()
 
@@ -104,6 +106,7 @@ open class XProcStepConfigurationImpl internal constructor(
         copy._inscopeNamespaces.putAll(_inscopeNamespaces)
         copy._inscopeStepTypes.putAll(_inscopeStepTypes)
         copy._stepName = _stepName
+        copy.validationMode = validationMode
         return copy
     }
 
@@ -112,6 +115,7 @@ open class XProcStepConfigurationImpl internal constructor(
         copy._inscopeNamespaces.putAll(_inscopeNamespaces)
         copy._inscopeStepTypes.putAll(_inscopeStepTypes)
         copy._stepName = _stepName
+        copy.validationMode = validationMode
         return copy
     }
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/model/AtomicUserStepModel.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/model/AtomicUserStepModel.kt
@@ -9,6 +9,7 @@ import com.xmlcalabash.runtime.api.RuntimePort
 import com.xmlcalabash.runtime.steps.AbstractStep
 import com.xmlcalabash.runtime.steps.CompoundStep
 import net.sf.saxon.s9api.QName
+import net.sf.saxon.s9api.ValidationMode
 
 class AtomicUserStepModel(runtime: XProcRuntime, model: AtomicModel, private val impl: CompoundStepModel): AtomicStepModel(runtime, model) {
     private var _type = type
@@ -52,6 +53,11 @@ class AtomicUserStepModel(runtime: XProcRuntime, model: AtomicModel, private val
             val instance = CompoundStep.newInstance(config, impl)
             instance.stepType = stepType
             instance.stepName = name
+
+            // Validation mode on an instance overrides the default...
+            if (stepConfig.validationMode != ValidationMode.DEFAULT) {
+                instance.head.stepConfig.validationMode = stepConfig.validationMode
+            }
 
             impl._inputs.clear()
             impl._inputs.putAll(saveCompoundInputs)

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/validation/ValidateWithXmlSchema.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/validation/ValidateWithXmlSchema.kt
@@ -12,29 +12,18 @@ import com.xmlcalabash.runtime.parameters.RuntimeStepParameters
 import com.xmlcalabash.steps.AbstractAtomicStep
 import com.xmlcalabash.util.S9Api
 import com.xmlcalabash.util.SaxonErrorReporter
-import com.xmlcalabash.util.XsdResolver
-import net.sf.saxon.Configuration
+import com.xmlcalabash.util.SaxonXsdValidator
 import net.sf.saxon.Controller
-import net.sf.saxon.lib.SchemaURIResolver
 import net.sf.saxon.om.NamespaceUri
 import net.sf.saxon.s9api.*
 import net.sf.saxon.serialize.SerializationProperties
 import net.sf.saxon.type.ValidationException
 import java.net.URI
-import javax.xml.transform.Source
 import javax.xml.transform.sax.SAXSource
-import javax.xml.transform.stream.StreamSource
 
 open class ValidateWithXmlSchema(): AbstractAtomicStep() {
-    companion object {
-        private val _useLocationHints = QName("use-location-hints")
-        private val _tryNamespaces = QName("try-namespaces")
-        private val _targetNamespace = QName("targetNamespace")
-    }
-
     lateinit var document: XProcDocument
     lateinit var errorReporter: SaxonErrorReporter
-    val schemas = mutableListOf<XProcDocument>()
 
     override fun setup(stepConfig: XProcStepConfiguration, receiver: Receiver, stepParams: RuntimeStepParameters) {
         super.setup(stepConfig, receiver, stepParams)
@@ -45,193 +34,34 @@ open class ValidateWithXmlSchema(): AbstractAtomicStep() {
 
     override fun run() {
         super.run()
-
         document = queues["source"]!!.first()
-        schemas.addAll(queues["schema"]!!)
-
-        val manager = stepConfig.processor.getSchemaManager()
-        if (manager == null) {
-            throw RuntimeException("Schema manager not found, XSD validation requires Saxon EE")
-        }
-
-        manager.errorReporter = errorReporter
-        manager.schemaURIResolver = XsdResolver(stepConfig)
-
-        validateWithSaxon(manager)
+        validateWithSaxon()
     }
 
     override fun reset() {
         super.reset()
         document = XProcDocument.ofEmpty(stepConfig)
-        schemas.clear()
     }
 
-    private fun validateWithSaxon(manager: SchemaManager) {
-        val useLocationHints = booleanBinding(_useLocationHints) ?: false
-        val tryNamespaces = booleanBinding(_tryNamespaces) ?: false
-        val assertValid = booleanBinding(Ns.assertValid) ?: true
-        val parameters = qnameMapBinding(Ns.parameters)
-        val mode = stringBinding(Ns.mode) ?: "strict"
-        val version = stringBinding(Ns.version) ?: "1.1"
-        val reportFormat = stringBinding(Ns.reportFormat) ?: "xvrl"
-
-        if (reportFormat != "xvrl") {
-            throw stepConfig.exception(XProcError.xcUnsupportedReportFormat(reportFormat))
-        }
-
-        val report = Errors(stepConfig, document.baseURI)
-        report.report.metadata.validator("Saxon ${stepConfig.processor.saxonEdition}",
-            stepConfig.processor.saxonProductVersion)
-
-        if (version != "1.0" && version != "1.1") {
-            throw stepConfig.exception(XProcError.xcXmlSchemaVersionNotAvailable(version))
-        }
-
-        val schemaDocuments = mutableListOf<XdmNode>()
-        for (schema in schemas) {
-            val schemaNode = S9Api.documentElement(schema.value as XdmNode)
-            val targetNS = schemaNode.getAttributeValue(_targetNamespace) ?: ""
-            stepConfig.debug { "Caching input schema ${schema.baseURI} for ${targetNS}"}
-
-            if (stepConfig.baseUri != null && schema.baseURI != null && schema.baseURI.toString().startsWith(stepConfig.baseUri.toString())) {
-                // It looks like this one was inline...
-                report.report.metadata.schema(schema.baseURI, NsXs.namespace, version, schemaNode)
-            } else {
-                report.report.metadata.schema(schema.baseURI, NsXs.namespace, version)
-            }
-
-            schemaDocuments.add(schema.value as XdmNode)
-        }
-
-        val sourceNode = S9Api.documentElement(document.value as XdmNode)
-        if (useLocationHints) {
-            val nonsSchemaHint = sourceNode.getAttributeValue(NsXsi.noNamespaceSchemaLocation)
-            val schemaHint = sourceNode.getAttributeValue(NsXsi.schemaLocation)
-            if (nonsSchemaHint != null) {
-                val uri = sourceNode.baseURI.resolve(nonsSchemaHint)
-                val docManager = stepConfig.environment.documentManager
-                val doc = docManager.load(uri, stepConfig)
-                schemaDocuments.add(doc.value as XdmNode)
-            }
-            if (schemaHint != null) {
-                val parts = schemaHint.split("\\s+".toRegex())
-                var idx = 1
-                while (idx < parts.size) {
-                    val uri = sourceNode.baseURI.resolve(parts[idx])
-                    val docManager = stepConfig.environment.documentManager
-                    try {
-                        val schema = docManager.load(uri, stepConfig)
-                        schemaDocuments.add(schema.value as XdmNode)
-                    } catch (ex: Exception) {
-                        throw stepConfig.exception(XProcError.xcNotSchemaValidXmlSchema(ex.message ?: "No message given"), ex)
-                    }
-                    idx += 2
-                }
-            }
-        }
-
-        if (tryNamespaces) {
-            val ns = sourceNode.nodeName.namespaceUri
-            if (ns != NamespaceUri.NULL) {
-                val docManager = stepConfig.environment.documentManager
-                try {
-                    val doc = docManager.load(URI(ns.toString()), stepConfig)
-                    schemaDocuments.add(doc.value as XdmNode)
-                } catch (ex: Exception) {
-                    stepConfig.debug { "Failed to load XML Shema from ${ns}: ${ex.message}" }
-                }
-            }
-        }
-
-        val saxonConfig = stepConfig.processor.underlyingConfiguration
-        saxonConfig.clearSchemaCache()
-        for (schema in schemaDocuments) {
-            val source = S9Api.xdmToInputSource(stepConfig, schema)
-            if (schema.baseURI != null) {
-                source.systemId = schema.baseURI.toString()
-            }
-            try {
-                manager.load(SAXSource(source))
-            } catch (ex: SaxonApiException) {
-                if (schema.baseURI != null) {
-                    throw stepConfig.exception(XProcError.xcXmlSchemaInvalidSchema(schema.baseURI!!), ex)
-                }
-                throw stepConfig.exception(XProcError.xcXmlSchemaInvalidSchema(), ex)
-            }
-        }
-
-        val destination = XdmDestination()
-        val controller = Controller(saxonConfig)
-        val pipe = controller.makePipelineConfiguration()
-        val preceiver = destination.getReceiver(pipe, SerializationProperties())
-        pipe.setRecoverFromValidationErrors(assertValid)
-        pipe.errorReporter = errorReporter
-        preceiver.setPipelineConfiguration(pipe)
-
-        val validator = manager.newSchemaValidator()
-        val invalidityHandler = validator.invalidityHandler
-
-        val listener = CachingErrorListener(stepConfig, report, invalidityHandler)
-
-        validator.destination = destination
-        validator.invalidityHandler = listener
-        validator.isLax = mode == "lax"
-        validator.isUseXsiSchemaLocation = useLocationHints
-
-        var raisedException: XProcError? = null
-
-        try {
-            validator.validate((document.value as XdmNode).asSource())
-        } catch (ex: SaxonApiException) {
-            val errors = report.asXml()
-            var msg = ex.message
-            if (listener.exceptions.isNotEmpty()) {
-                val lex = listener.exceptions.first()
-                when (lex) {
-                    is ValidationException -> {
-                        msg = lex.message
-                        val fail = lex.validationFailure
-                        val except = if (document.baseURI == null) {
-                            XProcError.xcNotSchemaValidXmlSchema(msg!!)
-                        } else {
-                            XProcError.xcNotSchemaValidXmlSchema(document.baseURI!!, msg!!)
-                        }
-                        raisedException = except
-                    }
-                }
-            } else {
-                val except = if (document.baseURI == null) {
-                    XProcError.xcNotSchemaValidXmlSchema(ex.message!!)
-                } else {
-                    XProcError.xcNotSchemaValidXmlSchema(document.baseURI!!, ex.message!!)
-                }
-                raisedException = except
-            }
-        } catch (ex: Exception) {
-            val except = if (document.baseURI == null) {
-                XProcError.xcNotSchemaValidXmlSchema(ex.message!!)
-            } else {
-                XProcError.xcNotSchemaValidXmlSchema(document.baseURI!!, ex.message!!)
-            }
-            raisedException = except
-        }
-
-        val xvrl = XProcDocument.ofXml(report.asXml(), stepConfig)
-
-        if (raisedException != null) {
-            if (assertValid) {
-                if (raisedException.code == NsErr.xc(156)) {
-                    throw stepConfig.exception(XProcError.xcNotSchemaValidXmlSchema(xvrl))
-                }
-                throw raisedException.exception()
-            } else {
-                receiver.output("result", document)
-                receiver.output("report", xvrl)
-            }
+    private fun validateWithSaxon() {
+        val validator = SaxonXsdValidator(stepConfig)
+        validator.useLocationHints = booleanBinding(Ns.useLocationHints) ?: false
+        validator.tryNamespaces = booleanBinding(Ns.tryNamespaces) ?: false
+        validator.assertValid = booleanBinding(Ns.assertValid) ?: true
+        validator.parameters = qnameMapBinding(Ns.parameters)
+        validator.version = stringBinding(Ns.version) ?: "1.1"
+        validator.reportFormat = stringBinding(Ns.reportFormat) ?: "xvrl"
+        if (stringBinding(Ns.mode) == "strict") {
+            validator.mode = ValidationMode.STRICT
         } else {
-            receiver.output("result", XProcDocument.ofXml(destination.xdmNode, stepConfig))
-            receiver.output("report", xvrl)
+            validator.mode = ValidationMode.LAX
         }
+        validator.schemas.clear()
+        validator.schemas.addAll(queues["schema"]!!)
+
+        val validated = validator.validate(document)
+        receiver.output("result", validated)
+        receiver.output("report", validator.xvrl!!)
     }
 
     override fun toString(): String = "p:validate-with-xml-schema"

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/tracing/DetailTraceListener.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/tracing/DetailTraceListener.kt
@@ -12,6 +12,7 @@ import com.xmlcalabash.util.SaxonTreeBuilder
 import net.sf.saxon.s9api.QName
 import org.apache.logging.log4j.kotlin.logger
 import java.io.FileOutputStream
+import java.net.URI
 import java.nio.file.Files
 import java.nio.file.Path
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/tracing/GetResourceDetail.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/tracing/GetResourceDetail.kt
@@ -1,0 +1,6 @@
+package com.xmlcalabash.tracing
+
+import java.net.URI
+
+class GetResourceDetail(val startTime: Long, val duration: Long, val uri: URI, val href: URI?, val resolved: Boolean, val cached: Boolean): TraceDetail(Thread.currentThread().id) {
+}

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/tracing/NsTrace.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/tracing/NsTrace.kt
@@ -10,6 +10,7 @@ object NsTrace {
     val thread = QName(namespace, "thread")
     val step = QName(namespace, "step")
     val document = QName(namespace, "document")
+    val resource = QName(namespace, "resource")
     val from = QName(namespace, "from")
     val to = QName(namespace, "to")
     val location = QName(namespace, "location")

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/tracing/TraceListener.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/tracing/TraceListener.kt
@@ -4,9 +4,11 @@ import com.xmlcalabash.api.Monitor
 import com.xmlcalabash.runtime.XProcStepConfiguration
 import com.xmlcalabash.util.SaxonTreeBuilder
 import net.sf.saxon.s9api.XdmNode
+import java.net.URI
 
 interface TraceListener: Monitor {
     val trace: List<TraceDetail>
+    fun getResource(ms: Long, uri: URI, href: URI? = null, resolved: Boolean, cached: Boolean)
     fun summary(config: XProcStepConfiguration): XdmNode
     fun documentSummary(config: XProcStepConfiguration, builder: SaxonTreeBuilder, detail: DocumentDetail)
 }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/SaxonXsdValidator.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/SaxonXsdValidator.kt
@@ -1,0 +1,212 @@
+package com.xmlcalabash.util
+
+import com.xmlcalabash.documents.DocumentProperties
+import com.xmlcalabash.documents.XProcDocument
+import com.xmlcalabash.exceptions.XProcError
+import com.xmlcalabash.namespace.Ns
+import com.xmlcalabash.namespace.NsCx
+import com.xmlcalabash.namespace.NsErr
+import com.xmlcalabash.namespace.NsXs
+import com.xmlcalabash.namespace.NsXsi
+import com.xmlcalabash.runtime.XProcStepConfiguration
+import com.xmlcalabash.steps.validation.CachingErrorListener
+import com.xmlcalabash.steps.validation.Errors
+import net.sf.saxon.Controller
+import net.sf.saxon.om.NamespaceUri
+import net.sf.saxon.s9api.*
+import net.sf.saxon.serialize.SerializationProperties
+import net.sf.saxon.type.ValidationException
+import java.net.URI
+import javax.xml.transform.sax.SAXSource
+
+class SaxonXsdValidator(val stepConfig: XProcStepConfiguration) {
+    var useLocationHints = stepConfig.xmlCalabash.xmlCalabashConfig.useLocationHints
+    var tryNamespaces = stepConfig.xmlCalabash.xmlCalabashConfig.tryNamespaces
+    var mode = stepConfig.validationMode
+    var assertValid = true
+    var parameters = mapOf<QName,XdmValue>()
+    var version = "1.1"
+    var reportFormat = "xvrl"
+    val schemas = mutableListOf<XProcDocument>()
+    val errorReporter = SaxonErrorReporter(stepConfig)
+    var xvrl: XProcDocument? = null
+
+    fun validate(source: XProcDocument): XProcDocument {
+        if (reportFormat != "xvrl") {
+            throw stepConfig.exception(XProcError.xcUnsupportedReportFormat(reportFormat))
+        }
+
+        if (version != "1.0" && version != "1.1") {
+            throw stepConfig.exception(XProcError.xcXmlSchemaVersionNotAvailable(version))
+        }
+
+        val manager = stepConfig.processor.getSchemaManager()
+        if (manager == null) {
+            throw RuntimeException("Schema manager not found, XSD validation requires Saxon EE")
+        }
+
+        manager.errorReporter = errorReporter
+        manager.schemaURIResolver = XsdResolver(stepConfig)
+
+        val report = Errors(stepConfig, source.baseURI)
+        report.report.metadata.validator(
+            "Saxon ${stepConfig.processor.saxonEdition}",
+            stepConfig.processor.saxonProductVersion
+        )
+
+        val schemaDocuments = mutableListOf<XdmNode>()
+        for (schema in schemas) {
+            val schemaNode = S9Api.documentElement(schema.value as XdmNode)
+            val targetNS = schemaNode.getAttributeValue(Ns.targetNamespace) ?: ""
+            stepConfig.debug { "Caching input schema ${schema.baseURI} for ${targetNS}" }
+
+            if (stepConfig.baseUri != null && schema.baseURI != null && schema.baseURI.toString()
+                    .startsWith(stepConfig.baseUri.toString())
+            ) {
+                // It looks like this one was inline...
+                report.report.metadata.schema(schema.baseURI, NsXs.namespace, version, schemaNode)
+            } else {
+                report.report.metadata.schema(schema.baseURI, NsXs.namespace, version)
+            }
+
+            schemaDocuments.add(schema.value as XdmNode)
+        }
+
+        val sourceNode = S9Api.documentElement(source.value as XdmNode)
+        if (useLocationHints) {
+            val nonsSchemaHint = sourceNode.getAttributeValue(NsXsi.noNamespaceSchemaLocation)
+            val schemaHint = sourceNode.getAttributeValue(NsXsi.schemaLocation)
+            if (nonsSchemaHint != null) {
+                val uri = sourceNode.baseURI.resolve(nonsSchemaHint)
+                val docManager = stepConfig.environment.documentManager
+                val doc = docManager.load(uri, stepConfig)
+                schemaDocuments.add(doc.value as XdmNode)
+            }
+            if (schemaHint != null) {
+                val parts = schemaHint.split("\\s+".toRegex())
+                var idx = 1
+                while (idx < parts.size) {
+                    val uri = sourceNode.baseURI.resolve(parts[idx])
+                    val docManager = stepConfig.environment.documentManager
+                    try {
+                        val schema = docManager.load(uri, stepConfig)
+                        schemaDocuments.add(schema.value as XdmNode)
+                    } catch (ex: Exception) {
+                        throw stepConfig.exception(
+                            XProcError.xcNotSchemaValidXmlSchema(
+                                ex.message ?: "No message given"
+                            ), ex
+                        )
+                    }
+                    idx += 2
+                }
+            }
+        }
+
+        if (tryNamespaces) {
+            val ns = sourceNode.nodeName.namespaceUri
+            if (ns != NamespaceUri.NULL) {
+                val docManager = stepConfig.environment.documentManager
+                try {
+                    val doc = docManager.load(URI(ns.toString()), stepConfig)
+                    schemaDocuments.add(doc.value as XdmNode)
+                } catch (ex: Exception) {
+                    stepConfig.debug { "Failed to load XML Shema from ${ns}: ${ex.message}" }
+                }
+            }
+        }
+
+        val saxonConfig = stepConfig.processor.underlyingConfiguration
+
+        stepConfig.saxonConfig.clearSchemaCache();
+        for (schema in schemaDocuments) {
+            val source = S9Api.xdmToInputSource(stepConfig, schema)
+            if (schema.baseURI != null) {
+                source.systemId = schema.baseURI.toString()
+            }
+            try {
+                manager.load(SAXSource(source))
+            } catch (ex: SaxonApiException) {
+                if (schema.baseURI != null) {
+                    throw stepConfig.exception(XProcError.xcXmlSchemaInvalidSchema(schema.baseURI!!), ex)
+                }
+                throw stepConfig.exception(XProcError.xcXmlSchemaInvalidSchema(), ex)
+            }
+        }
+
+        val destination = XdmDestination()
+        val controller = Controller(saxonConfig)
+        val pipe = controller.makePipelineConfiguration()
+        val preceiver = destination.getReceiver(pipe, SerializationProperties())
+        pipe.setRecoverFromValidationErrors(assertValid)
+        pipe.errorReporter = errorReporter
+        preceiver.setPipelineConfiguration(pipe)
+
+        val validator = manager.newSchemaValidator()
+        val invalidityHandler = validator.invalidityHandler
+
+        val listener = CachingErrorListener(stepConfig, report, invalidityHandler)
+
+        validator.destination = destination
+        validator.invalidityHandler = listener
+        validator.isLax = mode == ValidationMode.LAX
+        validator.isUseXsiSchemaLocation = useLocationHints
+
+        var raisedException: XProcError? = null
+
+        try {
+            validator.validate((source.value as XdmNode).asSource())
+        } catch (ex: SaxonApiException) {
+            var msg = ex.message
+            if (listener.exceptions.isNotEmpty()) {
+                val lex = listener.exceptions.first()
+                when (lex) {
+                    is ValidationException -> {
+                        msg = lex.message
+                        val except = if (source.baseURI == null) {
+                            XProcError.xcNotSchemaValidXmlSchema(msg!!)
+                        } else {
+                            XProcError.xcNotSchemaValidXmlSchema(source.baseURI!!, msg!!)
+                        }
+                        raisedException = except
+                    }
+                }
+            } else {
+                val except = if (source.baseURI == null) {
+                    XProcError.xcNotSchemaValidXmlSchema(ex.message!!)
+                } else {
+                    XProcError.xcNotSchemaValidXmlSchema(source.baseURI!!, ex.message!!)
+                }
+                raisedException = except
+            }
+        } catch (ex: Exception) {
+            val except = if (source.baseURI == null) {
+                XProcError.xcNotSchemaValidXmlSchema(ex.message!!)
+            } else {
+                XProcError.xcNotSchemaValidXmlSchema(source.baseURI!!, ex.message!!)
+            }
+            raisedException = except
+        }
+
+        xvrl = XProcDocument.ofXml(report.asXml(), stepConfig)
+
+        if (raisedException != null) {
+            if (assertValid) {
+                if (raisedException.code == NsErr.xc(156)) {
+                    throw stepConfig.exception(XProcError.xcNotSchemaValidXmlSchema(xvrl!!))
+                }
+                throw raisedException.exception()
+            } else {
+                return source
+            }
+        } else {
+            val vmode = if (mode == ValidationMode.STRICT) {
+                "strict"
+            } else {
+                "lax"
+            }
+            return XProcDocument.ofXml(destination.xdmNode, stepConfig,
+                DocumentProperties(mapOf(NsCx.validationMode to XdmAtomicValue(vmode))))
+        }
+    }
+}

--- a/xmlcalabash/src/main/resources/com/xmlcalabash/explain-errors.txt
+++ b/xmlcalabash/src/main/resources/com/xmlcalabash/explain-errors.txt
@@ -1546,6 +1546,24 @@ XPath version not supported: “$1”
 cxerr:XI0047
 At most one document is allowed on the source port, found $1.
 
+cxerr:XI0048
+The schema document is not an XSD schema: “$1”.
+
+cxerr:XI0049
+The cc:xml-schema element cannot have both an href attribute and content.
+
+cxerr:XI0050
+Non-whitespace text nodes are forbidden in cc:xml-schema elements.
+
+cxerr:XI0051
+The p:document instruction does not support multipart messages.
+
+cxerr:XI0052
+Unsupported validation mode: “$1”.
+
+cxerr:XI0053
+The cc:catalog element must be empty.
+
 cxerr:XI0200
 Invalid option value “$2” for $1.
 

--- a/xmlcalabash/src/main/resources/com/xmlcalabash/trace.rnc
+++ b/xmlcalabash/src/main/resources/com/xmlcalabash/trace.rnc
@@ -11,7 +11,7 @@ t.trace =
 t.thread =
     element t:thread {
         attribute id { xsd:long },
-        (t.step | t.document)+
+        (t.step | t.document | t.resource)+
     }
 
 t.step =
@@ -21,7 +21,7 @@ t.step =
         attribute type { xsd:QName },
         attribute start-time { xsd:dateTime },
         attribute duration-ms { xsd:long },
-        (t.step | t.document)*
+        (t.step | t.document | t.resource)*
     }
 
 t.document =
@@ -29,6 +29,17 @@ t.document =
         attribute id { xsd:long },
         attribute content-type { text }?,
         (t.from, t.to, t.location?)
+    }
+
+t.resource =
+    element t:resource {
+        attribute start-time { xsd:dateTime },
+        attribute duration-ms { xsd:long },
+        attribute uri { xsd:anyURI },
+        attribute href { xsd:anyURI }?,
+        attribute resolved { xsd:boolean }?,
+        attribute cached { xsd:boolean }?,
+        empty
     }
 
 t.from =

--- a/xmlcalabash/src/main/resources/com/xmlcalabash/xml-calabash.rnc
+++ b/xmlcalabash/src/main/resources/com/xmlcalabash/xml-calabash.rnc
@@ -11,7 +11,11 @@ cc.xmlCalabash =
         attribute verbosity { "trace" | "debug" | "progress" | "info" | "warn" | "error" }?,
         attribute piped-io { xsd:boolean }?,
         attribute console-output-encoding { xsd:string }?,
-        (cc.graphviz
+        attribute try-namespaces { xsd:boolean }?,
+        attribute use-location-hints { xsd:boolean }?,
+        attribute validation-mode { "strict" | "lax" }?,
+        (cc.catalog
+        | cc.graphviz
         | cc.inline
         | cc.mimetype
         | cc.pagedMedia
@@ -23,6 +27,7 @@ cc.xmlCalabash =
         | cc.messageReporter
         | cc.visualizer
         | cc.threading
+        | cc.xmlSchema
         | any-other-name)*
     }
 
@@ -129,6 +134,18 @@ cc.visualizer =
     element cc:visualizer {
         attribute name { "silent" | "plain" | "detail" },
         attribute * - name { text }*,
+        empty
+    }
+
+cc.xmlSchema =
+    element cc:xml-schema {
+        attribute href { xsd:anyURI }?,
+        any-other-name*
+    }
+
+cc.catalog =
+    element cc:catalog {
+        attribute href { xsd:anyURI }?,
         empty
     }
 


### PR DESCRIPTION
There are a bunch of changes in here.

1. Implicit (XML Schema) validation of primary inputs is controlled by the validation-mode
2. New configuration properties: validation-mode, try-namespaces, use-location-hints, cc:xml-schema, and cc:catalog
3. New command line options: --validation-mode, --try-namespaces, --use-location-hints, --xml-schema, and --catalog
4. New extension attribute, cx:validation-mode that can be applied to steps and p:declare-step.
5. New elements in p:pipeinfo for loading schemas and catalogs, cx:use-catalog and cx:import-schema

These are all (perhaps somewhat crudely) documented.

There’s also an update to the trace output. All loaded resources are now recorded in the trace, along with the time taken to retrieve them.