### PR TITLE
Resolve open ports when p:run is used in a loop

### DIFF
--- a/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/RunStep.kt
+++ b/xmlcalabash/src/main/kotlin/com/xmlcalabash/runtime/steps/RunStep.kt
@@ -140,6 +140,14 @@ open class RunStep(config: XProcStepConfiguration, compound: CompoundStepModel):
         }
     }
 
+    override fun reset() {
+        super.reset()
+        // These are provided by the "atomic" run step.
+        for ((runInput, _) in runParams.inputs) {
+            head.openPorts.remove(runInput)
+        }
+    }
+
     private fun listToValue(documents: List<XProcDocument>): XdmValue {
         var value: XdmValue = XdmEmptySequence.getInstance()
         for (doc in documents) {


### PR DESCRIPTION
Fix #541

The p:run step is weirdly compound but also atomic. The inputs that will be provided by the “atomic” step shouldn’t block the “compound” head from being ready to run.