### PR TITLE
Don’t print “Stack trace:” on errors if there’s no stack trace

### DIFF
--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/DefaultErrorExplanation.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/DefaultErrorExplanation.kt
@@ -111,7 +111,7 @@ class DefaultErrorExplanation(val printer: MessagePrinter): ErrorExplanation {
 
     override fun report(error: XProcError) {
         printer.println(message(error, true))
-        if (showStackTrace) {
+        if (showStackTrace && error.stackTrace.isNotEmpty()) {
             printer.println("Stack trace:")
             var count = error.stackTrace.size
             for (frame in error.stackTrace) {


### PR DESCRIPTION
Fix #417