### PR TITLE
Fix problems that arise on Windows

### DIFF
--- a/ext/trang/src/main/kotlin/com/xmlcalabash/ext/trang/TrangStep.kt
+++ b/ext/trang/src/main/kotlin/com/xmlcalabash/ext/trang/TrangStep.kt
@@ -67,6 +67,7 @@ class TrangStep(): AbstractTrangStep() {
             val stream = FileOutputStream(tempFile)
             val writer = DocumentWriter(doc, stream)
             writer.write()
+            stream.close()
             sources.add(tempFile)
 
             if (doc.baseURI == null) {

--- a/tests/extra-suite/test-suite/tests/java-properties-008.xml
+++ b/tests/extra-suite/test-suite/tests/java-properties-008.xml
@@ -56,9 +56,9 @@ lines‽</entry>
       <s:pattern>
         <s:rule context="/props">
           <s:assert test="contains(., '# Hello, world')">Comment is missing.</s:assert>
-          <s:assert test="contains(., '&#10;first=One&#10;')">first is missing.</s:assert>
-          <s:assert test="contains(., '&#10;second=Two&#10;')">second is missing.</s:assert>
-          <s:assert test="contains(., '&#10;three=\u201CSeveral\u201D\nlines\u203D&#10;')"
+          <s:assert test="contains(replace(., '&#13;', ''), '&#10;first=One&#10;')">first is missing.</s:assert>
+          <s:assert test="contains(replace(., '&#13;', ''), '&#10;second=Two&#10;')">second is missing.</s:assert>
+          <s:assert test="contains(replace(., '&#13;', ''), '&#10;three=\u201CSeveral\u201D\nlines\u203D&#10;')"
                     >third is missing.</s:assert>
         </s:rule>
       </s:pattern>

--- a/tests/extra-suite/test-suite/tests/java-properties-009.xml
+++ b/tests/extra-suite/test-suite/tests/java-properties-009.xml
@@ -52,10 +52,10 @@
       </s:pattern>
       <s:pattern>
         <s:rule context="/props">
-          <s:assert test="contains(., 'first=One&#10;')">first is missing.</s:assert>
-          <s:assert test="contains(., 'second=Two&#10;')">second is missing.</s:assert>
-          <s:assert test="contains(., 'third=&#10;')">third is missing.</s:assert>
-          <s:assert test="contains(., 'fourth=3.14&#10;')">fourth is missing.</s:assert>
+          <s:assert test="contains(replace(., '&#13;', ''), 'first=One&#10;')">first is missing.</s:assert>
+          <s:assert test="contains(replace(., '&#13;', ''), 'second=Two&#10;')">second is missing.</s:assert>
+          <s:assert test="contains(replace(., '&#13;', ''), 'third=&#10;')">third is missing.</s:assert>
+          <s:assert test="contains(replace(., '&#13;', ''), 'fourth=3.14&#10;')">fourth is missing.</s:assert>
         </s:rule>
       </s:pattern>
     </s:schema>

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/io/DocumentLoader.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/io/DocumentLoader.kt
@@ -182,6 +182,7 @@ class DocumentLoader(val stepConfig: StepConfiguration,
 
         val stream = FileInputStream(file)
         val doc = load(absURI, stream, mediaType)
+        stream.close()
         val end = System.nanoTime()
 
         for (monitor in stepConfig.environment.monitors) {


### PR DESCRIPTION
1. Don’t leave files open
2. Sort out some edge cases with Windows file names
3. Adjust the test driver wrt what can and can’t be done with file permissions
4. Correct some tests that rely on end-of-line characters
5. p:file-create-tempfile returns URI, not a filename