### PR TITLE
Improve conformance of p:import-functions

### DIFF
--- a/test-driver/src/test/resources/exclusions.txt
+++ b/test-driver/src/test/resources/exclusions.txt
@@ -1,18 +1,5 @@
 ab-p-archive-067 because multiple archives are supported for create
 
-ab-import-functions-008 because https://saxonica.plan.io/issues/6603
-ab-import-functions-009 because https://saxonica.plan.io/issues/6603
-
-ab-import-functions-011 because different in-scope implementations of the same function are not supported
-ab-import-functions-012 because that doesn’t work
-ab-import-functions-025 because that doesn’t work
-ab-import-functions-026 because that doesn’t work
-ab-import-functions-031 because that doesn’t work
-
-nw-import-functions-025 because that doesn’t work
-nw-import-functions-026 because that doesn’t work
-nw-import-functions-031 because that doesn’t work
-
 nw-urify-windows-bs-002 because https://github.com/xproc/3.0-test-suite/issues/841
 
 ab-os-exec-005 on Windows because it’s platform dependent

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/DeclareStepInstruction.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/DeclareStepInstruction.kt
@@ -83,6 +83,10 @@ class DeclareStepInstruction(parent: XProcInstruction?, stepConfig: InstructionC
             return true
         }
 
+    internal fun changeInstructionConfiguration(config: InstructionConfiguration) {
+        _stepConfig = config
+    }
+
     // ========================================================================================
 
     private val _imported = mutableSetOf<StepContainerInterface>()

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/DocumentContext.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/DocumentContext.kt
@@ -1,5 +1,6 @@
 package com.xmlcalabash.datamodel
 
+import com.xmlcalabash.config.SaxonConfiguration
 import com.xmlcalabash.exceptions.XProcError
 import com.xmlcalabash.exceptions.XProcException
 import net.sf.saxon.om.NamespaceUri
@@ -15,6 +16,7 @@ interface DocumentContext {
     val inscopeNamespaces: Map<String, NamespaceUri>
 
     fun copy(): DocumentContext
+    fun copy(newConfiguration: SaxonConfiguration): DocumentContext
 
     fun with(location: Location): DocumentContext
     fun with(prefix: String, uri: NamespaceUri): DocumentContext

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/DocumentContextImpl.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/DocumentContextImpl.kt
@@ -43,6 +43,13 @@ class DocumentContextImpl(private val saxonConfig: SaxonConfiguration): Document
         return context
     }
 
