### PR TITLE
Improve the error message associated with unknown port

### DIFF
--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/PipeInstruction.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/PipeInstruction.kt
@@ -115,7 +115,7 @@ class PipeInstruction(parent: XProcInstruction): ConnectionInstruction(parent, N
             if (port == null) {
                 throw stepConfig.exception(XProcError.xsNoPortPortNotReadable())
             } else {
-                throw stepConfig.exception(XProcError.xsPortNotReadable(port!!))
+                throw stepConfig.exception(XProcError.xsPortNotReadable(_step ?: "", port!!))
             }
         } else {
             _port = fromPort.port

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/XProcError.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/XProcError.kt
@@ -87,7 +87,7 @@ open class XProcError protected constructor(val code: QName, val variant: Int, e
         fun xsNoSteps() = static(15)
         fun xsRequiredAndDefaulted(name: QName) = static(17, name)
         fun xsMissingRequiredOption(name: QName) = static(18, name)
-        fun xsPortNotReadable(step: String) = static(Pair(22, 1), step)
+        fun xsPortNotReadable(port: String) = static(Pair(22, 1), port)
         fun xsPortNotReadable(step: String, port: String) = static(Pair(22, 2), step, port)
         fun xsOutputPortNotReadable(step: String, port: String) = static(Pair(22, 3), step, port)
         fun xsStepTypeInNoNamespace(type: QName) = static(Pair(25,1), type)

--- a/xmlcalabash/src/main/resources/com/xmlcalabash/explain-errors.txt
+++ b/xmlcalabash/src/main/resources/com/xmlcalabash/explain-errors.txt
@@ -345,7 +345,7 @@ If an option is required, it is a static error to invoke the step without
 specifying a value for that option.
 
 XS0022/1
-Attempt to connect to port on unknown or out-of-scope step: “$1”.
+Attempt to connect to unknown port “$1”.
 In all cases except when the p:pipe is within an p:output of a compound step, it
 is a static error if the port identified by the p:pipe is not in the readable
 ports of the step that contains the p:pipe.


### PR DESCRIPTION
Fix #478

The message has been corrected to

  Attempt to connect to unknown port “$1”.

But it also uses the step/port message now instead:

  Cannot read from “$2” on “$1”.

This will have the effect of printing the step name, even when it’s a generated name (such as “!xslt”), but that’s probably still a better aid to debugging.