### PR TITLE
Improve error messages for bad content and content type

### DIFF
--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/XProcError.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/XProcError.kt
@@ -216,7 +216,8 @@ open class XProcError protected constructor(val code: QName, val variant: Int, e
         fun xdUrifyDifferentDrives(filepath: String, basedir: String) = dynamic(75, filepath, basedir)
         fun xdUrifyMixedDrivesAndAuthorities(filepath: String, basedir: String) = dynamic(76, filepath, basedir)
         fun xdUrifyDifferentSchemes(filepath: String, basedir: String) = dynamic(77, filepath, basedir)
-        fun xdInvalidContentType(value: String) = dynamic(79, value)
+        fun xdInvalidContentType(value: String) = dynamic(Pair(79, 1), value)
+        fun xdInvalidContentTypeShortcut(value: String, correct: String) = dynamic(Pair(79, 2), value, correct)
         fun xdUrifyNonhierarchicalBase(filepath: String, basedir: String) = dynamic(80, filepath, basedir)
         fun xdInvalidExpression(expression: String) = dynamic(83, expression)
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/io/DocumentLoader.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/io/DocumentLoader.kt
@@ -7,6 +7,7 @@ import com.xmlcalabash.config.StepConfiguration
 import com.xmlcalabash.documents.DocumentProperties
 import com.xmlcalabash.documents.XProcDocument
 import com.xmlcalabash.exceptions.XProcError
+import com.xmlcalabash.exceptions.XProcException
 import com.xmlcalabash.namespace.Ns
 import com.xmlcalabash.namespace.NsCx
 import com.xmlcalabash.spi.ContentTypeLoader
@@ -23,6 +24,7 @@ import nu.validator.htmlparser.dom.HtmlDocumentBuilder
 import org.xml.sax.ErrorHandler
 import org.xml.sax.InputSource
 import org.xml.sax.SAXParseException
+import org.yaml.snakeyaml.error.MarkedYAMLException
 import java.io.*
 import java.net.URI
 import java.nio.ByteBuffer
@@ -109,8 +111,12 @@ class DocumentLoader(val stepConfig: StepConfiguration,
         if (absURI.scheme == "file") {
             try {
                 return loadFile()
-            } catch (ex: IOException) {
-                throw stepConfig.exception(XProcError.xdDoesNotExist(UriUtils.path(absURI), ex.message ?: "???"), ex)
+            } catch (ex: Exception) {
+                when (ex) {
+                    is FileNotFoundException -> throw stepConfig.exception(XProcError.xdDoesNotExist(UriUtils.path(absURI), ex.message ?: "???"), ex)
+                    is IOException -> throw stepConfig.exception(XProcError.xdIsNotReadable(UriUtils.path(absURI), ex.message ?: "???"), ex)
+                    else -> throw ex
+                }
             }
         }
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/AbstractAtomicStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/steps/AbstractAtomicStep.kt
@@ -290,7 +290,16 @@ abstract class AbstractAtomicStep(): XProcStep {
         if (value == XdmEmptySequence.getInstance()) {
             return default
         }
-        return MediaType.parse(value.underlyingValue.stringValue)
+        val ctype = value.underlyingValue.stringValue
+        when (ctype) {
+            "xml" -> throw XProcError.xdInvalidContentTypeShortcut(ctype, "application/xml").exception()
+            "html" -> throw XProcError.xdInvalidContentTypeShortcut(ctype, "text/html").exception()
+            "text" -> throw XProcError.xdInvalidContentTypeShortcut(ctype, "text/plain").exception()
+            "json" -> throw XProcError.xdInvalidContentTypeShortcut(ctype, "application/json").exception()
+            "yaml" -> throw XProcError.xdInvalidContentTypeShortcut(ctype, "application/yaml").exception()
+            "any" -> throw XProcError.xdInvalidContentTypeShortcut(ctype, "application/octet-stream").exception()
+            else -> return MediaType.parse(value.underlyingValue.stringValue)
+        }
     }
 
     fun wildcardMediaTypeBinding(name: QName, default: MediaType = MediaType.ANY): MediaType {

--- a/xmlcalabash/src/main/resources/com/xmlcalabash/explain-errors.txt
+++ b/xmlcalabash/src/main/resources/com/xmlcalabash/explain-errors.txt
@@ -271,10 +271,17 @@ Path (“$1”) and base URI (“$2”) have different schemes.
 It is a dynamic error if the relative path has a scheme that differs from the
 scheme of the base URI.
 
-XD0079
+XD0079/1
 Invalid content type: “$1”.
 It is a dynamic error if a supplied content-type is not a valid media type of
 the form “type/subtype+ext” or “type/subtype”.
+
+XD0079/2
+Cannot use content type shortcut “$1” here, use “$2”.
+Content type shorcuts (xml, json, etc.) can represent more than one specific
+content type. They can be used for inputs, but on ouputs, a single, specific
+content type must be provided. For “$1”, a common choice is “$2” but in some
+cases, a more specific $1 content type might be preferable.
 
 XD0080
 Cannot resolve path (“$1”) with a non-hierarchical base URI: “$2”.


### PR DESCRIPTION
Provide a more useful error message if someone uses a content-type shortcut on an output, or where a single, specific content type is required. Also raise “input not readable” rather than “file not found” for parse errors on inputs.