### PR TITLE
Refactor the DocumentManager API

### DIFF
--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/XProcError.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/XProcError.kt
@@ -477,8 +477,6 @@ open class XProcError protected constructor(val code: QName, val variant: Int, e
         fun xiMergeDuplicatesError(name: String) = internal(215, name)
         fun xiNotALibrary(uri: URI) = internal(216, uri)
 
-        fun xiLookupIsNotPossible() = internal(217)
-
         fun xiXvrlInvalidValue(name: QName, value: String) = internal(300, name, value)
         fun xiXvrlIllegalMessageName(name: QName) = internal(301, name)
         fun xiXvrlIllegalMessageAttribute(name: QName) = internal(302, name)

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/XProcRuntime.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/XProcRuntime.kt
@@ -14,6 +14,7 @@ import net.sf.saxon.s9api.Axis
 import net.sf.saxon.s9api.XdmDestination
 import net.sf.saxon.s9api.XdmNodeKind
 import org.xml.sax.InputSource
+import org.xmlresolver.ResolverFeature
 import javax.xml.transform.sax.SAXSource
 
 class XProcRuntime private constructor(internal val start: DeclareStepInstruction, internal val config: XProcStepConfiguration) {
@@ -44,7 +45,11 @@ class XProcRuntime private constructor(internal val start: DeclareStepInstructio
                                     } else {
                                         val uri = UriUtils.resolve(element.baseURI, href).toString()
                                         config.debug { "Adding catalog: ${uri}" }
-                                        config.environment.documentManager.resolverConfiguration.addCatalog(uri)
+                                        val rconfig = config.documentManager.resolver.configuration
+                                        val addnlCatalogs = mutableListOf<String>()
+                                        addnlCatalogs.addAll(rconfig.getFeature(ResolverFeature.CATALOG_ADDITIONS))
+                                        addnlCatalogs.add(uri)
+                                        rconfig.setFeature(ResolverFeature.CATALOG_ADDITIONS, addnlCatalogs)
                                     }
                                 }
                                 NsCx.importSchema -> {


### PR DESCRIPTION
Fix #455

It’s now possible to provide an XMLResolver to the DocumentManager. This replaces the various resolver interfaces on the DocumentManager.