### PR TITLE
Refactored build and configuration APIs

### DIFF
--- a/ext/epubcheck/src/main/kotlin/com/xmlcalabash/ext/epubcheck/EPubCheckConfigurer.kt
+++ b/ext/epubcheck/src/main/kotlin/com/xmlcalabash/ext/epubcheck/EPubCheckConfigurer.kt
@@ -1,29 +1,17 @@
 package com.xmlcalabash.ext.epubcheck
 
-import com.xmlcalabash.XmlCalabash
+import com.xmlcalabash.XmlCalabashBuilder
 import com.xmlcalabash.spi.Configurer
 import com.xmlcalabash.spi.ConfigurerProvider
 import net.sf.saxon.Configuration
-import org.apache.logging.log4j.kotlin.logger
-import javax.activation.MimetypesFileTypeMap
 
 class EPubCheckConfigurer(): Configurer, ConfigurerProvider {
-    override fun configure(xmlcalabash: XmlCalabash) {
-        // nop
+    override fun configure(builder: XmlCalabashBuilder) {
+        builder.addMimeType("application/epub+zip", listOf("epub"))
     }
 
     override fun configureSaxon(config: Configuration) {
         // nop
-    }
-
-    override fun configureContentTypes(contentTypes: MutableMap<String, String>, mimeTypes: MimetypesFileTypeMap) {
-        val ext = "epub"
-        val contentType = "application/epub+zip"
-        contentTypes[ext] = contentType
-        if (mimeTypes.getContentType("test.${ext}") == "application/octet-stream") {
-            logger.trace { "Assigning default content type to '.${ext}' files: ${contentType}" }
-            mimeTypes.addMimeTypes("${contentType} ${ext}")
-        }
     }
 
     override fun create(): Configurer {

--- a/ext/rdf/src/main/kotlin/com/xmlcalabash/ext/rdf/RdfConfigurer.kt
+++ b/ext/rdf/src/main/kotlin/com/xmlcalabash/ext/rdf/RdfConfigurer.kt
@@ -1,45 +1,29 @@
 package com.xmlcalabash.ext.rdf
 
-import com.xmlcalabash.XmlCalabash
+import com.xmlcalabash.XmlCalabashBuilder
 import com.xmlcalabash.spi.Configurer
 import com.xmlcalabash.spi.ConfigurerProvider
 import net.sf.saxon.Configuration
-import org.apache.logging.log4j.kotlin.logger
-import javax.activation.MimetypesFileTypeMap
 
 class RdfConfigurer(): Configurer, ConfigurerProvider {
-    override fun configure(xmlcalabash: XmlCalabash) {
-        // nop
+    override fun configure(builder: XmlCalabashBuilder) {
+        builder.addMimeType("application/ld+json", listOf("jsonld"))
+        builder.addMimeType("text/n3", listOf("n3"))
+        builder.addMimeType("application/n-quads", listOf("nq"))
+        builder.addMimeType("application/n-triples", listOf("nt"))
+        builder.addMimeType("application/rdf+xml", listOf("rdf"))
+        builder.addMimeType("application/rdf+json", listOf("rj"))
+        builder.addMimeType("application/sparql-query", listOf("rq"))
+        builder.addMimeType("application/sparql-results+json", listOf("srj"))
+        builder.addMimeType("application/sparql-results+xml", listOf("srx"))
+        builder.addMimeType("application/rdf+thrift", listOf("thrift"))
+        builder.addMimeType("application/trig", listOf("trig"))
+        builder.addMimeType("application/trix+xml", listOf("trix")) // I invented this one; I didn't find a spec
+        builder.addMimeType("text/turtle", listOf("ttl"))
     }
 
     override fun configureSaxon(config: Configuration) {
         // nop
-    }
-
-    override fun configureContentTypes(contentTypes: MutableMap<String, String>, mimeTypes: MimetypesFileTypeMap) {
-        val rdfMapping = mapOf(
-            "jsonld" to "application/ld+json",
-            "n3" to "text/n3",
-            "nq" to "application/n-quads",
-            "nt" to "application/n-triples",
-            "rdf" to "application/rdf+xml",
-            "rj" to "application/rdf+json",
-            "rq" to "application/sparql-query",
-            "srj" to "application/sparql-results+json",
-            "srx" to "application/sparql-results+xml",
-            "thrift" to "application/rdf+thrift",
-            "trig" to "application/trig",
-            "trix" to "application/trix+xml", // I invented this one; I didn't find a spec
-            "ttl" to "text/turtle"
-        )
-
-        for ((ext, contentType) in rdfMapping) {
-            contentTypes[ext] = contentType
-            if (mimeTypes.getContentType("test.${ext}") == "application/octet-stream") {
-                logger.trace { "Assigning default content type to '.${ext}' files: ${contentType}" }
-                mimeTypes.addMimeTypes("${contentType} ${ext}")
-            }
-        }
     }
 
     override fun create(): Configurer {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/XmlCalabashConfiguration.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/XmlCalabashConfiguration.kt
@@ -33,7 +33,6 @@ interface XmlCalabashConfiguration {
     val messageBufferSize: Int
     val messagePrinter: MessagePrinter
     val messageReporter: MessageReporter
-    val mimetypesFileTypeMap: MimetypesFileTypeMap
     val other: Map<QName, List<Map<QName, String>>>
     val pagedMediaCssProcessors: List<URI>
     val pagedMediaManagers: List<PagedMediaManager>
@@ -56,6 +55,4 @@ interface XmlCalabashConfiguration {
     val visualizerProperties: Map<String,String>
     val xmlCatalogs: List<URI>
     val xmlSchemaDocuments: List<URI>
-    val initializerClasses: List<Pair<String,Boolean>>
-    val configurers: List<Configurer>
 }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/config/ConfigurationLoader.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/config/ConfigurationLoader.kt
@@ -285,7 +285,7 @@ class ConfigurationLoader(val builder: XmlCalabashBuilder) {
         checkAttributes(node, listOf(Ns.contentType, _extensions))
         val ctype = node.getAttributeValue(Ns.contentType)!!
         val ext = node.getAttributeValue(_extensions)!!
-        builder.getMimetypesFileTypeMap().addMimeTypes("${ctype} ${ext}")
+        builder.addMimeType(ctype, ext.split("\\s+".toRegex()))
     }
 
     private fun parseSendmail(node: XdmNode) {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/config/XProcEnvironment.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/config/XProcEnvironment.kt
@@ -35,7 +35,6 @@ interface XProcEnvironment {
     val messagePrinter: MessagePrinter
     val monitors: MutableList<Monitor>
     val documentManager: DocumentManager
-    val mimeTypes: MimetypesFileTypeMap
     val errorExplanation: ErrorExplanation
     val messageReporter: MessageReporter
     val proxies: Map<String, String>

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/CompileEnvironment.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/CompileEnvironment.kt
@@ -88,7 +88,6 @@ open class CompileEnvironment(override val episode: String, override val xmlCala
     override val messagePrinter: MessagePrinter = xmlCalabash.config.messagePrinter
     override val messageReporter: MessageReporter = xmlCalabash.config.messageReporter
     override val monitors: MutableList<Monitor> = mutableListOf()
-    override val mimeTypes: MimetypesFileTypeMap = xmlCalabash.config.mimetypesFileTypeMap
     override val documentManager: DocumentManager = xmlCalabash.config.documentManager
     override val errorExplanation: ErrorExplanation = xmlCalabash.config.errorExplanation
     override val proxies: Map<String, String> = emptyMap()
@@ -110,16 +109,12 @@ open class CompileEnvironment(override val episode: String, override val xmlCala
         }
 
         for ((ext, contentType) in _defaultContentTypes) {
-            if (mimeTypes.getContentType("test.${ext}") == "application/octet-stream") {
+            if (documentManager.mimetypesFileTypeMap.getContentType("test.${ext}") == "application/octet-stream") {
                 if (showAssignments) {
-                    logger.debug { "Assigning default content type to '.${ext}' files: ${contentType}" }
+                    logger.debug { "Assigning default content type: ${contentType} to ${ext}" }
                 }
-                mimeTypes.addMimeTypes("${contentType} ${ext}")
+                documentManager.mimetypesFileTypeMap.addMimeTypes("${contentType} ${ext}")
             }
-        }
-
-        for (configurer in xmlCalabash.configurers) {
-            configurer.configureContentTypes(_defaultContentTypes, mimeTypes)
         }
 
         for (provider in DocumentResolverServiceProvider.providers()) {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/ImportFunctionsInstruction.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/ImportFunctionsInstruction.kt
@@ -59,7 +59,7 @@ class ImportFunctionsInstruction(parent: XProcInstruction?, stepConfig: Instruct
         }
 
         val ctype = if (contentType == null) {
-            MediaType.parse(stepConfig.mimeTypes.getContentType(href.toString()))
+            MediaType.parse(stepConfig.documentManager.mimetypesFileTypeMap.getContentType(href.toString()))
         } else {
             contentType!!
         }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/io/DocumentLoader.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/io/DocumentLoader.kt
@@ -160,7 +160,7 @@ class DocumentLoader(val stepConfig: StepConfiguration,
         mediaType = if (documentProperties.has(Ns.contentType)) {
             MediaType.parse(documentProperties[Ns.contentType]!!.underlyingValue.stringValue)
         } else {
-            val fileMediaType = stepConfig.environment.mimeTypes.getContentType(absURI.toString())
+            val fileMediaType = stepConfig.documentManager.mimetypesFileTypeMap.getContentType(absURI.toString())
             MediaType.parse(fileMediaType)
         }
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/io/DocumentManager.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/io/DocumentManager.kt
@@ -1,6 +1,5 @@
 package com.xmlcalabash.io
 
-import com.xmlcalabash.XmlCalabashConfiguration
 import com.xmlcalabash.config.StepConfiguration
 import com.xmlcalabash.documents.DocumentProperties
 import com.xmlcalabash.documents.XProcBinaryDocument
@@ -18,7 +17,6 @@ import org.apache.logging.log4j.kotlin.logger
 import org.xml.sax.EntityResolver
 import org.xml.sax.InputSource
 import org.xml.sax.ext.EntityResolver2
-import org.xmlresolver.ResolverConfiguration
 import org.xmlresolver.ResolverConstants
 import org.xmlresolver.ResourceRequestImpl
 import org.xmlresolver.XMLResolver
@@ -26,23 +24,29 @@ import org.xmlresolver.sources.ResolverSAXSource
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.net.URI
+import javax.activation.MimetypesFileTypeMap
 import javax.xml.transform.Source
 import javax.xml.transform.URIResolver
 import javax.xml.transform.sax.SAXSource
 import javax.xml.transform.stream.StreamSource
 
-open class DocumentManager(val xmlCalabashConfiguration: XmlCalabashConfiguration, val resolver: XMLResolver): EntityResolver, EntityResolver2, URIResolver, ResourceResolver, ModuleURIResolver {
-    constructor(xmlCalabashConfiguration: XmlCalabashConfiguration): this(xmlCalabashConfiguration, XMLResolver())
+open class DocumentManager(val resolver: XMLResolver): EntityResolver, EntityResolver2, URIResolver, ResourceResolver, ModuleURIResolver {
+    constructor(): this(XMLResolver())
 
-    constructor(manager: DocumentManager): this(manager.xmlCalabashConfiguration, manager.resolver) {
+    constructor(manager: DocumentManager): this(manager.resolver) {
         prefixMap.putAll(manager.prefixMap)
         prefixList.addAll(manager.prefixList)
         _cache.putAll(manager._cache)
+        _mimetypesFileTypeMap = manager._mimetypesFileTypeMap
     }
 
     private val prefixMap = mutableMapOf<String, DocumentResolver>()
     private val prefixList = mutableListOf<String>()
     private val _cache = mutableMapOf<URI, MutableMap<MediaType,XProcDocument>>()
+
+    private var _mimetypesFileTypeMap = MimetypesFileTypeMap()
+    val mimetypesFileTypeMap: MimetypesFileTypeMap
+        get() = _mimetypesFileTypeMap
 
     fun registerPrefix(prefix: String, resolver: DocumentResolver) {
         prefixMap[prefix] = resolver
@@ -139,7 +143,7 @@ open class DocumentManager(val xmlCalabashConfiguration: XmlCalabashConfiguratio
     }
 
     fun getCached(href: URI): XProcDocument? {
-        val contentType = MediaType.parse(xmlCalabashConfiguration.mimetypesFileTypeMap.getContentType(href.toString()))
+        val contentType = MediaType.parse(mimetypesFileTypeMap.getContentType(href.toString()))
         return getCached(href, contentType)
     }
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/spi/Configurer.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/spi/Configurer.kt
@@ -1,11 +1,9 @@
 package com.xmlcalabash.spi
 
-import com.xmlcalabash.XmlCalabash
+import com.xmlcalabash.XmlCalabashBuilder
 import net.sf.saxon.Configuration
-import javax.activation.MimetypesFileTypeMap
 
 interface Configurer {
-    fun configure(xmlcalabash: XmlCalabash)
+    fun configure(builder: XmlCalabashBuilder)
     fun configureSaxon(config: Configuration)
-    fun configureContentTypes(contentTypes: MutableMap<String, String>, mimeTypes: MimetypesFileTypeMap)
 }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/AbstractArchiveStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/AbstractArchiveStep.kt
@@ -61,10 +61,9 @@ abstract class AbstractArchiveStep(): AbstractAtomicStep() {
         for (pair in overrideContentTypes) {
             if (pair.first.toRegex().find(name) != null) {
                 return pair.second
-                break
             }
         }
-        return MediaType.parse(stepConfig.environment.mimeTypes.getContentType(name))
+        return MediaType.parse(stepConfig.documentManager.mimetypesFileTypeMap.getContentType(name))
     }
 
     protected fun selectFormat(contentType: MediaType, defaultFormat: QName?): QName {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/archives/ArInputArchive.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/archives/ArInputArchive.kt
@@ -31,7 +31,7 @@ open class ArInputArchive(stepConfig: StepConfiguration, doc: XProcBinaryDocumen
             val archiveEntry = XArchiveEntry(stepConfig, entry.name, entry, this)
             val amap = mutableMapOf<QName, String>(
                 Ns.name to entry.name,
-                Ns.contentType to "${MediaType.parse(stepConfig.environment.mimeTypes.getContentType(entry.name))}",
+                Ns.contentType to "${MediaType.parse(stepConfig.documentManager.mimetypesFileTypeMap.getContentType(entry.name))}",
                 NsCx.size to entry.size.toString(),
                 NsCx.groupId to entry.groupId.toString(),
             )

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/archives/ArjInputArchive.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/archives/ArjInputArchive.kt
@@ -32,7 +32,7 @@ open class ArjInputArchive(stepConfig: StepConfiguration, doc: XProcBinaryDocume
             val archiveEntry = XArchiveEntry(stepConfig, entry.name, entry, this)
             val amap = mutableMapOf<QName, String>(
                 Ns.name to entry.name,
-                Ns.contentType to "${MediaType.parse(stepConfig.environment.mimeTypes.getContentType(entry.name))}",
+                Ns.contentType to "${MediaType.parse(stepConfig.documentManager.mimetypesFileTypeMap.getContentType(entry.name))}",
                 NsCx.size to entry.size.toString(),
                 NsCx.windowsAttributes to entry.mode.toString(),
             )

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/archives/CpioInputArchive.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/archives/CpioInputArchive.kt
@@ -33,7 +33,7 @@ open class CpioInputArchive(stepConfig: StepConfiguration, doc: XProcBinaryDocum
             val archiveEntry = XArchiveEntry(stepConfig, entry.name, entry, this)
             val amap = mutableMapOf<QName, String>(
                 Ns.name to entry.name,
-                Ns.contentType to "${MediaType.parse(stepConfig.environment.mimeTypes.getContentType(entry.name))}",
+                Ns.contentType to "${MediaType.parse(stepConfig.documentManager.mimetypesFileTypeMap.getContentType(entry.name))}",
                 NsCx.size to "${entry.size}"
             )
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/archives/SevenZInputArchive.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/archives/SevenZInputArchive.kt
@@ -31,7 +31,7 @@ class SevenZInputArchive(stepConfig: StepConfiguration, doc: XProcBinaryDocument
             val archiveEntry = XArchiveEntry(stepConfig, entry.name, entry, this)
             val amap = mutableMapOf<QName, String>(
                 Ns.name to entry.name,
-                Ns.contentType to "${MediaType.parse(stepConfig.environment.mimeTypes.getContentType(entry.name))}",
+                Ns.contentType to "${MediaType.parse(stepConfig.documentManager.mimetypesFileTypeMap.getContentType(entry.name))}",
                 NsCx.size to entry.size.toString()
             )
             if (entry.hasCrc) {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/archives/TarInputArchive.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/archives/TarInputArchive.kt
@@ -28,7 +28,7 @@ open class TarInputArchive(stepConfig: StepConfiguration, doc: XProcBinaryDocume
             val archiveEntry = XArchiveEntry(stepConfig, entry.name, entry, this)
             val amap = mutableMapOf<QName, String>(
                 Ns.name to entry.name,
-                Ns.contentType to "${MediaType.parse(stepConfig.environment.mimeTypes.getContentType(entry.name))}",
+                Ns.contentType to "${MediaType.parse(stepConfig.documentManager.mimetypesFileTypeMap.getContentType(entry.name))}",
                 NsCx.groupId to entry.longGroupId.toString(),
                 NsCx.groupName to entry.groupName,
                 NsCx.userId to entry.longUserId.toString(),

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/archives/ZipInputArchive.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/archives/ZipInputArchive.kt
@@ -31,7 +31,7 @@ open class ZipInputArchive(stepConfig: StepConfiguration, doc: XProcBinaryDocume
             val archiveEntry = XArchiveEntry(stepConfig, entry.name, entry, this)
             val amap = mutableMapOf<QName, String>(
                 Ns.name to entry.name,
-                Ns.contentType to "${MediaType.parse(stepConfig.environment.mimeTypes.getContentType(entry.name))}",
+                Ns.contentType to "${MediaType.parse(stepConfig.documentManager.mimetypesFileTypeMap.getContentType(entry.name))}",
                 NsCx.size to entry.size.toString()
             )
             if (entry.unixMode != 0) {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/file/DirectoryListStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/file/DirectoryListStep.kt
@@ -131,7 +131,8 @@ class DirectoryListStep(): FileStep(NsP.directoryList) {
 
             return entry
         } else {
-            val ctype = overrideContentType ?: MediaType.parse(stepConfig.environment.mimeTypes.getContentType(dir))
+            val ctype = overrideContentType
+                ?: MediaType.parse(stepConfig.documentManager.mimetypesFileTypeMap.getContentType(dir))
             return DirectoryFile(dir, include, ctype)
         }
     }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/file/FileInfoStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/file/FileInfoStep.kt
@@ -41,7 +41,7 @@ class FileInfoStep(): FileStep(NsP.fileInfo) {
             }
         }
         if (!override) {
-            contentType = MediaType.parse(stepConfig.environment.mimeTypes.getContentType(file))
+            contentType = MediaType.parse(stepConfig.documentManager.mimetypesFileTypeMap.getContentType(file))
         }
 
         val atts = if (file.isDirectory) {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/spi/StandardConfigurer.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/spi/StandardConfigurer.kt
@@ -1,20 +1,15 @@
 package com.xmlcalabash.util.spi
 
-import com.xmlcalabash.XmlCalabash
+import com.xmlcalabash.XmlCalabashBuilder
 import com.xmlcalabash.spi.Configurer
 import net.sf.saxon.Configuration
-import javax.activation.MimetypesFileTypeMap
 
 class StandardConfigurer(): Configurer {
-    override fun configure(config: XmlCalabash) {
+    override fun configure(builder: XmlCalabashBuilder) {
         // nop
     }
 
     override fun configureSaxon(config: Configuration) {
-        // nop
-    }
-
-    override fun configureContentTypes(contentTypes: MutableMap<String, String>, mimeTypes: MimetypesFileTypeMap) {
         // nop
     }
 }


### PR DESCRIPTION
Fix #460

It’s now possible to create a document manager with its own resolver and configure that with the builder. This entailed moving a few APIs around. There’s a little bit of related cleanup in this PR as well.