### PR TITLE
Send message output to stderr instead of stdout

### DIFF
--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/DefaultMessagePrinter.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/DefaultMessagePrinter.kt
@@ -4,7 +4,7 @@ import com.xmlcalabash.io.MessagePrinter
 import java.io.PrintStream
 
 class DefaultMessagePrinter(override val encoding: String) : MessagePrinter {
-    private var _printStream: PrintStream = System.out
+    private var _printStream: PrintStream = System.err
     private val stream: PrintStream
         get() = _printStream
     private val mustSanitize = !encoding.lowercase().startsWith("utf")


### PR DESCRIPTION
Fix #370

This is a user-visible change, but I can’t think of another solution. If you explicitly request that pipeline output should go to stdout, we can’t also write messages there. (The fact that we *didn’t* was accidental, but nevermind.)

If you want to capture the pipeline output, you don’t want the messages mixed in, so stderr is arguably a better destination anyway.