### PR TITLE
Support user-styling of the SVG pipeline and graph output

### DIFF
--- a/app/src/main/kotlin/com/xmlcalabash/app/XmlCalabashCli.kt
+++ b/app/src/main/kotlin/com/xmlcalabash/app/XmlCalabashCli.kt
@@ -252,7 +252,7 @@ class XmlCalabashCli private constructor() {
                         stream.close()
                     }
 
-                    VisualizerOutput.svg(description, commandLine.pipelineGraphs!!, config.graphviz!!.absolutePath, commandLine.debug == true)
+                    VisualizerOutput.svg(description, commandLine.pipelineGraphs!!, config, commandLine.debug == true)
                 }
             }
 

--- a/test-driver/src/main/kotlin/com/xmlcalabash/testdriver/TestCase.kt
+++ b/test-driver/src/main/kotlin/com/xmlcalabash/testdriver/TestCase.kt
@@ -174,7 +174,7 @@ class TestCase(val suite: TestSuite, val testFile: File) {
                     if (graphviz == null) {
                         logger.warn { "Cannot create SVG descriptions, graphviz is not configured" }
                     } else {
-                        VisualizerOutput.svg(description, suite.options.outputGraph!!, graphviz!!.absolutePath)
+                        VisualizerOutput.svg(description, suite.options.outputGraph!!, config.xmlCalabashConfig)
                     }
                 }
             }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/config/ConfigurationLoader.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/config/ConfigurationLoader.kt
@@ -50,6 +50,7 @@ class ConfigurationLoader private constructor(private val config: XmlCalabashCon
         private val _count = QName("count")
         private val _cssFormatter = QName("css-formatter")
         private val _dot = QName("dot")
+        private val _style = QName("style")
         private val _extensions = QName("extensions")
         private val _host = QName("host")
         private val _licensed = QName("licensed")
@@ -278,7 +279,7 @@ class ConfigurationLoader private constructor(private val config: XmlCalabashCon
     }
 
     private fun parseGraphviz(node: XdmNode) {
-        checkAttributes(node, listOf(_dot))
+        checkAttributes(node, listOf(_dot), listOf(_style))
         val dot = File(node.getAttributeValue(_dot)!!)
         if (!dot.exists() || dot.isDirectory) {
             throw XProcError.xiCannotFindGraphviz(dot.absolutePath).exception()
@@ -287,6 +288,11 @@ class ConfigurationLoader private constructor(private val config: XmlCalabashCon
             throw XProcError.xiCannotExecuteGraphviz(dot.absolutePath).exception()
         }
         config.graphviz = dot
+
+        val style = node.getAttributeValue(_style)
+        if (style != null) {
+            config.graphStyle = node.baseURI.resolve(style)
+        }
     }
 
     private fun parseSaxonConfigurationProperty(node: XdmNode) {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/config/XmlCalabashConfiguration.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/config/XmlCalabashConfiguration.kt
@@ -41,6 +41,7 @@ abstract class XmlCalabashConfiguration {
     var inlineTrimWhitespace: Boolean = false
     var mpt: Double = 0.99999998
     var graphviz: File? = null
+    var graphStyle: URI? = null
     var serialization: Map<MediaType, Map<QName, String>> = emptyMap()
     var trace: File? = null
     var traceDocuments: File? = null

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/PipelineVisualization.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/PipelineVisualization.kt
@@ -63,17 +63,12 @@ class PipelineVisualization private constructor(private val instruction: XProcIn
 
     private fun startElement(qname: QName, attr: Map<String,String?>) {
         var nsmap: NamespaceMap = NamespaceMap.emptyMap()
-        nsmap = nsmap.put("", ns)
+        nsmap = nsmap.put("g", ns)
         nsmap = nsmap.put("p", NsP.namespace)
         nsmap = nsmap.put("cx", NsCx.namespace)
         nsmap = nsmap.put("xs", NsXs.namespace)
 
-        val name = if (qname.namespaceUri == ns) {
-            qname
-        } else {
-            QName(ns, qname.localName)
-        }
-
+        val name = QName(ns, "g:${qname.localName}")
         builder.addStartElement(name, instruction.stepConfig.stringAttributeMap(attr), nsmap)
         root = false
     }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/namespace/NsDescription.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/namespace/NsDescription.kt
@@ -7,7 +7,6 @@ object NsDescription {
     val namespace: NamespaceUri = NamespaceUri.of("http://xmlcalabash.com/ns/description")
 
     val description = QName(namespace, "g:description")
-    val graphs = QName(namespace, "g:graphs")
     val graph = QName(namespace, "g:graph")
     val declareStep = QName(namespace, "g:declare-step")
     val compound = QName(namespace, "g:compound")

--- a/xmlcalabash/src/main/resources/com/xmlcalabash/dot-to-text.xsl
+++ b/xmlcalabash/src/main/resources/com/xmlcalabash/dot-to-text.xsl
@@ -85,7 +85,15 @@
   <xsl:if test="@dot:*">
     <xsl:text> [</xsl:text>
     <xsl:for-each select="@dot:*">
-      <xsl:text>{local-name(.)}={string(.)};</xsl:text>
+      <xsl:text>{local-name(.)}=</xsl:text>
+      <xsl:choose>
+        <xsl:when test="string(.) castable as xs:double">
+          <xsl:text>{string(.)};</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:text>"{string(.)}";</xsl:text>
+        </xsl:otherwise>
+      </xsl:choose>
     </xsl:for-each>
     <xsl:text>]</xsl:text>
   </xsl:if>

--- a/xmlcalabash/src/main/resources/com/xmlcalabash/graphs.xsl
+++ b/xmlcalabash/src/main/resources/com/xmlcalabash/graphs.xsl
@@ -196,6 +196,9 @@
             <xsl:if test="$ispan ne 1">
               <xsl:attribute name="colspan" select="$ispan"/>
             </xsl:if>
+            <xsl:for-each select="@dot:*">
+              <xsl:attribute name="{local-name(.)}" select="."/>
+            </xsl:for-each>
             <xsl:variable name="welded" select="@welded-shut = 'true'"/>
             <xsl:variable name="lines" select="tokenize(@port, '/')"/>
             <xsl:for-each select="$lines">
@@ -295,6 +298,7 @@
       <xsl:if test="$style ne 'solid'">
         <xsl:attribute name="dot:style" select="$style"/>
       </xsl:if>
+      <xsl:copy-of select="@dot:*"/>
     </dot:edge>
   </xsl:if>
 </xsl:template>

--- a/xmlcalabash/src/main/resources/com/xmlcalabash/xml-calabash.rnc
+++ b/xmlcalabash/src/main/resources/com/xmlcalabash/xml-calabash.rnc
@@ -60,6 +60,7 @@ cc.inline =
 cc.graphviz =
     element cc:graphviz {
         attribute dot { text },
+        attribute style { text }?,
         empty
     }
 


### PR DESCRIPTION
With this PR, you can add a ‘style’ attribute to the `cc:graphviz` configuration element. That identifies a stylesheet that’s applied to the XML model of the pipelines and graphs before they’re styled with graphviz. It can do this by adding dot:* attributes to nodes and edges. Documentation, TBD.

Related to #336 but I won't close that until there's at least some documentation.