### PR TITLE
Add content-type support to document caching

### DIFF
--- a/documentation/src/reference/extension-steps/cx-cache-add.xml
+++ b/documentation/src/reference/extension-steps/cx-cache-add.xml
@@ -28,25 +28,42 @@ the cache.</para>
 <refsection>
 <title>Description</title>
 
-<para>If a step attempts to load a URI, and that URI is present in the cache,
-the cached value will always be returned. Some steps use the cache implicitly
-(for example, the validate steps update it to hold schema documents).</para>
+<para>XML Calabash maintains a document cache while the pipeline is running. The
+<tag>cx:cache-add</tag> allows a pipeline author to explicitly add a document to
+the cache. Some steps use the cache implicitly (for example, the validate steps
+update it to hold schema documents). When a request is made for a document (by a
+step, by one of the URI resolvers, etc.), if it appears in the cache, a cached document
+will be returned.</para>
 
-<para>A pipeline can add a document to the cache explicitly with <tag>cx:cache-add</tag>.
-If the <option>href</option> option is provided, it is used as the URI for
+<para>The cache has two levels. At the top level, a URI maps to a second level
+cache that maps from content types to documents. In this way, the cache can
+contain different representations for the same URI provided that they have
+different content types.</para>
+
+<para>The processor uses the combination of a URI and a content type to locate
+documents in the cache. If an exact content type match is found
+for a URI, that document is returned. If there isn’t an exact match, the cache
+tries to return a document of the right “type”: an XML document for an XML content type,
+a text document for a text content type, etc. If there’s no type match at all, an arbitrary
+document will be returned.</para>
+
+<para>If the <option>href</option> option is provided, it is used as the URI for
 caching, otherwise the <port>source</port> document URI is used.
 <error code="I0030">It is a
 <glossterm>dynamic error</glossterm> if the <port>source</port> document does not have
 a base URI and the <option>href</option> option is not provided.</error>
 </para>
 
-<para>Irrespective of the cache URI, the step simply copies it’s <port>source</port>
+<para>Irrespective of the cache URI, the step simply copies its <port>source</port>
 document to the <port>result</port> port. (It does not change the document’s base URI,
 even if an <option>href</option> option is provided to the <tag>cx:cache-add</tag> step.)</para>
 
 <para><error code="I0037">It is a <glossterm>dynamic error</glossterm> if the
 <option>fail-if-in-cache</option> option is <literal>true</literal> and the
 cache already contains a document with the URI being cached.</error></para>
+
+<para>A pipeline author can remove documents from the cache with <tag>cx:cache-delete</tag>.
+</para>
 
 <refsection>
 <title>Options</title>

--- a/documentation/src/reference/extension-steps/cx-cache-delete.xml
+++ b/documentation/src/reference/extension-steps/cx-cache-delete.xml
@@ -13,7 +13,7 @@
 <refsynopsisdiv>
 <refsection role="introduction">
 <title>Introduction</title>
-<para>XML Calabash maintains a cache of documents. This step removes a document from
+<para>XML Calabash maintains a cache of documents. This step deletes a document from
 the cache.</para>
 
 </refsection>
@@ -29,31 +29,32 @@ the cache.</para>
 <refsection>
 <title>Description</title>
 
-<para>XML Calabash maintains a cache of documents. If a step attempts to load a
-URI, and that URI is present in the cache, the cached value will always be
-returned. Some steps use the cache implicitly (for example, the validate steps
-update it to hold schema documents).</para>
-
-<para>A pipeline can remove a document from the cache explicitly with <tag>cx:cache-delete</tag>.
-If the <option>href</option> option is provided, it is used as the URI for
-caching, otherwise the <port>source</port> document URI is used.
-<error code="I0030">It is a
-<glossterm>dynamic error</glossterm> if the <port>source</port> document does not have
-a base URI and the <option>href</option> option is not provided.</error>
+<para>XML Calabash maintains a cache of documents, see <tag>cx:cache-add</tag>
+for a description of how this works. A pipeline can delete a document from the
+cache explicitly with <tag>cx:cache-delete</tag>. If the <option>href</option>
+option is provided, it is used as the URI for caching, otherwise the
+<port>source</port> document URI is used. <error code="I0030">It is a
+<glossterm>dynamic error</glossterm> if the <port>source</port> document does
+not have a base URI and the <option>href</option> option is not
+provided.</error>
 </para>
 
