### PR TITLE
Make sure that options on the command line are promoted as required

### DIFF
--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/StaticOptionDetails.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/StaticOptionDetails.kt
@@ -21,11 +21,11 @@ class StaticOptionDetails(val stepConfig: StepConfiguration, val name: QName, va
                     val castValue = stepConfig.typeUtils.xpathPromote(value, asType.itemType.typeName)
                     return override(castValue)
                 } catch (ex: Exception) {
-                    throw stepConfig.exception(XProcError.xsValueDoesNotSatisfyType(value.toString(), TypeUtils.sequenceTypeToString(asType)), ex)
+                    throw stepConfig.exception(XProcError.xdBadType(value.toString(), TypeUtils.sequenceTypeToString(asType)), ex)
                 }
             }
 
-            throw stepConfig.exception(XProcError.xsValueDoesNotSatisfyType(value.toString(), TypeUtils.sequenceTypeToString(asType)))
+            throw stepConfig.exception(XProcError.xdBadType(value.toString(), TypeUtils.sequenceTypeToString(asType)))
         }
 
         if (values.isNotEmpty()) {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/StaticOptionDetails.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/StaticOptionDetails.kt
@@ -2,6 +2,7 @@ package com.xmlcalabash.datamodel
 
 import com.xmlcalabash.config.StepConfiguration
 import com.xmlcalabash.exceptions.XProcError
+import com.xmlcalabash.namespace.NsXs
 import com.xmlcalabash.util.TypeUtils
 import net.sf.saxon.s9api.QName
 import net.sf.saxon.s9api.SequenceType
@@ -15,6 +16,15 @@ class StaticOptionDetails(val stepConfig: StepConfiguration, val name: QName, va
 
     internal fun override(value: XdmValue) {
         if (!asType.matches(value)) {
+            if (value is XdmAtomicValue && value.primitiveTypeName == NsXs.untypedAtomic && asType.itemType != NsXs.untypedAtomic) {
+                try {
+                    val castValue = stepConfig.typeUtils.xpathPromote(value, asType.itemType.typeName)
+                    return override(castValue)
+                } catch (ex: Exception) {
+                    throw stepConfig.exception(XProcError.xsValueDoesNotSatisfyType(value.toString(), TypeUtils.sequenceTypeToString(asType)), ex)
+                }
+            }
+
             throw stepConfig.exception(XProcError.xsValueDoesNotSatisfyType(value.toString(), TypeUtils.sequenceTypeToString(asType)))
         }
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/DefaultErrorExplanation.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/DefaultErrorExplanation.kt
@@ -113,15 +113,15 @@ class DefaultErrorExplanation(val reporter: MessageReporter): ErrorExplanation {
     }
 
     override fun report(error: XProcError) {
-        reporter.error { Report(Verbosity.ERROR,  message(error, true), error.location) }
+        reporter.error { Report(Verbosity.ERROR,  message(error, true)) }
         if (showStackTrace && error.stackTrace.isNotEmpty()) {
-            reporter.error { Report(Verbosity.ERROR, "Stack trace:", Location.NULL) }
+            reporter.error { Report(Verbosity.ERROR, "Stack trace:") }
             var count = error.stackTrace.size
             for (frame in error.stackTrace) {
                 if (frame.stepName.startsWith('!')) {
-                    reporter.error { Report(Verbosity.ERROR, "\t[${count}] <${frame.stepType}>", Location.NULL) }
+                    reporter.error { Report(Verbosity.ERROR, "\t[${count}] <${frame.stepType}>") }
                 } else {
-                    reporter.error { Report(Verbosity.ERROR, "\t[${count}] <${frame.stepType} name=\"${frame.stepName}\">", Location.NULL) }
+                    reporter.error { Report(Verbosity.ERROR, "\t[${count}] <${frame.stepType} name=\"${frame.stepName}\">") }
                 }
                 count--
             }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/parsers/xpl/elements/OptionNode.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/parsers/xpl/elements/OptionNode.kt
@@ -41,7 +41,7 @@ class OptionNode(parent: AnyNode, node: XdmNode, val name: QName, val select: St
                             val typeUtils = TypeUtils(stepConfig)
                             typeUtils.xpathPromote(value, asType!!.itemType.typeName)
                         } catch (ex: Exception) {
-                            throw stepConfig.exception(XProcError.xsValueDoesNotSatisfyType(value.toString(), TypeUtils.sequenceTypeToString(asType!!)), ex)
+                            throw stepConfig.exception(XProcError.xdBadType(value.toString(), TypeUtils.sequenceTypeToString(asType!!)), ex)
                         }
                     }
                 }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/parsers/xpl/elements/OptionNode.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/parsers/xpl/elements/OptionNode.kt
@@ -1,5 +1,6 @@
 package com.xmlcalabash.parsers.xpl.elements
 
+import com.xmlcalabash.exceptions.XProcError
 import com.xmlcalabash.util.TypeUtils
 import com.xmlcalabash.namespace.Ns
 import net.sf.saxon.s9api.QName
@@ -36,8 +37,12 @@ class OptionNode(parent: AnyNode, node: XdmNode, val name: QName, val select: St
 
                 if (value != null && asType != null) {
                     if (!asType!!.matches(value)) {
-                        val typeUtils = TypeUtils(stepConfig)
-                        typeUtils.xpathPromote(value, asType!!.itemType.typeName)
+                        try {
+                            val typeUtils = TypeUtils(stepConfig)
+                            typeUtils.xpathPromote(value, asType!!.itemType.typeName)
+                        } catch (ex: Exception) {
+                            throw stepConfig.exception(XProcError.xsValueDoesNotSatisfyType(value.toString(), TypeUtils.sequenceTypeToString(asType!!)), ex)
+                        }
                     }
                 }
 


### PR DESCRIPTION
Fix #450

A value passed on the command line, such as “true”, is created with a type of xs:untypedAtomic so that it can be promoted, if necessary, to some other value such as xs:boolean or xs:string. The promotion part wasn’t working for static option values.