### PR TITLE
Fix bugs in implicit validation

### DIFF
--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/config/StepConfiguration.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/config/StepConfiguration.kt
@@ -16,7 +16,7 @@ open class StepConfiguration(val saxonConfig: SaxonConfiguration,
     protected val _inscopeStepTypes = mutableMapOf<QName, DeclareStepInstruction>()
     val inscopeStepTypes: Map<QName, DeclareStepInstruction> = _inscopeStepTypes
 
-    var validationMode = ValidationMode.LAX
+    var validationMode = ValidationMode.DEFAULT
 
     var _qnameMapType: SequenceType? = null
     val qnameMapType: SequenceType

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/documents/DocumentProperties.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/documents/DocumentProperties.kt
@@ -5,6 +5,7 @@ import com.xmlcalabash.namespace.Ns
 import com.xmlcalabash.util.MediaClassification
 import net.sf.saxon.s9api.QName
 import net.sf.saxon.s9api.XdmAtomicValue
+import net.sf.saxon.s9api.XdmEmptySequence
 import net.sf.saxon.s9api.XdmMap
 import net.sf.saxon.s9api.XdmValue
 import java.net.URI
@@ -124,9 +125,9 @@ class DocumentProperties() {
 
     val baseURI: URI?
         get() {
-            if (properties.containsKey(Ns.baseUri)) {
-                // FIXME: get directly from the underlying value?
-                return URI(properties[Ns.baseUri]!!.underlyingValue.stringValue)
+            val base = properties[Ns.baseUri]
+            if (base != null && (base !== XdmEmptySequence.getInstance())) {
+                return URI(base.underlyingValue.stringValue)
             }
             return null
         }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/documents/XProcDocument.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/documents/XProcDocument.kt
@@ -157,7 +157,7 @@ open class XProcDocument internal constructor() {
             return ofXml(value, context, contentType, DocumentProperties())
         }
         fun ofXml(value: XdmNode, context: DocumentContext, contentType: MediaType, properties: DocumentProperties): XProcDocument {
-            val baseURI = value.baseURI ?: context.baseUri
+            val baseURI = properties.baseURI ?: value.baseURI ?: context.baseUri
             return XProcDocument(value, context, withDefaults(properties, baseURI, contentType))
         }
         fun ofXml(value: XdmNode, context: DocumentContext): XProcDocument {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/io/DocumentLoader.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/io/DocumentLoader.kt
@@ -167,7 +167,7 @@ class DocumentLoader(val stepConfig: StepConfiguration,
         properties.setAll(documentProperties)
         properties[Ns.contentType] = mediaType
 
-        if (properties.baseURI == null) {
+        if (!properties.has(Ns.baseUri)) {
             properties[Ns.baseUri] = file.toURI()
         }
 
@@ -215,7 +215,7 @@ class DocumentLoader(val stepConfig: StepConfiguration,
         mediaType = overrideMediaType
         properties.setAll(documentProperties)
         properties[Ns.contentType] = mediaType
-        if (href != null && properties.baseURI == null) {
+        if (href != null && !properties.has(Ns.baseUri)) {
             properties[Ns.baseUri] = href
         }
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/AtomicStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/AtomicStep.kt
@@ -13,6 +13,7 @@ import com.xmlcalabash.runtime.api.Receiver
 import com.xmlcalabash.runtime.model.AtomicBuiltinStepModel
 import com.xmlcalabash.runtime.parameters.RuntimeStepParameters
 import com.xmlcalabash.steps.AbstractAtomicStep
+import com.xmlcalabash.util.MediaClassification
 import com.xmlcalabash.util.S9Api
 import com.xmlcalabash.util.SaxonXsdValidator
 import net.sf.saxon.s9api.ValidationMode
@@ -71,8 +72,8 @@ open class AtomicStep(config: XProcStepConfiguration, atomic: AtomicBuiltinStepM
             } else {
                 if (stepConfig.validationMode != ValidationMode.DEFAULT && params.inputs[port]?.primary == true) {
                     val curVal = doc.properties[NsCx.validationMode]?.underlyingValue?.stringValue
-                    val validatable = (doc.value is XdmNode) &&!S9Api.isTextDocument(doc.value as XdmNode)
-                    if (false && validatable && (curVal == null || (curVal == "lax" && stepConfig.validationMode != ValidationMode.STRICT))) {
+                    val validatable = doc.contentType?.classification() == MediaClassification.XML
+                    if (validatable && (curVal == null || (curVal == "lax" && stepConfig.validationMode != ValidationMode.STRICT))) {
                         if (validator == null) {
                             validator = SaxonXsdValidator(stepConfig)
                         }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/CompoundStepHead.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/CompoundStepHead.kt
@@ -8,6 +8,7 @@ import com.xmlcalabash.namespace.NsP
 import com.xmlcalabash.runtime.XProcStepConfiguration
 import com.xmlcalabash.runtime.model.HeadModel
 import com.xmlcalabash.runtime.parameters.RuntimeStepParameters
+import com.xmlcalabash.util.MediaClassification
 import com.xmlcalabash.util.SaxonXsdValidator
 import com.xmlcalabash.util.Verbosity
 import net.sf.saxon.s9api.*
@@ -220,8 +221,8 @@ class CompoundStepHead(config: XProcStepConfiguration, val parent: CompoundStep,
             if (cache[port] != null) {
                 if (params.outputs[port]?.primary == true) {
                     for (doc in cache[port]!!) {
-                        //documents.add(validate(doc))
-                        documents.add(doc)
+                        documents.add(validate(doc))
+                        //documents.add(doc)
                     }
                 } else {
                     documents.addAll(cache[port]!!)
@@ -271,7 +272,7 @@ class CompoundStepHead(config: XProcStepConfiguration, val parent: CompoundStep,
     }
 
     private fun validate(document: XProcDocument): XProcDocument {
-        if (stepConfig.validationMode == ValidationMode.DEFAULT) {
+        if (stepConfig.validationMode == ValidationMode.DEFAULT || document.contentType?.classification() != MediaClassification.XML) {
             return document
         }
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/SaxonXsdValidator.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/SaxonXsdValidator.kt
@@ -200,6 +200,12 @@ class SaxonXsdValidator(val stepConfig: XProcStepConfiguration) {
             val props = DocumentProperties(source.properties)
             props[NsCx.validationMode] = XdmAtomicValue(vmode)
 
+            // Special case, if the input document has no base URI, don't let this
+            // validation manufacture a default one...
+            if (props.baseURI == null) {
+                props[Ns.baseUri] = XdmEmptySequence.getInstance()
+            }
+
             return XProcDocument.ofXml(destination.xdmNode, stepConfig, props)
         }
     }


### PR DESCRIPTION
Implicit validation was accidentally enabled by default. (Well, not in alpha27 where it’s disabled entirely.) There were also some issues with correct handling of the base URI when the base URI was explicitly absent.