### PR TITLE
Use correct step context when evaluating static expressions

### DIFF
--- a/tests/extra-suite/test-suite/pipelines/show.xsl
+++ b/tests/extra-suite/test-suite/pipelines/show.xsl
@@ -1,0 +1,11 @@
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+                xmlns:c="http://www.w3.org/ns/xproc-step"
+                version="3.0"
+                expand-text="yes">
+  <xsl:param name="test" select="''" as="xs:string"/>
+
+  <xsl:template name="main">
+    <c:result>{$test}</c:result>
+  </xsl:template>
+</xsl:stylesheet>

--- a/tests/extra-suite/test-suite/pipelines/step.xpl
+++ b/tests/extra-suite/test-suite/pipelines/step.xpl
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                name="step" type="ex:step"
+                xmlns:c="http://www.w3.org/ns/xproc-step"
+                xmlns:ex="http://example.com/xproc"
+                version="3.0" exclude-inline-prefixes="#all">
+    
+    <p:input port="source" sequence="true"></p:input>
+    <p:output port="result" sequence="true"></p:output>
+    
+    <p:option name="test" select="''"/>
+    <p:xslt template-name="main" parameters="map{'test':$test}">
+      <p:with-input port="stylesheet" href="show.xsl"/>
+    </p:xslt>
+</p:declare-step>

--- a/tests/extra-suite/test-suite/pipelines/test/test.xpl
+++ b/tests/extra-suite/test-suite/pipelines/test/test.xpl
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                xmlns:c="http://www.w3.org/ns/xproc-step" 
+                xmlns:cx="http://xmlcalabash.com/ns/extensions" 
+                xmlns:ex="http://example.com/xproc"
+                version="3.0" exclude-inline-prefixes="#all">
+    <p:import href="../step.xpl"/>
+    
+    <p:input port="source" sequence="true"/>
+    <p:output port="result" primary="true" sequence="true"/>
+    
+    <!-- test --> 
+    <ex:step name="test">
+      <p:with-option name="test" select="resolve-uri('test.xml')"></p:with-option>
+    </ex:step>
+</p:declare-step>

--- a/tests/extra-suite/test-suite/tests/static-expr-context-001.xml
+++ b/tests/extra-suite/test-suite/tests/static-expr-context-001.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+  <t:info>
+    <t:title>static-expr-context-001</t:title>
+    <t:revision-history>
+      <t:revision>
+        <t:date>2025-05-21</t:date>
+        <t:author>
+          <t:name>Norm Tovey-Walsh</t:name>
+        </t:author>
+        <t:description xmlns="http://www.w3.org/1999/xhtml">
+          <p>Created test. Adapted from a test provided by George Bina. Thank you, George!</p>
+        </t:description>
+      </t:revision>
+    </t:revision-history>
+  </t:info>
+  <t:description xmlns="http://www.w3.org/1999/xhtml">
+    <p>Make sure that static expressions are evaluated with the correct context.</p>
+  </t:description>
+  <t:pipeline src="../pipelines/test/test.xpl"/>
+  <t:schematron>
+    <s:schema queryBinding="xslt2"
+              xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
+      <s:pattern>
+        <s:rule context="/">
+          <s:assert test="c:result">The root isn’t a c:result.</s:assert>
+          <s:assert test="ends-with(c:result, 'pipelines/test/test.xml')">Wrong base URI.</s:assert>
+        </s:rule>
+      </s:pattern>
+    </s:schema>
+  </t:schematron>
+</t:test>

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/XProcExpression.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/datamodel/XProcExpression.kt
@@ -129,8 +129,8 @@ abstract class XProcExpression(val stepConfig: StepConfiguration, val asType: Se
     val staticValue: XdmValue?
         get() = _staticValue
 
-    abstract fun xevaluate(config: StepConfiguration): () -> XdmValue
-    abstract fun evaluate(config: StepConfiguration): XdmValue
+    abstract fun xevaluate(stepConfig: StepConfiguration): () -> XdmValue
+    abstract fun evaluate(stepConfig: StepConfiguration): XdmValue
     abstract fun cast(asType: SequenceType, values: List<XdmAtomicValue> = emptyList()): XProcExpression
 
     internal open fun computeStaticValue(stepConfig: InstructionConfiguration): XdmValue? {

--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/PipelineStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/PipelineStep.kt
@@ -21,8 +21,9 @@ class PipelineStep(config: XProcStepConfiguration, compound: CompoundStepModel):
             }
 
             if (step.externalName in staticOptions) {
-                val value = staticOptions[step.externalName]!!.staticValue.evaluate(stepConfig)
-                val document = XProcDocument.ofValue(value, stepConfig, MediaType.OCTET_STREAM, DocumentProperties())
+                val details = staticOptions[step.externalName]!!
+                val value = details.staticValue.evaluate(details.stepConfig)
+                val document = XProcDocument.ofValue(value, details.stepConfig, MediaType.OCTET_STREAM, DocumentProperties())
                 step.externalValue = document
             } else if (step.externalName in head.options) {
                 val list = head.options[step.externalName]!!


### PR DESCRIPTION
Fix #521

Previously, the option was evaluated with the static context of the declare step, not the static context of the expression. This is often harmless, but it can lead to the wrong base URI being used.

Shout out to George Bina for providing the original test case.