### PR TITLE
Correct a typo that prevented “?” from being escaped in p:urify()

### DIFF
--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/Urify.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/Urify.kt
@@ -259,7 +259,7 @@ class Urify(filepath: String, basedir: String?) {
             return _path!!
         }
 
-        var newpath = path!!.replace("\\?", "%3F")
+        var newpath = path!!.replace("?", "%3F")
             .replace("#", "%23")
             .replace("\\", "%5C")
             .replace(" ", "%20")


### PR DESCRIPTION
Fix #400

But see also: https://github.com/xproc/3.0-specification/issues/1145