### PR TITLE
Print usage information if only `info` is given

### DIFF
--- a/app/src/main/kotlin/com/xmlcalabash/app/XmlCalabashCli.kt
+++ b/app/src/main/kotlin/com/xmlcalabash/app/XmlCalabashCli.kt
@@ -168,6 +168,12 @@ class XmlCalabashCli private constructor() {
                 showMimetypes()
                 return
             }
+            "info" -> {
+                stepConfig.messagePrinter.println("The 'info' subcommands are 'version', 'mimetypes', or 'mimetype'.")
+                stepConfig.messagePrinter.println("")
+                help()
+                return
+            }
             else -> Unit
         }
 


### PR DESCRIPTION
Don’t NPE.

Fix #519