### PR TITLE
Fix the error location for dynamic errors in atomic steps

### DIFF
--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/AtomicStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/AtomicStep.kt
@@ -189,7 +189,7 @@ open class AtomicStep(config: XProcStepConfiguration, atomic: AtomicBuiltinStepM
         }
 
         if (inputErrors.isNotEmpty()) {
-            throw inputErrors.first().exception()
+            throw stepConfig.exception(inputErrors.first())
         }
 
         synchronized(openPorts) {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/CompoundStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/CompoundStep.kt
@@ -84,7 +84,7 @@ abstract class CompoundStep(config: XProcStepConfiguration, compound: CompoundSt
         runnableProviders[compound.head] = { head }
         runnableProviders[compound.foot] = { foot }
         for (step in compound.steps) {
-            val stepRunnable = step.runnable(config)
+            val stepRunnable = step.runnable(step.stepConfig)
             runnableProviders[step] = stepRunnable
         }
     }


### PR DESCRIPTION
Fix #493

Make sure that the step configuration used to create atomic steps is the step configuration of the atomic step, not the configuration of their parent compound step.