### PR TITLE
Don’t print a stack trace when p:run fails

### DIFF
--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/parsers/xpl/elements/XplDocument.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/parsers/xpl/elements/XplDocument.kt
@@ -69,7 +69,7 @@ class XplDocument(val builder: PipelineBuilder, val xml: XdmNode) {
                                 && parseBoolean(node.getAttributeValue(Ns.static))) {
                                 try {
                                     val name = tree.stepConfig.typeUtils.parseQName(node.getAttributeValue(Ns.name))
-                                    var defaultValue = node.getAttributeValue(Ns.select) ?: "()"
+                                    val defaultValue = node.getAttributeValue(Ns.select) ?: "()"
                                     OptionNode(tree, node, name, defaultValue)
                                 } catch (ex: Exception) {
                                     ElementNode(tree, node)

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/RunStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/RunStep.kt
@@ -37,7 +37,6 @@ open class RunStep(config: XProcStepConfiguration, compound: CompoundStepModel):
                 val source = cache["!source"]!!.first().value as XdmNode
                 parser.parse(source)
             } catch (ex: Exception) {
-                ex.printStackTrace()
                 throw stepConfig.exception(XProcError.xcNotAPipeline(), ex)
             }
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/TypeUtils.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/TypeUtils.kt
@@ -326,7 +326,7 @@ class TypeUtils(val context: DocumentContext) {
             val st = parser.parseSequenceType(asExpr, icontext)
             return SequenceType.fromUnderlyingSequenceType(context.processor, st)
         } catch (ex: XPathException) {
-            throw context.exception(XProcError.Companion.xsInvalidSequenceType(asExpr))
+            throw context.exception(XProcError.Companion.xsInvalidSequenceType(asExpr), ex)
         }
     }
 

--- a/xmlcalabash/src/main/resources/com/xmlcalabash/explain-errors.txt
+++ b/xmlcalabash/src/main/resources/com/xmlcalabash/explain-errors.txt
@@ -1288,9 +1288,9 @@ It is a dynamic error if the assert-valid option on p:validate-with-json-schema
 is true and the input document is not valid.
 
 XC0200
-Input is not a pipeline.
+The pipeline could not be compiled.
 It is a dynamic error if the pipeline input to the p:run step is not a valid
-pipeline.
+pipeline or if there are errors in any of its static options.
 
 XC0201/1
 Cannot uncompress to “$1”.


### PR DESCRIPTION
Fix #456