### PR TITLE
Corrects the way p:os-exec handles charsets

### DIFF
--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/StandardLibrary.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/StandardLibrary.kt
@@ -1034,8 +1034,6 @@ class StandardLibrary private constructor(builder: PipelineBuilder, private val 
         option.asType = stepConfig.typeUtils.parseSequenceType("xs:string*")
         option = decl.option(QName("cwd"))
         option.asType = stepConfig.typeUtils.parseSequenceType("xs:string?")
-        option = decl.option(QName("charset"))
-        option.asType = stepConfig.typeUtils.parseSequenceType("xs:string?")
         option = decl.option(QName("result-content-type"))
         option.select = XProcExpression.select(stepConfig, "'text/plain'")
         option.asType = stepConfig.typeUtils.parseSequenceType("xs:string")

--- a/xmlcalabash/src/main/resources/com/xmlcalabash/library.xpl
+++ b/xmlcalabash/src/main/resources/com/xmlcalabash/library.xpl
@@ -382,7 +382,6 @@
       <p:option name="command" required="true" as="xs:string"/>
       <p:option name="args" select="()" as="xs:string*"/>
       <p:option name="cwd" as="xs:string?"/>
-      <p:option name="charset" as="xs:string?"/>
       <p:option name="result-content-type" select="'text/plain'" as="xs:string"/>
       <p:option name="error-content-type" select="'text/plain'" as="xs:string"/>
       <p:option name="path-separator" as="xs:string?"/>


### PR DESCRIPTION
Removes the bogus charset option; uses the charset parameter on result-content-type and error-content-type