-<para>Irrespective of the cache URI, the step simply copies it’s <port>source</port>
+<para>Irrespective of the cache URI, the step simply copies its <port>source</port>
 document to the <port>result</port> port. (It does not change the document’s base URI,
-even if an <option>href</option> option is provided to the <tag>cx:cache-add</tag> step.)</para>
+even if an <option>href</option> option is provided to the <tag>cx:cache-delete</tag> step.)</para>
 
 <para><error code="I0038">It is a <glossterm>dynamic error</glossterm> if the
 <option>fail-if-not-in-cache</option> option is <literal>true</literal> and the
 cache does not contains a document with the URI being cached.</error></para>
 
+<para>The <tag>cx:cache-delete</tag> step will only delete documents that match
+that content type. (Wildcards may be used for the media type and
+subtype).</para>
+
 <refsection>
 <title>Options</title>
 
-<para>There are two  options.</para>
+<para>There are three options.</para>
 
 <variablelist>
 <varlistentry><term><option>href</option></term>
@@ -64,6 +65,11 @@ cache does not contains a document with the URI being cached.</error></para>
 <varlistentry><term><option>fail-if-not-in-cache</option></term>
 <listitem>
 <para>Determines whether the URI must already exist in the cache.</para>
+</listitem>
+</varlistentry>
+<varlistentry><term><option>content-type</option></term>
+<listitem>
+<para>Determines which content-type hits in the cache will be deleted.</para>
 </listitem>
 </varlistentry>
 </variablelist>

--- a/ext/cache/src/main/kotlin/com/xmlcalabash/ext/cache/CacheAddStep.kt
+++ b/ext/cache/src/main/kotlin/com/xmlcalabash/ext/cache/CacheAddStep.kt
@@ -3,6 +3,7 @@ package com.xmlcalabash.ext.cache
 import com.xmlcalabash.documents.DocumentProperties
 import com.xmlcalabash.documents.XProcDocument
 import com.xmlcalabash.exceptions.XProcError
+import com.xmlcalabash.io.MediaType
 import com.xmlcalabash.namespace.Ns
 import com.xmlcalabash.steps.AbstractAtomicStep
 import net.sf.saxon.om.NamespaceUri
