### PR TITLE
Improvements to the p:urify() function

### DIFF
--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/UriUtils.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/UriUtils.kt
@@ -1,6 +1,7 @@
 package com.xmlcalabash.util
 
 import java.net.URI
+import java.nio.charset.StandardCharsets
 import java.nio.file.Paths
 
 class UriUtils {
@@ -44,6 +45,34 @@ class UriUtils {
             builder.append(lastPart)
 
             return URI(builder.toString())
+        }
+        fun encodeForUri(value: String): String {
+            val genDelims = ":/?#[]@"
+            val subDelims = "!$'()*,;=" // N.B. no "&" and no "+" !
+            val unreserved = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-._~"
+            val okChars = genDelims + subDelims + unreserved
+
+            val encoded = StringBuilder()
+            for (byte in value.toByteArray(StandardCharsets.UTF_8)) {
+                // Whoever decided that bytes should be signed needs their head examined
+                val bint = if (byte.toInt() < 0) {
+                    byte.toInt() + 256
+                } else {
+                    byte.toInt()
+                }
+                val ch = Char(bint)
+                if (okChars.indexOf(ch) >= 0) {
+                    encoded.append(ch)
+                } else {
+                    if (ch == ' ') {
+                        encoded.append("+")
+                    } else {
+                        encoded.append(String.format("%%%02X", ch.code))
+                    }
+                }
+            }
+
+            return encoded.toString()
         }
     }
 }

--- a/xmlcalabash/src/test/kotlin/com/xmlcalabash/test/UrifyNonWindowsTest.kt
+++ b/xmlcalabash/src/test/kotlin/com/xmlcalabash/test/UrifyNonWindowsTest.kt
@@ -32,6 +32,42 @@ class UrifyNonWindowsTest {
     }
 
     @Test
+    fun urify_fragid1() {
+        val path = Urify.urify("#fragid", "file:///path/to/thing")
+        Assertions.assertEquals("file:///path/to/thing#fragid", path)
+    }
+
+    @Test
+    fun urify_fragid2() {
+        val path = Urify.urify("x#fragid", "file:///path/to/thing")
+        Assertions.assertEquals("file:///path/to/x#fragid", path)
+    }
+
+    @Test
+    fun urify_fragid3() {
+        val path = Urify.urify("?x#fragid", "file:///path/to/thing")
+        Assertions.assertEquals("file:///path/to/thing?x#fragid", path)
+    }
+
+    @Test
+    fun urify_i18n() {
+        val path = Urify.urify("?föö=bär#ß", "file:///path/to/thing")
+        Assertions.assertEquals("file:///path/to/thing?f%C3%B6%C3%B6=b%C3%A4r#%C3%9F", path)
+    }
+
+    @Test
+    fun urify_path1() {
+        val path = Urify.urify("xyzzy", "file:///path/to/thing.txt")
+        Assertions.assertEquals("file:///path/to/xyzzy", path)
+    }
+
+    @Test
+    fun urify_path2() {
+        val path = Urify.urify(".", "file:///path/to/thing.txt")
+        Assertions.assertEquals("file:///path/to/", path)
+    }
+
+    @Test
     fun urify_emptyString() {
         val path = Urify("")
         Assertions.assertNull(path.scheme)


### PR DESCRIPTION
Fix #362

This PR updates the behavior of p:urify(). There are spec changes still under discussion in this area, but the current behavior is so fundamentally broken that I’m making a few proactive fixes.

I’ve also arranged it so that every step that asks for a URI value gets the p:urify()’d result. I’m hoping this improves things on Windows.