### PR TITLE
Make sure that the resolver configuration is initialized correctly

### DIFF
--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/XmlCalabashBuilder.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/XmlCalabashBuilder.kt
@@ -22,6 +22,7 @@ import net.sf.saxon.Configuration
 import net.sf.saxon.s9api.QName
 import net.sf.saxon.s9api.ValidationMode
 import org.apache.logging.log4j.kotlin.logger
+import org.xmlresolver.ResolverFeature
 import java.io.File
 import java.io.IOException
 import java.net.URI
@@ -488,6 +489,7 @@ class XmlCalabashBuilder {
         }
 
         val saxonConfiguration = SaxonConfiguration.newInstance(config.licensed, config.saxonConfigurationFile?.toURI(), config.saxonConfigurationProperties, config.xmlSchemaDocuments, initializers, configurers)
+        saxonConfiguration.configuration.resourceResolver = config._documentManager
         config._saxonConfiguration = saxonConfiguration
         return init(config)
     }
@@ -732,6 +734,14 @@ class XmlCalabashBuilder {
             config._visualizerProperties.putAll(_visualizerProperties)
             config._xmlCatalogs.addAll(_xmlCatalogs)
             config._xmlSchemaDocuments.addAll(_xmlSchemaDocuments)
+
+            val xmlconfig = config.documentManager.resolver.configuration
+            val catlist = mutableListOf<String>()
+            catlist.addAll(xmlconfig.getFeature(ResolverFeature.CATALOG_FILES))
+            for (cat in config.xmlCatalogs) {
+                catlist.add(cat.toString())
+            }
+            xmlconfig.setFeature(ResolverFeature.CATALOG_FILES, catlist)
 
             return config
         }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/config/SaxonConfiguration.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/config/SaxonConfiguration.kt
@@ -147,6 +147,7 @@ class SaxonConfiguration private constructor(val licensed: Boolean,
 
         newConfig.configuration.namePool = configuration.namePool
         newConfig.configuration.documentNumberAllocator = configuration.documentNumberAllocator
+        newConfig.configuration.resourceResolver = configuration.resourceResolver
 
         newConfig._processor = Processor(newConfig.configuration)
         newConfig.configureProcessor(newConfig._processor)

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/io/DocumentManager.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/io/DocumentManager.kt
@@ -249,11 +249,11 @@ open class DocumentManager(val resolver: XMLResolver): EntityResolver, EntityRes
         return null
     }
 
-    override fun resolveEntity(name: String?, publicId: String?, baseURI: String?, systemId: String?): InputSource {
+    override fun resolveEntity(name: String?, publicId: String?, baseURI: String?, systemId: String?): InputSource? {
         return resolver.entityResolver2.resolveEntity(name, publicId, baseURI, systemId)
     }
 
-    override fun resolveEntity(publicId: String?, systemId: String?): InputSource {
+    override fun resolveEntity(publicId: String?, systemId: String?): InputSource? {
         if (systemId != null) {
             val source = inputFromCache(URI(systemId))
             if (source != null) {
@@ -264,7 +264,7 @@ open class DocumentManager(val resolver: XMLResolver): EntityResolver, EntityRes
         return resolver.entityResolver2.resolveEntity(publicId, systemId)
     }
 
-    override fun getExternalSubset(name: String?, baseURI: String?): InputSource {
+    override fun getExternalSubset(name: String?, baseURI: String?): InputSource? {
         return resolver.entityResolver2.getExternalSubset(name, baseURI)
     }
 


### PR DESCRIPTION
Fix #488

There are two related fixes here, and an API correction. The fixes are:

1. The DocumentManager is used as the ResourceResolver for the underlying Saxon configuration, and that configuration is copied when new configurations are created.

2. The catalog files passed to the configuration builder are added to the DocumentManager’s resolver configuration. They’re added as catalogs in addition to whatever might have been configured outside XML Calabash. They’re not “additional catalogs” because those might be used by steps that add catalogs.

The API correction is that the resolver APIs can return null.