### PR TITLE
Disable standard Java logging to STDERR

### DIFF
--- a/xmlcalabash/src/main/resources/logback.xml
+++ b/xmlcalabash/src/main/resources/logback.xml
@@ -6,7 +6,7 @@
     </encoder>
   </appender>
   
-  <root level="WARN" additivity="false">
+  <root level="OFF" additivity="false">
     <appender-ref ref="STDERR"/>
   </root>
 </configuration>


### PR DESCRIPTION
This seems a bit odd, but XML Calabash has its own error reporter (necessary so that pipelines and integrators can capture the error messages). That reporter sends all messages to the standard Java logging system. That’s necessary so that it’s possible to capture lower level debug messages to a file without sending them all to the console.

But it means that if an error occurs, the reporter prints the error message and then the underlying Java logging system prints it again, in a slightly different format. That’s going to be both confusing and annoying, so by default no Java log messages are printed.

The only downside is that if some underlying library prints an error log message, it won’t get displayed. That means using a separate logback.xml configuration file may be needed a little more often. Time will tell if this is a satisfactory solution.