### PR TITLE
Don’t require port name on command line if there’s only one port

### DIFF
--- a/app/src/main/kotlin/com/xmlcalabash/app/CommandLine.kt
+++ b/app/src/main/kotlin/com/xmlcalabash/app/CommandLine.kt
@@ -414,9 +414,12 @@ class CommandLine private constructor(val args: Array<out String>) {
         }
     }
 
-    private fun split(arg: String, type: String): Pair<String, String> {
+    private fun split(arg: String, type: String, defaultName: String? = null): Pair<String, String> {
         val pos = arg.indexOf("=")
         if (pos <= 0) {
+            if (defaultName != null) {
+                return Pair(defaultName, arg)
+            }
             throw XProcError.xiCliMalformedOption(type, arg).exception()
         }
         return Pair(arg.substring(0, pos).trim(), arg.substring(pos + 1).trim())
@@ -424,7 +427,7 @@ class CommandLine private constructor(val args: Array<out String>) {
 
     private fun parseInput(arg: String) {
         // -i:contentType@port=path
-        val (portspec, href) = split(arg, "input")
+        val (portspec, href) = split(arg, "input", "*anonymous")
         var port = portspec
         var contentType = MediaType.ANY
         if (portspec.contains("@")) {
@@ -445,7 +448,7 @@ class CommandLine private constructor(val args: Array<out String>) {
 
     private fun parseOutput(arg: String) {
         // -i:port=path
-        val (port, filename) = split(arg, "output")
+        val (port, filename) = split(arg, "output", "*anonymous")
         if (_outputs.containsKey(port)) {
             throw XProcError.xiCliDuplicateOutputFile(filename).exception()
         }

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/XProcError.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/exceptions/XProcError.kt
@@ -479,6 +479,7 @@ open class XProcError protected constructor(val code: QName, val variant: Int, e
         fun xiCliMoreThanOnePipeline(first: String, second: String) = internal(204, first, second)
         fun xiCliMalformedOption(type: String, opt: String) = internal(205, type, opt)
         fun xiCliDuplicateOutputFile(filename: String) = internal(206, filename)
+        fun xiCliPortNameRequired(type: String) = internal(207, type)
 
         fun xiTooLateForStaticOptions(name: QName) = internal(213, name)
         fun xiCliDuplicateNamespace(prefix: String) = internal(214, prefix)

--- a/xmlcalabash/src/main/resources/com/xmlcalabash/explain-errors.txt
+++ b/xmlcalabash/src/main/resources/com/xmlcalabash/explain-errors.txt
@@ -1656,6 +1656,9 @@ Command line option malformed: “$2” ($1).
 cxerr:XI0206
 Duplicate output file: “$1”.
 
+cxerr:XI0207
+Pipeline has more than one $1; port name required on command line.
+
 cxerr:XI0213
 Static options cannot be provided after the pipeline has been compiled: “$1”.
 


### PR DESCRIPTION
Fix #498

If a pipeline has only one port, allow --input:/path/to/file or --output:/path/to/file without the port name.