### PR TITLE
Improve error messages by including more detail

### DIFF
--- a/app/src/main/kotlin/com/xmlcalabash/app/XmlCalabashCli.kt
+++ b/app/src/main/kotlin/com/xmlcalabash/app/XmlCalabashCli.kt
@@ -20,6 +20,7 @@ import com.xmlcalabash.namespace.NsFn
 import com.xmlcalabash.namespace.NsXs
 import com.xmlcalabash.spi.DocumentResolverServiceProvider
 import com.xmlcalabash.util.DefaultMessagePrinter
+import com.xmlcalabash.util.ErrorDetail
 import com.xmlcalabash.util.UriUtils
 import com.xmlcalabash.util.Verbosity
 import com.xmlcalabash.util.VisualizerOutput
@@ -448,6 +449,19 @@ class XmlCalabashCli private constructor() {
 
         for (error in errors) {
             errorExplanation.report(error.error)
+
+            when (error.error.code) {
+                NsErr.xc(93) -> {
+                    // This is kind of awful
+                    val reports = error.error.details[2] as List<*>
+                    for (anyReport in reports) {
+                        val report = anyReport as ErrorDetail
+                        stepConfig.xmlCalabashConfig.messageReporter.report(Verbosity.ERROR, report.extra) { report.message }
+                    }
+                }
+                else -> Unit
+            }
+
             if (commandLine.explainErrors) {
                 errorExplanation.reportExplanation(error.error)
             }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/DefaultErrorExplanation.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/DefaultErrorExplanation.kt
@@ -79,12 +79,9 @@ class DefaultErrorExplanation(val printer: MessagePrinter): ErrorExplanation {
             sb.append("\n").append("   cause: ${error.throwable!!.toString()}")
         }
 
-        if (error.details.isNotEmpty()) {
-            sb.append("\n")
-        }
-
         for (detail in error.details) {
             if (detail is XProcDocument) {
+                sb.append("\n")
                 sb.append(showDetail(detail))
             }
         }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/XProcError.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/XProcError.kt
@@ -4,6 +4,7 @@ import com.xmlcalabash.datamodel.Location
 import com.xmlcalabash.io.MediaType
 import com.xmlcalabash.documents.XProcDocument
 import com.xmlcalabash.namespace.NsErr
+import com.xmlcalabash.util.ErrorDetail
 import net.sf.saxon.s9api.*
 import java.net.URI
 import java.util.*
@@ -278,7 +279,7 @@ open class XProcError protected constructor(val code: QName, val variant: Int, e
 
         fun xcUnsupportedScheme(scheme: String) = step(90, scheme)
         fun xcAttributeNameCollision(name: String) = step(92, name)
-        fun xcXsltCompileError(message: String, exception: Exception) = step(93, message, exception)
+        fun xcXsltCompileError(message: String, exception: Exception, details: List<ErrorDetail>) = step(93, message, exception, details)
         fun xcXsltInputNot20Compatible() = step(Pair(94,1))
         fun xcXsltInputNot20Compatible(media: MediaType) = step(Pair(94,2), media)
         fun xcXsltRuntimeError(message: String) = step(95, message)

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/functions/PipelineFunction.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/functions/PipelineFunction.kt
@@ -36,11 +36,11 @@ class PipelineFunction(private val decl: DeclareStepInstruction): ExtensionFunct
     }
 
     override fun getMinimumNumberOfArguments(): Int {
-        return inputs.size
+        return 1
     }
 
     override fun getMaximumNumberOfArguments(): Int {
-        return 1
+        return inputs.size + 1
     }
 
     override fun getArgumentTypes(): Array<out SequenceType?>? {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/XsltStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/XsltStep.kt
@@ -192,7 +192,7 @@ open class XsltStep(): AbstractAtomicStep() {
                 else -> throw stepConfig.exception(XProcError.xcXsltRuntimeError(sae.message!!))
             }
 
-            throw stepConfig.exception(XProcError.xcXsltCompileError(sae.message!!, sae))
+            throw stepConfig.exception(XProcError.xcXsltCompileError(sae.message!!, sae, errorReporter.errorMessages))
         }
 
         val transformer = exec.load30()

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/DefaultMessageReporter.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/DefaultMessageReporter.kt
@@ -1,20 +1,34 @@
 package com.xmlcalabash.util
 
 import com.xmlcalabash.api.MessageReporter
-import com.xmlcalabash.io.MessagePrinter
-import com.xmlcalabash.util.NopMessageReporter
+import com.xmlcalabash.namespace.Ns
 import net.sf.saxon.s9api.QName
 
 class DefaultMessageReporter(nextReporter: MessageReporter? = null): NopMessageReporter(nextReporter) {
     override fun report(verbosity: Verbosity, extraAttributes: Map<QName, String>, message: () -> String) {
         if (verbosity >= threshold) {
-            val prefix = when (verbosity) {
-                Verbosity.TRACE -> "Trace: "
-                Verbosity.DEBUG -> "Debug: "
-                Verbosity.INFO -> ""
-                Verbosity.WARN -> "Warning: "
-                Verbosity.ERROR -> "Error: "
+            val prefix = StringBuilder()
+
+            when (verbosity) {
+                Verbosity.TRACE -> prefix.append("Trace")
+                Verbosity.DEBUG -> prefix.append("Debug")
+                Verbosity.INFO -> Unit
+                Verbosity.WARN -> prefix.append("Warning")
+                Verbosity.ERROR -> prefix.append("Error")
             }
+
+            if (verbosity == Verbosity.WARN || verbosity == Verbosity.ERROR) {
+                val uri = extraAttributes[Ns.baseUri] ?: extraAttributes[Ns.systemIdentifier]
+                if (uri != null) {
+                    prefix.append(" at ").append(uri).append(":")
+                    extraAttributes[Ns.lineNumber]?.let { prefix.append(it).append(":") }
+                    extraAttributes[Ns.columnNumber]?.let { prefix.append(it).append(":") }
+                    prefix.append(" ")
+                }
+            } else {
+                prefix.append(": ")
+            }
+
             try {
                 messagePrinter.println("${prefix}${message()}")
             } catch (ex: Exception) {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/ErrorDetail.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/ErrorDetail.kt
@@ -1,0 +1,6 @@
+package com.xmlcalabash.util
+
+import net.sf.saxon.s9api.QName
+
+data class ErrorDetail(val message: String, val extra: Map<QName,String>) {
+}

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/SaxonErrorReporter.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/SaxonErrorReporter.kt
@@ -16,6 +16,10 @@ class SaxonErrorReporter(val stepConfig: StepConfiguration): ErrorReporter {
     val error: XmlProcessingError?
         get() = _error
 
+    private var _errorMessages = mutableListOf<ErrorDetail>()
+    val errorMessages: List<ErrorDetail>
+        get() = _errorMessages
+
     override fun report(error: XmlProcessingError?) {
         if (error == null) {
             stepConfig.error({ "Saxon error reporter called with null error?"} )
@@ -56,6 +60,8 @@ class SaxonErrorReporter(val stepConfig: StepConfiguration): ErrorReporter {
         } else {
             error.message
         }
+
+        _errorMessages.add(ErrorDetail(message, extra))
 
         stepConfig.messageReporter.report(Verbosity.DEBUG, extra) { message }
     }


### PR DESCRIPTION
When, for example, the `p:xslt` step fails because of a stylesheet compilation error, report what the underlying error was!