### PR TITLE
Attempt to improve the way writing to standard output is handled

### DIFF
--- a/app/src/main/kotlin/com/xmlcalabash/app/FileOutputReceiver.kt
+++ b/app/src/main/kotlin/com/xmlcalabash/app/FileOutputReceiver.kt
@@ -3,6 +3,7 @@ package com.xmlcalabash.app
 import com.xmlcalabash.config.XmlCalabash
 import com.xmlcalabash.documents.XProcDocument
 import com.xmlcalabash.io.DocumentWriter
+import com.xmlcalabash.runtime.api.RuntimePort
 import com.xmlcalabash.util.DefaultOutputReceiver
 import net.sf.saxon.s9api.Processor
 import org.apache.logging.log4j.kotlin.logger
@@ -10,9 +11,10 @@ import java.io.FileOutputStream
 
 class FileOutputReceiver(xmlCalabash: XmlCalabash,
                          processor: Processor,
+                         outputManifold: Map<String,RuntimePort>,
                          val files: Map<String,OutputFilename>,
                          val stdout: String?
-): DefaultOutputReceiver(xmlCalabash, processor) {
+): DefaultOutputReceiver(xmlCalabash, processor, outputManifold, outputManifold.keys - files.keys) {
 
     private val wroteTo = mutableSetOf<String>()
 

--- a/app/src/main/kotlin/com/xmlcalabash/app/XmlCalabashCli.kt
+++ b/app/src/main/kotlin/com/xmlcalabash/app/XmlCalabashCli.kt
@@ -312,7 +312,7 @@ class XmlCalabashCli private constructor() {
                 pipeline.option(name, XProcDocument.ofValue(value, stepConfig, MediaType.OCTET_STREAM, DocumentProperties()))
             }
 
-            pipeline.receiver = FileOutputReceiver(xmlCalabash, xmlCalabash.saxonConfig.processor, commandLine.outputs, explicitStdout ?: implicitStdout)
+            pipeline.receiver = FileOutputReceiver(xmlCalabash, xmlCalabash.saxonConfig.processor, pipeline.outputManifold, commandLine.outputs, explicitStdout ?: implicitStdout)
             pipeline.run()
         } catch (ex: Exception) {
             if (ex is XProcException) {

--- a/documentation/src/userguide/run.xml
+++ b/documentation/src/userguide/run.xml
@@ -194,8 +194,13 @@ output port is bound to some other output, no output will be sent to standard ou
 
 <para>If piped mode is not enabled, and no port is explicitly bound to standard
 output, the pipeline will write the output from all otherwise unbound output
-ports to standard output. If standard output appears to be going to a terminal
-window:</para>
+ports to standard output. If exactly one port is being written to standard
+output, and if that port cannot produce a sequence, then the output is written
+directly to standard output.</para>
+
+<para>If more than one port may appear on standard output, or if a sequence of
+documents may appear, and if standard output appears to be going to a terminal
+window, “decoration” is added as an aid to comprehension:</para>
 
 <itemizedlist>
 <listitem>
@@ -216,8 +221,9 @@ one document is output).</para>
 
 <para>The method for determining whether output is going to a terminal or being
 redirected isn’t terribly sophisticated and may be wrong in some
-circumstances. It’s safer to use <option>--output</option> to write to a file
-if you want to save the output or enable piped mode.</para>
+circumstances. It’s safer to explicitly enable piped mode or
+use <option>--output</option> to write to a file
+if you want to save the output.</para>
 </listitem>
 </varlistentry>
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/XProcPipeline.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/XProcPipeline.kt
@@ -27,7 +27,7 @@ class XProcPipeline internal constructor(runtime: XProcRuntime, pipeline: Compou
     val outputManifold = pipeline.outputs
     val optionManifold = pipeline.options
     val runnable: CompoundStep
-    var receiver: Receiver = DefaultOutputReceiver(pipeline.stepConfig)
+    var receiver: Receiver = DefaultOutputReceiver(pipeline.stepConfig, outputManifold)
     private val setOptions = mutableSetOf<QName>()
     private val boundInputs = mutableSetOf<String>()
     private var traceListener: TraceListener? = null


### PR DESCRIPTION
Fix #360

This is an attempt to make standard output easier to use. If only a single port is writing to standard output, and if that port cannot produce a sequence, then the output appears without any decoration.