### PR TITLE
Improved error reporting

### DIFF
--- a/app/src/main/kotlin/com/xmlcalabash/app/CommandLine.kt
+++ b/app/src/main/kotlin/com/xmlcalabash/app/CommandLine.kt
@@ -62,6 +62,7 @@ class CommandLine private constructor(val args: Array<out String>) {
     private var _debugger: Boolean? = null
     private var _visualizer: String? = null
     private val _visualizerOptions = mutableMapOf<String,String>()
+    private var _stacktrace = false
     private var _verbosity: Verbosity? = null
     private var _explainErrors = false
     private var _assertions: AssertionsLevel? = null
@@ -121,6 +122,10 @@ class CommandLine private constructor(val args: Array<out String>) {
     /** Enable debugging output? */
     val debug: Boolean?
         get() = _debug
+
+    /** Print a stack (step) trace on error? */
+    val stacktrace: Boolean
+        get() = _stacktrace
 
     /** How chatty shall we be? */
     val verbosity: Verbosity?
@@ -258,6 +263,7 @@ class CommandLine private constructor(val args: Array<out String>) {
         ArgumentDescription("--trace", listOf(), ArgumentType.FILE) { it -> _trace = File(it) },
         ArgumentDescription("--nogo", listOf(), ArgumentType.BOOLEAN, "true") { it -> _nogo = it == "true" },
         ArgumentDescription("--trace-documents", listOf("--trace-docs"), ArgumentType.DIRECTORY) { it -> _traceDocuments = File(it) },
+        ArgumentDescription("--stacktrace", listOf("--stack-trace"), ArgumentType.BOOLEAN, "true") { it -> _stacktrace = it == "true" },
         ArgumentDescription("--verbosity", listOf("-V"),
             ArgumentType.STRING, "info", listOf("trace", "debug", "progress", "info", "warn", "error")) { it ->
             _verbosity = when(it) {

--- a/documentation/src/userguide/run.xml
+++ b/documentation/src/userguide/run.xml
@@ -82,6 +82,7 @@ given, the <command>run</command> command is assumed.</para>
   <arg rep="norepeat" linkend="cli-trace-documents">--trace-documents:<replaceable>output-directory</replaceable></arg>
   <sbr/>
   <arg rep="norepeat" linkend="cli-assertions">--assertions:<replaceable>level</replaceable></arg>
+  <arg rep="norepeat" linkend="cli-stacktrace">--stacktrace</arg>
   <sbr/>
   <arg rep="norepeat" linkend="cli-licensed">--licensed</arg>
   <arg rep="norepeat" linkend="cli-debug">--debug</arg>
@@ -455,6 +456,15 @@ You can configure it in the usual ways.</para>
 <listitem>
 <para>Start an interactive debugging session on the pipeline.
 See <xref linkend="debugging"/>.</para>
+</listitem>
+</varlistentry>
+
+<varlistentry xml:id="cli-stacktrace">
+  <term><option>--stacktrace</option></term>
+<listitem>
+<para>If the stacktrace option is enabled, a stack trace (really a “step trace”) will
+be printed if the pipeline fails at runtime. This trace will show the step that
+failed and its ancestors.</para>
 </listitem>
 </varlistentry>
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/DefaultErrorExplanation.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/DefaultErrorExplanation.kt
@@ -25,7 +25,7 @@ import java.nio.charset.StandardCharsets
 import javax.xml.transform.sax.SAXSource
 
 class DefaultErrorExplanation(val reporter: MessageReporter): ErrorExplanation {
-    var showStackTrace = true
+    override var showStacktrace = false
 
     companion object {
         private var loaded = false
@@ -114,7 +114,7 @@ class DefaultErrorExplanation(val reporter: MessageReporter): ErrorExplanation {
 
     override fun report(error: XProcError) {
         reporter.error { Report(Verbosity.ERROR,  message(error, true)) }
-        if (showStackTrace && error.stackTrace.isNotEmpty()) {
+        if (showStacktrace && error.stackTrace.isNotEmpty()) {
             reporter.error { Report(Verbosity.ERROR, "Stack trace:") }
             var count = error.stackTrace.size
             for (frame in error.stackTrace) {
@@ -134,7 +134,7 @@ class DefaultErrorExplanation(val reporter: MessageReporter): ErrorExplanation {
     }
 
     override fun reportExplanation(error: XProcError) {
-        reporter.error { Report(Verbosity.ERROR, explanation(error), error.location) }
+        reporter.error { Report(Verbosity.ERROR, explanation(error), Location.NULL) }
     }
 
     private fun template(code: QName, variant: Int, count: Int): ErrorExplanationTemplate {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/ErrorExplanation.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/ErrorExplanation.kt
@@ -1,6 +1,7 @@
 package com.xmlcalabash.exceptions
 
 interface ErrorExplanation {
+    var showStacktrace: Boolean
     fun report(error: XProcError)
     fun reportExplanation(error: XProcError)
     fun message(error: XProcError, includeDetails: Boolean): String

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/XProcError.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/XProcError.kt
@@ -184,6 +184,7 @@ open class XProcError protected constructor(val code: QName, val variant: Int, e
         fun xdBadType(value: String, type: ItemType) = dynamic(Pair(36,2), value, type)
         fun xdBadType(name: QName, value: String, type: String) = dynamic(Pair(36,3), name, value, type)
         fun xdBadType(message: String) = dynamic(Pair(36,4), message)
+        fun xdBadTypeEmpty(type: String) = dynamic(Pair(36,5), type)
         fun xdBadInputContentType(port: String, type: String) = dynamic(38, port, type)
         fun xdUnsupportedCharset(charset: String) = dynamic(39, charset)
         fun xdBadBase64Input() = dynamic(40)
@@ -517,11 +518,15 @@ open class XProcError protected constructor(val code: QName, val variant: Int, e
         if (code == NsErr.xd(36)) {
             val detail0 = details[0].toString()
             val detail1 = details[1].toString()
-            return xsValueDoesNotSatisfyType(detail0, detail1)
+            val error = xsValueDoesNotSatisfyType(detail0, detail1)
+            error._throwable = throwable
+            return error
         }
 
         if (code == NsErr.xd(69)) {
-            return xsUnboundPrefix(details[0].toString())
+            val error = xsUnboundPrefix(details[0].toString())
+            error._throwable = throwable
+            return error
         }
 
         return this
@@ -568,6 +573,7 @@ open class XProcError protected constructor(val code: QName, val variant: Int, e
 
     fun at(doc: XProcDocument): XProcError {
         val error = XProcError(this, location, Location(doc.baseURI))
+        error._throwable = throwable
         error._moreDetails.addAll(moreDetails)
         return error
     }
@@ -592,6 +598,7 @@ open class XProcError protected constructor(val code: QName, val variant: Int, e
 
     fun with(newCode: QName): XProcError {
         val error = XProcError(newCode, 1, location, inputLocation, *details)
+        error._throwable = throwable
         error._moreDetails.addAll(moreDetails)
         return error
     }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/parsers/xpl/elements/OptionNode.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/parsers/xpl/elements/OptionNode.kt
@@ -5,6 +5,7 @@ import com.xmlcalabash.util.TypeUtils
 import com.xmlcalabash.namespace.Ns
 import net.sf.saxon.s9api.QName
 import net.sf.saxon.s9api.SequenceType
+import net.sf.saxon.s9api.XdmEmptySequence
 import net.sf.saxon.s9api.XdmNode
 
 class OptionNode(parent: AnyNode, node: XdmNode, val name: QName, val select: String): ElementNode(parent, node) {
@@ -41,6 +42,9 @@ class OptionNode(parent: AnyNode, node: XdmNode, val name: QName, val select: St
                             val typeUtils = TypeUtils(stepConfig)
                             typeUtils.xpathPromote(value, asType!!.itemType.typeName)
                         } catch (ex: Exception) {
+                            if (value == XdmEmptySequence.getInstance()) {
+                                throw stepConfig.exception(XProcError.xdBadTypeEmpty(TypeUtils.sequenceTypeToString(asType!!)), ex)
+                            }
                             throw stepConfig.exception(XProcError.xdBadType(value.toString(), TypeUtils.sequenceTypeToString(asType!!)), ex)
                         }
                     }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/TypeUtils.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/TypeUtils.kt
@@ -762,7 +762,7 @@ class TypeUtils(val context: DocumentContext) {
         if (type.namespaceUri != NsXs.namespace) {
             throw context.exception(XProcError.Companion.xiImpossible("Attempt to cast to non-xs type"))
         }
-        if (value.underlyingValue !is AtomicValue) {
+        if (value.underlyingValue !is AtomicValue && value != XdmEmptySequence.getInstance()) {
             throw context.exception(XProcError.Companion.xiImpossible("Attempt to promote non-atomic: ${value}"))
         }
 

--- a/xmlcalabash/src/main/resources/com/xmlcalabash/explain-errors.txt
+++ b/xmlcalabash/src/main/resources/com/xmlcalabash/explain-errors.txt
@@ -116,6 +116,12 @@ Invalid type: “$1”.
 It is a dynamic error if the supplied or defaulted value of a variable or option
 cannot be converted to the required type.
 
+XD0036/5
+An empty sequence cannot be converted to the type “$1”.
+It is a dynamic error if the supplied or defaulted value of a variable or option
+cannot be converted to the required type. The empty sequence can only be converted
+to a type that is optional ($1?) or may be repeated zero or more times ($1*).
+
 XD0038
 Input with content type “$2” not allowed on port “$1”.
 It is a dynamic error if an input document arrives on a port and it does not


### PR DESCRIPTION
Fixed a bug where causes sometimes got lost in nested exceptions. When a pipeline fails, the error report now includes the chain of causes. Separated out the special case of empty sequence in a type conversion error to improve the error message. Added a --stacktrace option to enable stack (step) traces in errors (and disabled them by default). Removed the location information from the front of each line of explanation when the --explain option is used.