@@ -26,7 +27,8 @@ class CacheAddStep(): AbstractAtomicStep() {
         }
 
         if (href != null) {
-            if (failIfCached && stepConfig.environment.documentManager.getCached(href) != null) {
+            val contentType = document.contentType ?: MediaType.OCTET_STREAM
+            if (failIfCached && stepConfig.environment.documentManager.getCached(href, contentType) != null) {
                 throw stepConfig.exception(XProcError.xiDocumentInCache(href))
             }
             val props = DocumentProperties(document.properties)

--- a/ext/cache/src/main/kotlin/com/xmlcalabash/ext/cache/CacheDeleteStep.kt
+++ b/ext/cache/src/main/kotlin/com/xmlcalabash/ext/cache/CacheDeleteStep.kt
@@ -3,10 +3,13 @@ package com.xmlcalabash.ext.cache
 import com.xmlcalabash.documents.DocumentProperties
 import com.xmlcalabash.documents.XProcDocument
 import com.xmlcalabash.exceptions.XProcError
+import com.xmlcalabash.io.MediaType
 import com.xmlcalabash.namespace.Ns
+import com.xmlcalabash.namespace.Ns.mediaType
 import com.xmlcalabash.steps.AbstractAtomicStep
 import net.sf.saxon.om.NamespaceUri
 import net.sf.saxon.s9api.QName
+import net.sf.saxon.s9api.XdmEmptySequence
 
 class CacheDeleteStep(): AbstractAtomicStep() {
     companion object {
@@ -20,17 +23,23 @@ class CacheDeleteStep(): AbstractAtomicStep() {
         val failIfNotCached = booleanBinding(failIfNotInCache)!!
         val href = uriBinding(Ns.href)
 
+        var contentType: MediaType? = document.contentType ?: MediaType.OCTET_STREAM
+        val ctypeOption = options[Ns.contentType]!!.value
+        if (ctypeOption !== XdmEmptySequence.getInstance()) {
+            contentType = wildcardMediaTypeBinding(Ns.contentType)
+        }
+
         if (href == null && document.baseURI == null) {
             throw stepConfig.exception(XProcError.xiBaseUriRequiredToCache())
         }
 
         if (href != null) {
-            if (failIfNotCached && stepConfig.environment.documentManager.getCached(href) == null) {
+            if (failIfNotCached && stepConfig.environment.documentManager.getCached(href, contentType!!) == null) {
                 throw stepConfig.exception(XProcError.xiDocumentNotInCache(href))
             }
             val props = DocumentProperties(document.properties)
             props.set(Ns.baseUri, href)
-            stepConfig.environment.documentManager.uncache(document.with(props))
+            stepConfig.environment.documentManager.uncache(document.with(props), contentType!!)
         } else {
             if (failIfNotCached && stepConfig.environment.documentManager.getCached(document.baseURI!!) == null) {
                 throw stepConfig.exception(XProcError.xiDocumentNotInCache(document.baseURI!!))

--- a/ext/cache/src/main/resources/com/xmlcalabash/ext/cache.xpl
+++ b/ext/cache/src/main/resources/com/xmlcalabash/ext/cache.xpl
@@ -13,6 +13,7 @@
   <p:declare-step type="cx:cache-delete">
     <p:option name="href" as="xs:anyURI?" select="()"/>
     <p:option name="fail-if-not-in-cache" as="xs:boolean" select="false()"/>
+    <p:option name="content-type" as="xs:string" select="'*/*'"/>
     <p:input port="source"/>
     <p:output port="result"/>
   </p:declare-step>

--- a/tests/extra-suite/test-suite/tests/cache-007.xml
+++ b/tests/extra-suite/test-suite/tests/cache-007.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+  <t:info>
+    <t:title>cache-007</t:title>
+    <t:revision-history>
+      <t:revision>
+        <t:date>2025-04-16</t:date>
+        <t:author>
+          <t:name>Norm Tovey-Walsh</t:name>
+        </t:author>
+        <t:description xmlns="http://www.w3.org/1999/xhtml">
+          <p>Created test.</p>
+        </t:description>
+      </t:revision>
+    </t:revision-history>
+  </t:info>
+  <t:description xmlns="http://www.w3.org/1999/xhtml">
+    <p>Tests that the same URI with different content types can be cached.</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0"
+                    xmlns:err="http://www.w3.org/ns/xproc-error"
+                    xmlns:cx="http://xmlcalabash.com/ns/extensions"
+                    xmlns:p="http://www.w3.org/ns/xproc">
+      <p:import href="https://xmlcalabash.com/ext/library/cache.xpl"/>
+      <p:output port="result"/>
+
+      <cx:cache-add name="cache-add-1"
+                    href="https://xmlcalabash.com/does/not/exist.xml">
+        <p:with-input>
+          <does-so/>
+        </p:with-input>
+      </cx:cache-add>
+
+      <cx:cache-add name="cache-add-2"
+                    href="https://xmlcalabash.com/does/not/exist.xml">
+        <p:with-input>
+          <p:inline content-type="text/plain">&lt;actually-text&gt;</p:inline>
+        </p:with-input>
+      </cx:cache-add>
+
+      <p:try>
+        <p:xinclude depends="cache-add-1 cache-add-2">
+          <p:with-input>
+            <doc xmlns:xi="http://www.w3.org/2001/XInclude">
+              <as-xml><xi:include href="https://xmlcalabash.com/does/not/exist.xml"/></as-xml>
+              <as-text><xi:include href="https://xmlcalabash.com/does/not/exist.xml" parse="text"/></as-text>
+            </doc>
+          </p:with-input>
+        </p:xinclude>
+        <p:catch code="err:XC0029">
+          <p:identity>
+            <p:with-input>
+              <fail/>
+            </p:with-input>
+          </p:identity>
+        </p:catch>
+      </p:try>
+    </p:declare-step>
+  </t:pipeline>
+  <t:schematron>
+    <s:schema queryBinding="xslt2"
+              xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:pattern>
+        <s:rule context="/">
+          <s:assert test="doc">The document root is not doc.</s:assert>
+          <s:assert test="doc/as-xml/does-so">The document doesn’t contain does-so.</s:assert>
+          <s:assert test="contains(doc/as-text, '&lt;actually-text&gt;')"
+                    >The document doesn’t contain actually-text.</s:assert>
+        </s:rule>
+      </s:pattern>
+    </s:schema>
+  </t:schematron>
+</t:test>

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/CompileEnvironment.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/CompileEnvironment.kt
@@ -83,8 +83,8 @@ open class CompileEnvironment(override val episode: String, override val xmlCala
     override val messagePrinter: MessagePrinter = xmlCalabash.config.messagePrinter
     override val messageReporter: MessageReporter = xmlCalabash.config.messageReporter
     override val monitors: MutableList<Monitor> = mutableListOf()
-    override val documentManager: DocumentManager = DocumentManager()
     override val mimeTypes: MimetypesFileTypeMap = MimetypesFileTypeMap()
+    override val documentManager: DocumentManager = DocumentManager(this)
     override val errorExplanation: ErrorExplanation = DefaultErrorExplanation(messagePrinter)
     override val proxies: Map<String, String> = emptyMap()
     override val assertions: AssertionsLevel = xmlCalabash.config.assertions

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/PipelineVisualization.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/PipelineVisualization.kt
@@ -180,6 +180,8 @@ class PipelineVisualization private constructor(val instruction: XProcInstructio
             when (child) {
                 is InputInstruction, is OutputInstruction -> Unit
                 is WithInputInstruction, is WithOutputInstruction -> Unit
+                // What should we actually do with this?
+                is WithOptionInstruction -> Unit
                 else -> describe(child, localns)
             }
         }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/io/MediaType.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/io/MediaType.kt
@@ -152,13 +152,44 @@ class MediaType private constructor(val mediaType: String, val mediaSubtype: Str
         }
 
         fun parse(mtype: String, forceEncoding: String? = null): MediaType {
-            var ctype = parseMatch(mtype, forceEncoding)
+            val ctype = parseMatch(mtype, forceEncoding)
             if (!"[A-Za-z0-9][-A-Za-z0-9!#\$&0^_\\\\.+]*".toRegex().matches(ctype.mediaType) || ctype.mediaType.length > 127) {
                 throw XProcError.xdInvalidContentType(mtype).exception()
             }
-            if (!"[A-Za-z0-9][-A-Za-z0-9!#\$&0^_\\\\.+]*".toRegex().matches(ctype.mediaSubtype) || ctype.mediaSubtype.length > 127) {
+
+            val subtype = if (ctype.suffix != null) {
+                "${ctype.mediaSubtype}+${ctype.suffix}"
+            } else {
+                ctype.mediaSubtype
+            }
+
+            if (!"[A-Za-z0-9][-A-Za-z0-9!#\$&0^_\\\\.+]*".toRegex().matches(subtype) || subtype.length > 127) {
                 throw XProcError.xdInvalidContentType(mtype).exception()
             }
+
+            return ctype
+        }
+
+        fun parseWildcard(mtype: String, forceEncoding: String? = null): MediaType {
+            val ctype = parseMatch(mtype, forceEncoding)
+            if (ctype.mediaType != "*") {
+                if (!"[A-Za-z0-9][-A-Za-z0-9!#\$&0^_\\\\.+]*".toRegex().matches(ctype.mediaType) || ctype.mediaType.length > 127) {
+                    throw XProcError.xdInvalidContentType(mtype).exception()
+                }
+            }
+
+            val subtype = if (ctype.suffix != null) {
+                "${ctype.mediaSubtype}+${ctype.suffix}"
+            } else {
+                ctype.mediaSubtype
+            }
+
+            if (ctype.mediaSubtype != "*") {
+                if (!"[A-Za-z0-9][-A-Za-z0-9!#\$&0^_\\\\.+]*".toRegex().matches(subtype) || subtype.length > 127) {
+                    throw XProcError.xdInvalidContentType(mtype).exception()
+                }
+            }
+
             return ctype
         }
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/AbstractAtomicStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/AbstractAtomicStep.kt
@@ -239,6 +239,14 @@ abstract class AbstractAtomicStep(): XProcStep {
         return MediaType.parse(value.underlyingValue.stringValue)
     }
 
+    fun wildcardMediaTypeBinding(name: QName, default: MediaType = MediaType.ANY): MediaType {
+        val value = options[name]!!.value
+        if (value == XdmEmptySequence.getInstance()) {
+            return default
+        }
+        return MediaType.parseWildcard(value.underlyingValue.stringValue)
+    }
+
     fun stringMapBinding(name: QName): Map<String,String> {
         if (options[name] == null) {
             return mapOf()

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/XIncludeStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/XIncludeStep.kt
@@ -5,6 +5,7 @@ import com.nwalsh.sinclude.DocumentResolver
 import com.nwalsh.sinclude.XInclude
 import com.xmlcalabash.documents.XProcDocument
 import com.xmlcalabash.exceptions.XProcError
+import com.xmlcalabash.io.MediaType
 import com.xmlcalabash.namespace.Ns
 import com.xmlcalabash.namespace.NsCx
 import net.sf.saxon.s9api.XdmNode
@@ -33,7 +34,7 @@ open class XIncludeStep(): AbstractAtomicStep() {
     inner class XiResolver(val defaultResolver: DocumentResolver): DocumentResolver {
         override fun resolveXml(base: XdmNode, uri: String, accept: String?, acceptLanguage: String?): XdmNode? {
             val href = base.baseURI.resolve(uri)
-            val cached = stepConfig.environment.documentManager.getCached(href)
+            val cached = stepConfig.environment.documentManager.getCached(href, MediaType.XML)
             if (cached == null) {
                 return defaultResolver.resolveXml(base, uri, accept, acceptLanguage)
             }
@@ -47,7 +48,7 @@ open class XIncludeStep(): AbstractAtomicStep() {
 
         override fun resolveText(base: XdmNode, uri: String, encoding: String?, accept: String?, acceptLanguage: String?): XdmNode? {
             val href = base.baseURI.resolve(uri)
-            val cached = stepConfig.environment.documentManager.getCached(href)
+            val cached = stepConfig.environment.documentManager.getCached(href, MediaType.TEXT)
             if (cached == null) {
                 return defaultResolver.resolveText(base, uri, encoding, accept, acceptLanguage)
             }


### PR DESCRIPTION
Fix #353

This PR updates the way the internal document cache is used so that the same URI can appear in the cache with different content types. For example, to support both XML and text inclusions with XInclude. The documentation for the cx:cache-add and cx:cache-delete steps has been updated to describe how this works.