### PR TITLE
Improve presentation of error output from p:error

### DIFF
--- a/app/src/main/kotlin/com/xmlcalabash/app/XmlCalabashCli.kt
+++ b/app/src/main/kotlin/com/xmlcalabash/app/XmlCalabashCli.kt
@@ -472,13 +472,6 @@ class XmlCalabashCli private constructor() {
             if (errors[0].cause != null && errors[0].cause != errors[0]) {
                 errors[0].cause!!.printStackTrace()
             }
-        } else {
-            if (errors[0].cause != null && errors[0].cause != errors[0]) {
-                val message = errors[0].cause!!.message
-                if (message != null) {
-                    stepConfig.messagePrinter.println(message)
-                }
-            }
         }
 
         exitProcess(1)

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/Location.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/Location.kt
@@ -1,12 +1,34 @@
 package com.xmlcalabash.datamodel
 
 import com.xmlcalabash.documents.XProcDocument
+import com.xmlcalabash.namespace.Ns
+import com.xmlcalabash.util.ErrorDetail
 import net.sf.saxon.s9api.XdmNode
 import java.net.URI
 
-class Location(private val uri: URI?, lineNo: Int?, colNo: Int?) {
+class Location(uri: URI?, lineNo: Int?, colNo: Int?) {
     companion object {
         val NULL = Location(null, null, null)
+
+        fun from(detail: ErrorDetail?): Location {
+            if (detail == null) {
+                return NULL
+            }
+
+            val baseUri = detail.extra[Ns.systemIdentifier]
+            val line = detail.extra[Ns.lineNumber]?.toInt()
+            val col = detail.extra[Ns.columnNumber]?.toInt()
+
+            if (baseUri == null) {
+                if (line == null) {
+                    return NULL
+                }
+                return Location(baseUri, line, col)
+            }
+
+            return Location(URI(baseUri), line, col)
+        }
+
     }
 
     val baseUri: URI? = uri
@@ -27,7 +49,7 @@ class Location(private val uri: URI?, lineNo: Int?, colNo: Int?) {
 
     override fun toString(): String {
         val sb = StringBuilder()
-        sb.append(uri ?: "???")
+        sb.append(baseUri ?: "???")
         if (lineNumber >= 0) {
             sb.append(":${lineNumber}")
         }

--- a/xmlcalabash/src/main/resources/com/xmlcalabash/explain-errors.txt
+++ b/xmlcalabash/src/main/resources/com/xmlcalabash/explain-errors.txt
@@ -1027,7 +1027,7 @@ that cannot be represented in the XDM version associated with the chosen XQuery
 version, e.g. with a map, an array, or a function when XDM 3.0 is used.
 
 XC0103
-Failed to compile query: $1 ($2).
+Failed to compile query: $1.
 It is a dynamic error if any error occurs during XQuery’s static analysis phase.
 
 XC0104


### PR DESCRIPTION
Fix #403

Instead of printing “(no message for error)”, output the user-provided details. This PR also improves the error output from the p:xslt and p:xquery steps and fixes a few other problems with p:xquery.