### PR TITLE
Added ‘info’ command

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,6 +35,7 @@ val collectionManagerRelease by configurations.dependencyScope("collectionManage
 
 val dep_slf4j = project.findProperty("slf4j").toString()
 val dep_nineml = project.findProperty("nineml").toString()
+val dep_activation = project.findProperty("activation").toString()
 
 dependencies {
   xmlcalabashRelease(project(mapOf("path" to ":xmlcalabash",
@@ -94,6 +95,7 @@ dependencies {
 
   implementation("org.nineml:coffeesacks:${dep_nineml}")
   implementation("org.slf4j:slf4j-api:${dep_slf4j}")
+  implementation("javax.activation:activation:${dep_activation}") // For mimetype mapping
 }
 
 val xmlcalabashJar = configurations.resolvable("xmlcalabashJar") {

--- a/app/src/main/kotlin/com/xmlcalabash/app/XmlCalabashCli.kt
+++ b/app/src/main/kotlin/com/xmlcalabash/app/XmlCalabashCli.kt
@@ -155,9 +155,20 @@ class XmlCalabashCli private constructor() {
             return
         }
 
-        if (commandLine.command == "version") {
-            version()
-            return
+        when (commandLine.command) {
+            "info-version" -> {
+                version()
+                return
+            }
+            "info-mimetype" -> {
+                showMimetype(commandLine.mimetypeExtension)
+                return
+            }
+            "info-mimetypes" -> {
+                showMimetypes()
+                return
+            }
+            else -> Unit
         }
 
         var tstart: Long = 0
@@ -546,6 +557,37 @@ class XmlCalabashCli private constructor() {
                 } else {
                     println("(You appear to have ${edition} but the license is explicitly disabled.)")
                 }
+            }
+        }
+    }
+
+    private fun showMimetype(extension: String?) {
+        println("Filename extension/content type mapping:")
+
+        val types = xmlCalabash.config.documentManager.mimetypesFileTypeMap
+        if (extension == null) {
+            println("\tdefault content type is ${types.getContentType("default")}")
+            return
+        }
+
+        val dotlessExt = extension.trimStart('.')
+        val ctype = types.getContentType("file.${dotlessExt}")
+        println("\t.${dotlessExt} is ${ctype}")
+    }
+
+    private fun showMimetypes() {
+        val types = xmlCalabash.config.documentManager.mimetypesFileTypeMap
+        if (types is MemoMimetypesFileTypeMap) {
+            val extensions = types.extensionMap.keys.sorted()
+            if (extensions.isNotEmpty()) {
+                println("Filename extension/content type mappings defined by XML Calabash:")
+                for (ext in extensions) {
+                    val ctype = types.extensionMap[ext]!!
+                    println("\t.${ext} is ${ctype}")
+                }
+                println("Additional mappings may have been defined in the JVM, for example with a .mime.types file.")
+                println("See https://docs.oracle.com/javase/7/docs/api/javax/activation/MimetypesFileTypeMap.html")
+                println("Use the 'info mimetype <ext>' command to query the content type of a particular <ext>.")
             }
         }
     }

--- a/app/src/main/resources/com/xmlcalabash/help.txt
+++ b/app/src/main/resources/com/xmlcalabash/help.txt
@@ -2,9 +2,11 @@ Usage: [command] [options] pipeline.xpl optname=value…
 
 Where command is:
 
+  run                  To run a pipeline (the default if no command is given)
   help                 To display this summary
-  version              To display information about the version and configuration
-  run                  To run a pipeline
+  info version         To display information about the version and configuration
+  info mimetypes       To display information about mimetype mappings
+  info mimetype ext    To display the mimetype of file.ext files (or URIs)
 
 And some of the frequently used options are:
 

--- a/documentation/src/userguide/install.xml
+++ b/documentation/src/userguide/install.xml
@@ -116,48 +116,67 @@ resources, XML Calabash defines a pragmatically more useful default.</para>
 </row>
 </thead>
 <tbody>
-<row><entry>7z</entry><entry>application/x-7z-compressed</entry></row>
-<row><entry>a</entry><entry>application/x-archive</entry></row>
-<row><entry>arj</entry><entry>application/x-arj</entry></row>
-<row><entry>bmp</entry><entry>image/bmp</entry></row>
-<row><entry>bz2</entry><entry>application/bzip2</entry></row>
-<row><entry>cpio</entry><entry>application/x-cpio</entry></row>
-<row><entry>css</entry><entry>text/plain</entry></row>
-<row><entry>eps</entry><entry>image/eps</entry></row>
-<row><entry>fo</entry><entry>application/xml</entry></row>
-<row><entry>gif</entry><entry>image/gif</entry></row>
-<row><entry>gz</entry><entry>application/gzip</entry></row>
-<row><entry>gzip</entry><entry>application/gzip</entry></row>
-<row><entry>jar</entry><entry>application/java-archive</entry></row>
-<row><entry>jpg, jpeg</entry><entry>image/jpeg</entry></row>
-<row><entry>json</entry><entry>application/json</entry></row>
-<row><entry>lzma</entry><entry>application/lzma</entry></row>
-<row><entry>nvdl</entry><entry>application/nvdl+xml</entry></row>
-<row><entry>pdf</entry><entry>application/pdf</entry></row>
-<row><entry>rnc</entry><entry>application/relax-ng-compact-syntax</entry></row>
-<row><entry>rng</entry><entry>application/relax-ng+xml</entry></row>
-<row><entry>sch</entry><entry>application/schematron+xml</entry></row>
-<row><entry>svg</entry><entry>image/svg+xml</entry></row>
-<row><entry>tar</entry><entry>application/x-tar</entry></row>
-<row><entry>text</entry><entry>text/plain</entry></row>
-<row><entry>txt</entry><entry>text/plain</entry></row>
-<row><entry>xml</entry><entry>application/xml</entry></row>
-<row><entry>xpl</entry><entry>application/xml</entry></row>
-<row><entry>xq</entry><entry>application/xquery</entry></row>
-<row><entry>xqy</entry><entry>application/xquery</entry></row>
-<row><entry>xsd</entry><entry>application/xsd+xml</entry></row>
-<row><entry>xsl</entry><entry>application/xslt+xml</entry></row>
-<row><entry>xslt</entry><entry>application/xslt+xml</entry></row>
-<row><entry>xz</entry><entry>application/xz</entry></row>
-<row><entry>zip</entry><entry>application/zip</entry></row>
+<row><entry>.7z</entry><entry>application/x-7z-compressed</entry></row>
+<row><entry>.a</entry><entry>application/x-archive</entry></row>
+<row><entry>.arj</entry><entry>application/x-arj</entry></row>
+<row><entry>.bmp</entry><entry>image/bmp</entry></row>
+<row><entry>.bz2</entry><entry>application/bzip2</entry></row>
+<row><entry>.cpio</entry><entry>application/x-cpio</entry></row>
+<row><entry>.css</entry><entry>text/plain</entry></row>
+<row><entry>.csv</entry><entry>text/csv</entry></row>
+<row><entry>.dtd</entry><entry>application/xml-dtd</entry></row>
+<row><entry>.epub</entry><entry>application/epub+zip</entry></row>
+<row><entry>.fo</entry><entry>application/xml</entry></row>
+<row><entry>.gz</entry><entry>application/gzip</entry></row>
+<row><entry>.gzip</entry><entry>application/gzip</entry></row>
+<row><entry>.jar</entry><entry>application/java-archive</entry></row>
+<row><entry>.json</entry><entry>application/json</entry></row>
+<row><entry>.jsonld</entry><entry>application/ld+json</entry></row>
+<row><entry>.lzma</entry><entry>application/lzma</entry></row>
+<row><entry>.n3</entry><entry>text/n3</entry></row>
+<row><entry>.nq</entry><entry>application/n-quads</entry></row>
+<row><entry>.nt</entry><entry>application/n-triples</entry></row>
+<row><entry>.nvdl</entry><entry>application/nvdl+xml</entry></row>
+<row><entry>.pdf</entry><entry>application/pdf</entry></row>
+<row><entry>.rdf</entry><entry>application/rdf+xml</entry></row>
+<row><entry>.rj</entry><entry>application/rdf+json</entry></row>
+<row><entry>.rnc</entry><entry>application/relax-ng-compact-syntax</entry></row>
+<row><entry>.rng</entry><entry>application/relax-ng+xml</entry></row>
+<row><entry>.rq</entry><entry>application/sparql-query</entry></row>
+<row><entry>.sch</entry><entry>application/schematron+xml</entry></row>
+<row><entry>.srj</entry><entry>application/sparql-results+json</entry></row>
+<row><entry>.srx</entry><entry>application/sparql-results+xml</entry></row>
+<row><entry>.svg</entry><entry>image/svg+xml</entry></row>
+<row><entry>.tar</entry><entry>application/x-tar</entry></row>
+<row><entry>.thrift</entry><entry>application/rdf+thrift</entry></row>
+<row><entry>.toml</entry><entry>application/toml</entry></row>
+<row><entry>.trig</entry><entry>application/trig</entry></row>
+<row><entry>.trix</entry><entry>application/trix+xml</entry></row>
+<row><entry>.ttl</entry><entry>text/turtle</entry></row>
+<row><entry>.xml</entry><entry>application/xml</entry></row>
+<row><entry>.xpl</entry><entry>application/xproc+xml</entry></row>
+<row><entry>.xq</entry><entry>application/xquery</entry></row>
+<row><entry>.xql</entry><entry>application/xquery</entry></row>
+<row><entry>.xqm</entry><entry>application/xquery</entry></row>
+<row><entry>.xquery</entry><entry>application/xquery</entry></row>
+<row><entry>.xqy</entry><entry>application/xquery</entry></row>
+<row><entry>.xsd</entry><entry>application/xsd+xml</entry></row>
+<row><entry>.xsl</entry><entry>application/xslt+xml</entry></row>
+<row><entry>.xslt</entry><entry>application/xslt+xml</entry></row>
+<row><entry>.xz</entry><entry>application/xz</entry></row>
+<row><entry>.yaml</entry><entry>application/x-yaml</entry></row>
+<row><entry>.yml</entry><entry>application/x-yaml</entry></row>
+<row><entry>.zip</entry><entry>application/zip</entry></row>
 </tbody>
 </tgroup>
 </table>
 
-<para>Extensions to XML Calabash may also update this table. For example, the
-<tag>cx:epubcheck</tag> step adds a mapping for the extension
-“<filename class="extension">epub</filename>”. If the defaults are problematic, you can
-override them with one of the existing configuration mechanisms.</para>
+<para>Extensions to XML Calabash may also update this table. To find out the
+mappings actually in effect, use the <link linkend="run-info-mimetypes">info
+mimetypes</link> or <link linkend="run-info-mimetype">info mimetype</link>
+commands to check the mappings in effect on your system. If the defaults are
+problematic, you can override them with one of the existing configuration
+mechanisms.</para>
 
 <para>Also, if you have a different convention, perhaps using the extension
 “<literal>.schematron</literal>” for Schematron files or “<literal>.xs</literal>” for

--- a/documentation/src/userguide/run.xml
+++ b/documentation/src/userguide/run.xml
@@ -33,7 +33,7 @@ extensive features for managing dependencies. In the short term, it’s just a b
 have a license for Saxon PE or Saxon EE, it makes sense to swap out the Saxon HE
 library that ships with XML Calabash for PE or EE.</para>
 <para>To save you the trouble of constructing and managing a large classpath, the
-alpha distribution of XML Calabash is configured with a hack. Simply
+distribution of XML Calabash is configured with a hack. Simply
 delete the <filename>Saxon-HE-<?version DEPENDENCY_saxon?>.jar</filename> file from the
 <filename class="directory">lib</filename> directory and copy in your PE or EE jar instead. You
 <emphasis>must</emphasis> use a <?version DEPENDENCY_saxon?> jar file for this purpose!
@@ -53,7 +53,7 @@ by your own script.</para>
 
 <para>XML Calabash has a command driven command-line interface. It supports
 three commands: <command linkend="run-run">run</command>, to run a pipeline;
-<command linkend="run-version">version</command>, to print the version, and
+<command linkend="run-info">info</command>, to print diagnostic information, and
 <command linkend="run-help">help</command> to display help. If no command is
 given, the <command>run</command> command is assumed.</para>
 
@@ -653,18 +653,26 @@ dissimilar to the preceding section. If help is requested, all of the other
 command line arguments are ignored.</para>
 </section>
 
-<section xml:id="run-version">
-<title>The <literal>version</literal> command</title>
+<section xml:id="run-info">
+<title>The <literal>info</literal> command</title>
+
+<para xml:id="run-version">(There used to be a <literal>version</literal> command; it’s been generalized
+into the <literal>info</literal> command; “<literal>version</literal>” still works as a command, it’s
+a synonym for “<literal>info version</literal>”.</para>
+
+<section xml:id="run-info-version">
+<title>The <literal>info version</literal> command</title>
 
 <cmdsynopsis>
   <command>xmlcalabash</command>
+  <arg choice="plain">info</arg>
   <arg choice="plain">version</arg>
   <arg rep="norepeat" linkend="cli-verbosity">--verbosity:<replaceable>verbosity</replaceable></arg>
 </cmdsynopsis>
 
 <para>Displays the XML Calabash version and the version of Saxon:</para>
 
-<screen><userinput><prompt>$</prompt> xmlcalabash version</userinput>
+<screen><userinput><prompt>$</prompt> xmlcalabash info version</userinput>
 <computeroutput>XML Calabash version <?version?> (build <?version build-id?>, <?version build-date display?>)
 Running with Saxon <?version saxon-edition?> version <?dep saxon?> using at most 1 of 12 available threads</computeroutput></screen>
 
@@ -674,7 +682,7 @@ is requested, the version summary will include details about third party
 dependencies such as the HTML parser and XML resolver. In this case, the output
 is formatted in a way that can more easily be parsed, for example by a shell script.</para>
 
-<screen><userinput><prompt>$</prompt> xmlcalabash --debug</userinput>
+<screen><userinput><prompt>$</prompt> xmlcalabash info version --debug</userinput>
 <computeroutput>PRODUCT_NAME=XML Calabash
 VERSION=<?version VERSION?>
 BUILD_DATE=<?version BUILD_DATE?>
@@ -707,5 +715,61 @@ DEPENDENCY_xmlResolver=<?version DEPENDENCY_xmlResolver?></computeroutput></scre
 the processor <emphasis>expected</emphasis>. The versions actually used are controlled by what appears on 
 the classpath at runtime.</para>
 </important>
+</section>
+<section xml:id="run-info-mimetypes">
+<title>The <literal>info mimtypes</literal> command</title>
+
+<cmdsynopsis>
+  <command>xmlcalabash</command>
+  <arg choice="plain">info</arg>
+  <arg choice="plain">mimetypes</arg>
+</cmdsynopsis>
+
+<para>Displays the MIME types that have been registered by default, by the user’s configuration
+file, and by extension steps. There may be additional mime types defined by Java using a
+<link xlink:href="https://docs.oracle.com/javase/7/docs/api/javax/activation/MimetypesFileTypeMap.html"
+>.mime.types</link> file or other mechanism. The underlying mapping doesn’t provide any API for enumerating
+the mappings, so there’s no
+way to list all of them.</para>
+
+<screen><userinput><prompt>$</prompt> xmlcalabash info mimetypes</userinput>
+<computeroutput>Filename extension/content type mappings defined by XML Calabash:
+	.7z is application/x-7z-compressed
+	.a is application/x-archive
+	.arj is application/x-arj
+	.bmp is image/bmp
+	.bz2 is application/bzip2
+	…
+	.yaml is application/x-yaml
+	.yml is application/x-yaml
+	.zip is application/zip
+Additional mappings may have been defined in the JVM, for example with a .mime.types file.
+See <link xlink:href="https://docs.oracle.com/javase/7/docs/api/javax/activation/MimetypesFileTypeMap.html"/>
+Use the 'info mimetype &lt;ext&gt;' command to query the content type of a particular &lt;ext&gt;.</computeroutput></screen>
+
+</section>
+<section xml:id="run-info-mimetype">
+<title>The <literal>info mimtype</literal> command</title>
+
+<cmdsynopsis>
+  <command>xmlcalabash</command>
+  <arg choice="plain">info</arg>
+  <arg choice="plain">mimetype</arg>
+  <arg choice="plain"><replaceable>extension</replaceable></arg>
+</cmdsynopsis>
+
+<para>Returns information about the content type of files (or URIs) that end with
+.<replaceable>extension</replaceable>.</para>
+
+<screen><userinput><prompt>$</prompt> xmlcalabash info mimetype xslt</userinput>
+<computeroutput>Filename extension/content type mapping:
+	.xslt is application/xslt+xml</computeroutput></screen>
+
+<para>The query is against all of the defined mimetypes, both those defined by XML Calabash
+and those defined by Java using a
+<link xlink:href="https://docs.oracle.com/javase/7/docs/api/javax/activation/MimetypesFileTypeMap.html"
+>.mime.types</link> file or other mechanism.</para>
+
+</section>
 </section>
 </chapter>

--- a/documentation/src/xsl/user-custom.xsl
+++ b/documentation/src/xsl/user-custom.xsl
@@ -152,6 +152,10 @@
         <xsl:sequence select="$formatted/node()"/>
       </xsl:when>
 
+      <xsl:when test="starts-with($tagname, 'xsl:')">
+        <xsl:sequence select="$formatted/node()"/>
+      </xsl:when>
+
       <xsl:when test="exists($target)">
         <a href="#{$link-to}">
           <xsl:sequence select="$formatted/node()"/>

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/io/DocumentManager.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/io/DocumentManager.kt
@@ -8,6 +8,7 @@ import com.xmlcalabash.exceptions.XProcError
 import com.xmlcalabash.namespace.NsCx
 import com.xmlcalabash.spi.DocumentResolver
 import com.xmlcalabash.tracing.TraceListener
+import com.xmlcalabash.util.MemoMimetypesFileTypeMap
 import com.xmlcalabash.util.UriUtils
 import net.sf.saxon.lib.ModuleURIResolver
 import net.sf.saxon.lib.ResourceResolver
@@ -44,7 +45,7 @@ open class DocumentManager(val resolver: XMLResolver): EntityResolver, EntityRes
     private val prefixList = mutableListOf<String>()
     private val _cache = mutableMapOf<URI, MutableMap<MediaType,XProcDocument>>()
 
-    private var _mimetypesFileTypeMap = MimetypesFileTypeMap()
+    private var _mimetypesFileTypeMap = MemoMimetypesFileTypeMap()
     val mimetypesFileTypeMap: MimetypesFileTypeMap
         get() = _mimetypesFileTypeMap
 

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/MemoMimetypesFileTypeMap.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/util/MemoMimetypesFileTypeMap.kt
@@ -1,0 +1,27 @@
+package com.xmlcalabash.util
+
+import javax.activation.MimetypesFileTypeMap
+
+class MemoMimetypesFileTypeMap(): MimetypesFileTypeMap() {
+    private val _extensionMap = mutableMapOf<String, String>()
+    val extensionMap: Map<String, String>
+        get() = _extensionMap
+
+    override fun addMimeTypes(mime_types: String?) {
+        super.addMimeTypes(mime_types)
+        if (mime_types == null) {
+            return
+        }
+        val tokens = mutableListOf<String>()
+        tokens.addAll(mime_types.split("\\s+".toRegex()))
+        val ctype = tokens.removeFirstOrNull()
+        if (ctype != null) {
+            for (ext in tokens) {
+                val dotless = ext.trimStart('.')
+                if (dotless != "") {
+                    _extensionMap.put(ext, ctype)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fix #509

The command `info mimetypes` will show the known mimetypes mappings. The command `info mimetype ext` will show the mimetype of file.ext files (and URIs). The command `info version` replaces `version`, although `version` is still recognized. Updated the documentation and help text.