### PR TITLE
Don’t accidentally turn null into “null” in the graph visualization.

### DIFF
--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/graph/GraphVisualization.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/graph/GraphVisualization.kt
@@ -314,7 +314,7 @@ class GraphVisualization private constructor(val graph: Graph, private val filen
 
             val href = if (model.step is AtomicDocumentStepInstruction) {
                 try {
-                    model.step.staticOptions[Ns.href]?.staticValue.toString()
+                    model.step.staticOptions[Ns.href]?.staticValue?.toString()
                 } catch (ex: Exception) {
                     null
                 }


### PR DESCRIPTION
Fix #472