### PR TITLE
Rework the DocumentManager API

### DIFF
--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/XmlCalabashConfiguration.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/XmlCalabashConfiguration.kt
@@ -2,6 +2,8 @@ package com.xmlcalabash
 
 import com.xmlcalabash.api.MessageReporter
 import com.xmlcalabash.config.SaxonConfiguration
+import com.xmlcalabash.exceptions.ErrorExplanation
+import com.xmlcalabash.io.DocumentManager
 import com.xmlcalabash.io.MediaType
 import com.xmlcalabash.io.MessagePrinter
 import com.xmlcalabash.spi.Configurer
@@ -12,6 +14,7 @@ import net.sf.saxon.s9api.QName
 import net.sf.saxon.s9api.ValidationMode
 import java.io.File
 import java.net.URI
+import javax.activation.MimetypesFileTypeMap
 
 interface XmlCalabashConfiguration {
     val saxonConfiguration: SaxonConfiguration
@@ -19,7 +22,9 @@ interface XmlCalabashConfiguration {
     val consoleEncoding: String
     val debug: Boolean
     val debugger: Boolean
+    val documentManager: DocumentManager
     val eagerEvaluation: Boolean
+    val errorExplanation: ErrorExplanation
     val graphStyle: URI?
     val graphviz: File?
     val implicitParameterName: QName?
@@ -28,7 +33,7 @@ interface XmlCalabashConfiguration {
     val messageBufferSize: Int
     val messagePrinter: MessagePrinter
     val messageReporter: MessageReporter
-    val mimetypes: Map<String, List<String>>
+    val mimetypesFileTypeMap: MimetypesFileTypeMap
     val other: Map<QName, List<Map<QName, String>>>
     val pagedMediaCssProcessors: List<URI>
     val pagedMediaManagers: List<PagedMediaManager>

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/config/ConfigurationLoader.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/config/ConfigurationLoader.kt
@@ -65,12 +65,12 @@ class ConfigurationLoader(val builder: XmlCalabashBuilder) {
     fun load(source: File) {
         val isrc = InputSource(FileInputStream(source))
         isrc.systemId = source.toURI().toString()
-        return load(isrc)
+        load(isrc)
     }
 
     fun load(source: URI) {
         val isrc = InputSource(source.toString())
-        return load(isrc)
+        load(isrc)
     }
 
     fun load(source: InputSource) {
@@ -282,7 +282,9 @@ class ConfigurationLoader(val builder: XmlCalabashBuilder) {
 
     private fun parseMimetype(node: XdmNode) {
         checkAttributes(node, listOf(Ns.contentType, _extensions))
-        builder.addMimetype(node.getAttributeValue(Ns.contentType), node.getAttributeValue(_extensions).split("\\s+".toRegex()))
+        val ctype = node.getAttributeValue(Ns.contentType)!!
+        val ext = node.getAttributeValue(_extensions)!!
+        builder.getMimetypesFileTypeMap().addMimeTypes("${ctype} ${ext}")
     }
 
     private fun parseSendmail(node: XdmNode) {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/CompileEnvironment.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/CompileEnvironment.kt
@@ -87,9 +87,9 @@ open class CompileEnvironment(override val episode: String, override val xmlCala
     override val messagePrinter: MessagePrinter = xmlCalabash.config.messagePrinter
     override val messageReporter: MessageReporter = xmlCalabash.config.messageReporter
     override val monitors: MutableList<Monitor> = mutableListOf()
-    override val mimeTypes: MimetypesFileTypeMap = MimetypesFileTypeMap()
-    override val documentManager: DocumentManager = DocumentManager(this)
-    override val errorExplanation: ErrorExplanation = DefaultErrorExplanation(messagePrinter)
+    override val mimeTypes: MimetypesFileTypeMap = xmlCalabash.config.mimetypesFileTypeMap
+    override val documentManager: DocumentManager = xmlCalabash.config.documentManager
+    override val errorExplanation: ErrorExplanation = xmlCalabash.config.errorExplanation
     override val proxies: Map<String, String> = emptyMap()
     override val assertions: AssertionsLevel = xmlCalabash.config.assertions
 
@@ -119,13 +119,6 @@ open class CompileEnvironment(override val episode: String, override val xmlCala
 
         for (configurer in xmlCalabash.configurers) {
             configurer.configureContentTypes(_defaultContentTypes, mimeTypes)
-        }
-
-        for ((contentType, extensions) in xmlCalabash.config.mimetypes) {
-            if (showAssignments) {
-                messageReporter.debug { Report(Verbosity.DEBUG, "Assigning content type to '${extensions}' files: ${contentType}") }
-            }
-            mimeTypes.addMimeTypes("${contentType} ${extensions}")
         }
 
         for (provider in DocumentResolverServiceProvider.providers()) {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/XProcError.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/XProcError.kt
@@ -476,6 +476,8 @@ open class XProcError protected constructor(val code: QName, val variant: Int, e
         fun xiMergeDuplicatesError(name: String) = internal(215, name)
         fun xiNotALibrary(uri: URI) = internal(216, uri)
 
+        fun xiLookupIsNotPossible() = internal(217)
+
         fun xiXvrlInvalidValue(name: QName, value: String) = internal(300, name, value)
         fun xiXvrlIllegalMessageName(name: QName) = internal(301, name)
         fun xiXvrlIllegalMessageAttribute(name: QName) = internal(302, name)

--- a/xmlcalabash/src/main/resources/com/xmlcalabash/explain-errors.txt
+++ b/xmlcalabash/src/main/resources/com/xmlcalabash/explain-errors.txt
@@ -1633,6 +1633,14 @@ Duplicated name encountered when combining archives: “$1”
 When the cx:merge-duplicates policy is “error”, it is an error if multiple
 entries with the same name are encountered when merging archive files.
 
+cxerr:XI0216
+Input is not a p:library
+
+cxerr:XI0217
+Lookup is not possible when custom resolvers are provided
+If a configuration installs a customer resolver, then lookup is disabled.
+There is no way for it to give a correct answer.
+
 cxerr:XI0300
 Negative line and column numbers are not allowed: $1=$2
 

--- a/xmlcalabash/src/test/resources/configfile.xml
+++ b/xmlcalabash/src/test/resources/configfile.xml
@@ -1,0 +1,4 @@
+<!-- -*- nxml -*- -->
+<cc:xml-calabash xmlns:cc="https://xmlcalabash.com/ns/configuration">
+  <cc:inline trim-whitespace="true"/>
+</cc:xml-calabash>


### PR DESCRIPTION
Fix #424

This changes some of the configuration options. It’s now possible to provide your own DocumentManager, ErrorExplainer, or MimetypeFileTypeMap. The latter replacing the mimetypes map that was previously used.

In addition, you can now set your own EntityResolver, ResourceResolver, or ModuleURIResolver on the DocumentManager. These are used preferentially. If you specify your own resolvers, the p:lookup() function will not work. (It can’t lookup things in the custom resolvers so it fails.)