+    override fun copy(newConfig: SaxonConfiguration): DocumentContext {
+        val context = DocumentContextImpl(newConfig)
+        context._location = _location
+        context._inscopeNamespaces.putAll(_inscopeNamespaces)
+        return context
+    }
+
     override fun with(location: Location): DocumentContext {
         val context = DocumentContextImpl(saxonConfig)
         context._location = location

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/LibraryInstruction.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/LibraryInstruction.kt
@@ -49,6 +49,10 @@ open class LibraryInstruction(stepConfig: InstructionConfiguration): XProcInstru
     val exportedOptions: Map<QName, OptionInstruction>
         get() = _exportedOptions
 
+    internal fun changeInstructionConfiguration(config: InstructionConfiguration) {
+        _stepConfig = config
+    }
+
     fun findDeclarations() {
         findDeclarations(emptyMap(), emptyMap(), emptyMap())
     }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/XProcFunctionLibrary.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/XProcFunctionLibrary.kt
@@ -1,0 +1,57 @@
+package com.xmlcalabash.datamodel
+
+import net.sf.saxon.Configuration
+import net.sf.saxon.functions.ExecutableFunctionLibrary
+import net.sf.saxon.functions.FunctionLibrary
+import net.sf.saxon.query.XQueryFunctionLibrary
+import net.sf.saxon.s9api.QName
+
+class XProcFunctionLibrary(val exposedNames: Map<QName, Int>, val library: FunctionLibrary): FunctionLibrary by library {
+    override fun setConfiguration(config: Configuration?) {
+        library.setConfiguration(config)
+    }
+
+    fun suppressDuplicates(seen: Map<QName, Int>, config: Configuration): FunctionLibrary {
+        for ((key, arity) in exposedNames) {
+            if (seen[key] == arity) {
+                when (library) {
+                    is XQueryFunctionLibrary -> return suppressedXQuery(seen, library)
+                    is ExecutableFunctionLibrary -> return suppressedExecutable(seen, library, config)
+                    else -> throw IllegalStateException("Unknown function library type ${library.javaClass}")
+                }
+            }
+        }
+        return library
+    }
+
+    private fun suppressedXQuery(seen: Map<QName, Int>, library: XQueryFunctionLibrary): FunctionLibrary {
+        val functionLibrary = XQueryFunctionLibrary(library.configuration)
+        for (function in library.functionDefinitions) {
+            val name = if (function.functionName.prefix == "") {
+                QName(function.functionName.namespaceUri, function.functionName.localPart)
+            } else {
+                QName(function.functionName.namespaceUri, "${function.functionName.prefix}:${function.functionName.localPart}")
+            }
+            if (seen[name] != function.numberOfParameters) {
+                functionLibrary.declareFunction(function)
+            }
+        }
+        return functionLibrary
+    }
+
+    private fun suppressedExecutable(seen: Map<QName, Int>, library: ExecutableFunctionLibrary, config: Configuration): FunctionLibrary {
+        val functionLibrary = ExecutableFunctionLibrary(config)
+        for (function in library.allFunctions) {
+            val name = if (function.functionName.prefix == "") {
+                QName(function.functionName.namespaceUri, function.functionName.localPart)
+            } else {
+                QName(function.functionName.namespaceUri, "${function.functionName.prefix}:${function.functionName.localPart}")
+            }
+
+            if (seen[name] != function.numberOfParameters) {
+                functionLibrary.addFunction(function)
+            }
+        }
+        return functionLibrary
+    }
+}

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/XProcInstruction.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/XProcInstruction.kt
@@ -4,9 +4,15 @@ import net.sf.saxon.om.NamespaceUri
 import net.sf.saxon.s9api.QName
 import net.sf.saxon.s9api.XdmNode
 
-abstract class XProcInstruction internal constructor(initialParent: XProcInstruction?, val stepConfig: InstructionConfiguration, val instructionType: QName) {
+abstract class XProcInstruction internal constructor(initialParent: XProcInstruction?, initialStepConfig: InstructionConfiguration, val instructionType: QName) {
     internal lateinit var builder: PipelineBuilder
     internal var _parent = initialParent
+
+    // We have to brute force a changae here for nested step declarations. Ugly as sin, but...
+    protected var _stepConfig: InstructionConfiguration = initialStepConfig
+
+    val stepConfig: InstructionConfiguration
+        get() = _stepConfig
 
     val id = stepConfig.nextId
     var expandText: Boolean? = null

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/XProcError.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/XProcError.kt
@@ -149,6 +149,7 @@ open class XProcError protected constructor(val code: QName, val variant: Int, e
         fun xsInvalidValues(value: String) = static(101, value)
         fun xsDifferentPrimaryOutputs() = static(102)
         fun xsUnknownFunctionMediaType(type: String) = static(104, type)
+        fun xsDuplicateFunction(name: QName, arity: Int) = static(105, name, arity)
         fun xsImportFunctionsUnloadable(uri: URI) = static(106, uri)
         fun xsXPathStaticError(msg: String) = static(Pair(107,1), msg)
         fun xsXPathStaticError(name: QName) = static(Pair(107,2), name)

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/XProcRuntime.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/XProcRuntime.kt
@@ -85,9 +85,9 @@ class XProcRuntime private constructor(internal val start: DeclareStepInstructio
     internal val runnables = mutableMapOf<String, CompoundStepModel>()
     val environment = config.environment
 
-    fun stepConfiguration(instructionConfig: InstructionConfiguration): XProcStepConfiguration {
+    fun stepConfiguration(instructionConfig: InstructionConfiguration, newConfig: Boolean): XProcStepConfiguration {
         // Issue #160, don't create a new Saxon configuration here
-        val impl = config.from(instructionConfig, false)
+        val impl = config.from(instructionConfig, newConfig)
         impl.validationMode = instructionConfig.validationMode
         return impl
     }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/XProcStepConfiguration.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/XProcStepConfiguration.kt
@@ -10,7 +10,8 @@ class XProcStepConfiguration(saxonConfig: SaxonConfiguration,
                              environment: RuntimeEnvironment): StepConfiguration(saxonConfig, context, environment) {
     fun from(config: InstructionConfiguration, newConfig: Boolean = true): XProcStepConfiguration {
         val xconfig = if (newConfig) {
-            XProcStepConfiguration(config.saxonConfig.newConfiguration(), config.context, environment as RuntimeEnvironment)
+            val newSaxonConfig = config.saxonConfig.newConfiguration()
+            XProcStepConfiguration(newSaxonConfig, config.context.copy(newSaxonConfig), environment as RuntimeEnvironment)
         } else {
             XProcStepConfiguration(config.saxonConfig, config.context, environment as RuntimeEnvironment)
         }
@@ -21,6 +22,12 @@ class XProcStepConfiguration(saxonConfig: SaxonConfiguration,
 
     override fun copy(): XProcStepConfiguration {
         val xconfig = XProcStepConfiguration(saxonConfig, context, environment as RuntimeEnvironment)
+        xconfig._inscopeStepTypes.putAll(inscopeStepTypes)
+        return xconfig
+    }
+
+    override fun copy(newConfig: SaxonConfiguration): XProcStepConfiguration {
+        val xconfig = XProcStepConfiguration(newConfig, context.copy(newConfig), environment as RuntimeEnvironment)
         xconfig._inscopeStepTypes.putAll(inscopeStepTypes)
         return xconfig
     }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/model/StepModel.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/model/StepModel.kt
@@ -5,6 +5,7 @@ import com.xmlcalabash.datamodel.Location
 import com.xmlcalabash.datamodel.StaticOptionDetails
 import com.xmlcalabash.graph.Model
 import com.xmlcalabash.graph.ModelInputPort
+import com.xmlcalabash.graph.PipelineModel
 import com.xmlcalabash.namespace.Ns
 import com.xmlcalabash.namespace.NsP
 import com.xmlcalabash.runtime.XProcRuntime
@@ -15,7 +16,7 @@ import com.xmlcalabash.runtime.steps.AbstractStep
 import net.sf.saxon.s9api.QName
 
 abstract class StepModel(val runtime: XProcRuntime, model: Model) {
-    val stepConfig = runtime.stepConfiguration(model.step.stepConfig)
+    val stepConfig = runtime.stepConfiguration(model.step.stepConfig, model is PipelineModel)
     val id: String = model.id
     val threadGroup = model.threadGroup
     val location: Location = model.step.location

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/TypeUtils.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/TypeUtils.kt
@@ -24,6 +24,7 @@ import net.sf.saxon.om.FingerprintedQName
 import net.sf.saxon.om.GroundedValue
 import net.sf.saxon.om.NamespaceUri
 import net.sf.saxon.om.NodeInfo
+import net.sf.saxon.om.StructuredQName
 import net.sf.saxon.s9api.ItemType
 import net.sf.saxon.s9api.Location
 import net.sf.saxon.s9api.OccurrenceIndicator
@@ -941,6 +942,13 @@ class TypeUtils(val context: DocumentContext) {
             }
         }
         return map
+    }
+
+    fun QNameFromStructuredQName(qname: StructuredQName): QName {
+        if (qname.prefix == "") {
+            return QName(qname.namespaceUri, qname.localPart)
+        }
+        return QName(qname.namespaceUri, "${qname.prefix}:${qname.localPart}")
     }
 
     // ============================================================

--- a/xmlcalabash/src/main/resources/com/xmlcalabash/explain-errors.txt
+++ b/xmlcalabash/src/main/resources/com/xmlcalabash/explain-errors.txt
@@ -621,6 +621,9 @@ XS0104
 Unexpected media type for function loading: “$1”.
 Only XSLT and XQuery function libraries can be loaded by p:import-functions.
 
+XS0105
+Cannot import two functions named “$1” with the same arity ($2).
+
 XS0106
 Functions cannot be imported: “$1”.
 It is a static error if the processor detects that a particular library is unloadable.


### PR DESCRIPTION
Fix #434

This PR doesn’t use the fix proposed in the issue, but I did refactor the code a bit so that private functions are excluded and attempts to import multiple functions with the same name and arity fail. I also sorted out a tricky bug where the context wasn’t really right inside a declare-step or library that imported functions. Fixing that bug also allowed me to support nested imports. Win.