### PR TITLE
Raise an exception of a value template expression has a syntax error

### DIFF
--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/XProcAvtExpression.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/XProcAvtExpression.kt
@@ -14,7 +14,10 @@ class XProcAvtExpression private constructor(stepConfig: XProcStepConfiguration,
     }
 
     override fun cast(asType: SequenceType, values: List<XdmAtomicValue>): XProcExpression {
-        return avt(stepConfig, avt, asType, values)
+        if (details.error == null) {
+            return avt(stepConfig, avt, asType, values)
+        }
+        return this
     }
 
     override fun xevaluate(config: XProcStepConfiguration): () -> XdmValue {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/XProcExpression.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/XProcExpression.kt
@@ -17,7 +17,8 @@ abstract class XProcExpression(val stepConfig: XProcStepConfiguration, val asTyp
             val expr = XProcSelectExpression.newInstance(stepConfig, select, asType, collection, values)
             expr._details = XPathExpressionParser(stepConfig).parse(select)
             if (expr.details.error != null) {
-                throw stepConfig.exception(XProcError.xsXPathStaticError(expr.details.error?.message ?: ""), expr.details.error!!)
+                stepConfig.warn { "Invalid select expression: ${select}: ${expr.details.error?.message ?: "(no explanation)"}" }
+                //throw stepConfig.exception(XProcError.xsXPathStaticError(expr.details.error?.message ?: ""), expr.details.error!!)
             }
             return expr
         }
@@ -34,7 +35,8 @@ abstract class XProcExpression(val stepConfig: XProcStepConfiguration, val asTyp
             val expr = XProcMatchExpression.newInstance(stepConfig, match)
             expr._details = XPathExpressionParser(stepConfig).parse(match)
             if (expr.details.error != null) {
-                throw stepConfig.exception(XProcError.xsXPathStaticError(expr.details.error?.message ?: ""), expr.details.error!!)
+                stepConfig.warn { "Invalid match expression: ${match}: ${expr.details.error?.message ?: "(no explanation)"}" }
+                //throw stepConfig.exception(XProcError.xsXPathStaticError(expr.details.error?.message ?: ""), expr.details.error!!)
             }
             return expr
         }
@@ -50,6 +52,10 @@ abstract class XProcExpression(val stepConfig: XProcStepConfiguration, val asTyp
             val functions = mutableSetOf<Pair<QName,Int>>()
             for (avtExpr in avt.expressions()) {
                 val details = parser.parse(avtExpr)
+                if (error == null && details.error != null) {
+                    val s = "Invalid value template expression: ${avtExpr}: ${details.error.message ?: "(no explanation)"}"
+                    stepConfig.warn { "Invalid value template expression: ${avtExpr}: ${details.error.message ?: "(no explanation)"}" }
+                }
                 error = error ?: details.error
                 context = context || details.contextRef
                 alwaysDynamic = alwaysDynamic || details.alwaysDynamic

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/XProcError.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/XProcError.kt
@@ -209,6 +209,7 @@ open class XProcError protected constructor(val code: QName, val variant: Int, e
         fun xdUrifyDifferentSchemes(filepath: String, basedir: String) = dynamic(77, filepath, basedir)
         fun xdInvalidContentType(value: String) = dynamic(79, value)
         fun xdUrifyNonhierarchicalBase(filepath: String, basedir: String) = dynamic(80, filepath, basedir)
+        fun xdInvalidExpression(expression: String) = dynamic(83, expression)
 
         fun xdTvtCannotSerializeAttributes(name: String) = dynamic(84, name)
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/internal/ExpressionStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/internal/ExpressionStep.kt
@@ -23,6 +23,11 @@ open class ExpressionStep(val params: ExpressionStepParameters): AbstractAtomicS
 
     override fun run() {
         super.run()
+
+        params.expression.details.error?.let {
+            throw throw stepConfig.exception(XProcError.xsXPathStaticError(params.expression.toString()), it)
+        }
+
         // Expression steps are unusual in that source may not exist
         contextItems.addAll(queues["source"] ?: emptyList())
 

--- a/xmlcalabash/src/main/resources/com/xmlcalabash/explain-errors.txt
+++ b/xmlcalabash/src/main/resources/com/xmlcalabash/explain-errors.txt
@@ -274,6 +274,12 @@ XD0080
 Cannot resolve path (“$1”) with a non-hierarchical base URI: “$2”.
 It is a dynamic error if the basedir has a non-hierarchical scheme.
 
+XD0083
+Invalid expression: “$1”.
+The expression cannot be evaluated (because of errors in expression syntax,
+references to unbound namespace prefixes, references to unknown variables or
+functions, etc.).
+
 XS0001
 Pipeline contains a loop through “$1”.
 It is a static error if there are any loops in the connections between steps,


### PR DESCRIPTION
Fix #342

Syntactically invalid AVTs weren’t raising a syntax error and the evaluation step wasn’t reporting it. This lead to odd dynamic errors. On reflection, none of the expression errors should be raised at the point of compilation. Instead a warning is issued and the error only occurs if the expression is evaluated.